### PR TITLE
Update removal detection

### DIFF
--- a/lib/recipes-data/.eslintrc.json
+++ b/lib/recipes-data/.eslintrc.json
@@ -14,6 +14,18 @@
       },
 			"rules": {}
 		},
+    {
+      "files": ["*.test.ts", "*.test.tsx"],
+      "parserOptions": {
+        "project": ["lib/recipes-data/tsconfig.spec.json"]
+      },
+      "rules": {
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/ban-ts-comment": "off",
+        "@typescript-eslint/prefer-ts-expect-error": "off",
+        "@typescript-eslint/no-unsafe-call": "off"
+      }
+    },
 		{
 			"files": ["*.js", "*.jsx"],
 			"rules": {}

--- a/lib/recipes-data/src/lib/fastly.test.ts
+++ b/lib/recipes-data/src/lib/fastly.test.ts
@@ -1,5 +1,5 @@
-import {FastlyError, sendFastlyPurgeRequest} from "./fastly";
 import fetch from "node-fetch";
+import {FastlyError, sendFastlyPurgeRequest} from "./fastly";
 
 jest.mock("./config", ()=>({
   ContentPrefix: "cdn.content.location",

--- a/lib/recipes-data/src/lib/takedowns.test.ts
+++ b/lib/recipes-data/src/lib/takedowns.test.ts
@@ -1,0 +1,113 @@
+import {DynamoDBClient} from "@aws-sdk/client-dynamodb";
+import {mockClient} from "aws-sdk-client-mock";
+import { recipesforArticle } from './dynamo';
+import type { RecipeIndexEntry } from './models';
+import {recipesToTakeDown} from "./takedowns";
+
+const mockDynamo = mockClient(DynamoDBClient);
+const ddbFakeClient = new DynamoDBClient(); //the mocking above means that this is not a real client
+
+jest.mock("./dynamo", ()=>({
+  recipesforArticle: jest.fn()
+}));
+
+describe("recipesToTakeDown", ()=>{
+  beforeEach(()=>{
+    jest.resetAllMocks();
+    mockDynamo.reset();
+  });
+
+  it("should return a list of recipe references that feature in the DB but not in the incoming update", async ()=>{
+    const fakeDbContent:RecipeIndexEntry[] = [
+      {
+        sha: "vers938",
+        uid: "number1"
+      },
+      {
+        sha: "vers963",
+        uid: "number2"
+      },
+      {
+        sha: "vers346",
+        uid: "number3"
+      },
+      {
+        sha: "vers432",
+        uid: "number4"
+      },
+      {
+        sha: "vers9789",
+        uid: "number5"
+      },
+    ];
+
+    const fakeUpdateIds:string[] = ["number1","number3","number4"];
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    recipesforArticle.mockReturnValue(Promise.resolve(fakeDbContent));
+
+    const result = await recipesToTakeDown(ddbFakeClient, "some-article-id", fakeUpdateIds);
+    expect(result).toEqual([
+      {sha: "vers963", uid:"number2"},
+      {sha: "vers9789", uid: "number5"}
+    ]);
+
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(recipesforArticle.mock.calls.length).toEqual(1);
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(recipesforArticle.mock.calls[0][0]).toEqual(ddbFakeClient);
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(recipesforArticle.mock.calls[0][1]).toEqual("some-article-id");
+  });
+
+  it("should return an empty list if there is nothing to take down", async ()=>{
+    const fakeDbContent:RecipeIndexEntry[] = [
+      {
+        sha: "vers938",
+        uid: "number1"
+      },
+      {
+        sha: "vers346",
+        uid: "number3"
+      },
+      {
+        sha: "vers432",
+        uid: "number4"
+      },
+    ];
+
+    const fakeUpdateIds:string[] = ["number1","number3","number4"];
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    recipesforArticle.mockReturnValue(Promise.resolve(fakeDbContent));
+
+    const result = await recipesToTakeDown(ddbFakeClient, "some-article-id", fakeUpdateIds);
+    expect(result).toEqual([]);
+
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(recipesforArticle.mock.calls.length).toEqual(1);
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(recipesforArticle.mock.calls[0][0]).toEqual(ddbFakeClient);
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(recipesforArticle.mock.calls[0][1]).toEqual("some-article-id");
+  });
+
+  it("should return an empty list if both input and current state are empty", async ()=>{
+    const fakeDbContent:RecipeIndexEntry[] = [];
+
+    const fakeUpdateIds:string[] = [];
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    recipesforArticle.mockReturnValue(Promise.resolve(fakeDbContent));
+
+    const result = await recipesToTakeDown(ddbFakeClient, "some-article-id", fakeUpdateIds);
+    expect(result).toEqual([]);
+
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(recipesforArticle.mock.calls.length).toEqual(1);
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(recipesforArticle.mock.calls[0][0]).toEqual(ddbFakeClient);
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(recipesforArticle.mock.calls[0][1]).toEqual("some-article-id");
+  });
+})

--- a/lib/recipes-data/src/lib/takedowns.ts
+++ b/lib/recipes-data/src/lib/takedowns.ts
@@ -1,0 +1,20 @@
+import type {DynamoDBClient} from "@aws-sdk/client-dynamodb";
+import { recipesforArticle } from './dynamo';
+import type { RecipeIndexEntry } from './models';
+
+/**
+ * This function checks an incoming list of recipes (from an article update) against the list of recipes
+ * currently present.  If we are missing any of the "current" recipes then these should be taken down.
+ * @param dynamoClient DynamoDB client so we can query the index database
+ * @param canonicalArticleId ID of the article that's being updated
+ * @param recipeIdsToKeep list of the "new" recipes that are in the update (and should therefore be kept)
+ * @return list of the recipes that were present in the current version but not in the update. These should be taken down.
+ */
+export async function recipesToTakeDown(dynamoClient:DynamoDBClient, canonicalArticleId:string, recipeIdsToKeep: string[]):Promise<RecipeIndexEntry[]>
+{
+  const toKeepSet = new Set(recipeIdsToKeep);
+  const currentSet = await recipesforArticle(dynamoClient, canonicalArticleId);
+
+  //ES6 does not give us a Set.difference method, unfortunately. So we have to do it here.
+  return currentSet.filter(rec=>!toKeepSet.has(rec.uid));
+}


### PR DESCRIPTION
## What does this change?

- Implements https://trello.com/c/YQmY2nBJ
- Fix eslint config for library tests; loosen the rules on tests files so that they are not a sea of red

From the card:

**Library function to detect taken-down recipes during an update**

Input:
- the output of Library Function to extract all recipes from an article

Output:
- list of articles to take down, in the same format as the input (i.e., same as the input but with articles not to take down removed)

You’ll need to:
- do a DynamoDB Query on the table, for primary key==canonical article ID
- iterate the responses to find the immutable recipe IDs
- compare this with the input list. Any recipe IDs that are present in the input list and not present in the database data should be removed, and therefore make up the response body

## How to test

Automated tests are provided. Look these over and make sure they they are ok!

## How can we measure success?

One more step
