### PR TITLE
Unscrambling types

### DIFF
--- a/lib/recipes-data/src/lib/extract_recipedata_from_element.test.ts
+++ b/lib/recipes-data/src/lib/extract_recipedata_from_element.test.ts
@@ -91,7 +91,7 @@ describe("extractRecipeData", () => {
     }
     const result = extractRecipeData(canonicalId, block)
     expect(result.length).toEqual(1)
-    expect(result[0].recipeUId).toEqual("lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers-1") //
+    expect(result[0].recipeUID).toEqual("lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers-1") //
     expect(result[0].jsonBlob).toEqual(block.elements[1].recipeTypeData?.recipeJson)
   })
 
@@ -195,7 +195,7 @@ describe("extractRecipeData", () => {
     }
     const result = extractRecipeData(canonicalId, block)
     expect(result.length).toEqual(3)
-    expect(result[2].recipeUId).toEqual("lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers-3") //
+    expect(result[2].recipeUID).toEqual("lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers-3") //
     expect(result[2].jsonBlob).toEqual(block.elements[3].recipeTypeData?.recipeJson)
   })
 

--- a/lib/recipes-data/src/lib/extract_recipedata_from_element.ts
+++ b/lib/recipes-data/src/lib/extract_recipedata_from_element.ts
@@ -1,27 +1,21 @@
 import type {Block} from "@guardian/content-api-models/v1/block";
 import {ElementType} from "@guardian/content-api-models/v1/elementType";
+import type { RecipeReferenceWithoutChecksum } from './models';
 
-
-export interface RecipeOutput {
-  recipeUId: string;
-  jsonBlob: string;
-  checksum?: string;
-}
-
-export function extractRecipeData(canonicalId: string, block: Block): RecipeOutput[] {
+export function extractRecipeData(canonicalId: string, block: Block): RecipeReferenceWithoutChecksum[] {
   const allRecipes = block.elements
     .filter(elem => elem.type === ElementType.RECIPE)
     .map(recp => parseJsonBlob(canonicalId, recp.recipeTypeData?.recipeJson as string))
   return allRecipes
 }
 
-function parseJsonBlob(canonicalId: string, recipeJson: string): RecipeOutput {
+function parseJsonBlob(canonicalId: string, recipeJson: string): RecipeReferenceWithoutChecksum {
   const recipeData = JSON.parse(recipeJson) as Record<string, unknown>
   if (!recipeData.id) {
     throw new Error(`Error! No id present in the recipeJson, canonicalId is ${canonicalId}`)
   } else {
-    return <RecipeOutput>{
-      recipeUId: `${canonicalId}-${recipeData.id as string}`,
+    return <RecipeReferenceWithoutChecksum>{
+      recipeUID: `${canonicalId}-${recipeData.id as string}`,
       jsonBlob: recipeJson
     }
   }


### PR DESCRIPTION
## What does this change?

Due to the asynchronous development process we've managed to create some overlapping type instances that duplicate functionality.

This PR removes the duplication, creating a single consistent set of types that live in `models.ts`.  References to the fields are also updated.

## How to test

Double-check that the tests make sense and still pass.

## How can we measure success?

More readable code
