### PR TITLE
Bringing together the work into a single lambda function

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,15 @@ Will update the CDK snapshot and allow the tests to pass again
 
 ## How does it work?
 
-TBD
+```mermaid
+flowchart LR
+    crier([ crier ]) --> kinesis --> responder[recipes-responder]
+    responder --> content["Recipe content
+    extraction"] --> s3[(s3)]
+    responder --> dynamodb --> responder --> index[Index content] --> s3
+    s3 --> Fastly --> app([ Mobile app ])
+```
+- The recipes-responder lambda function receives updates from the Crier kinesis stream
+- Anything which is not an article update/takedown is ignored
+- Each article update is scanned to find any receipe element
+## What's in the box?

--- a/README.md
+++ b/README.md
@@ -41,5 +41,60 @@ flowchart LR
 ```
 - The recipes-responder lambda function receives updates from the Crier kinesis stream
 - Anything which is not an article update/takedown is ignored
-- Each article update is scanned to find any receipe element
+- Each article update is scanned to find any recipe elements in the article
+- We take a SHA of the recipe content so we can detect changes
+- The list of recipes (with SHA identifiers) is compared against the list of recipes we already have for that article ID
+  - If a recipe SHA does not exist, then it's been removed or updated => we remove its content from the bucket and its entry from the database
+- We then take the list of "new" recipes (updated or newly inserted), output their content to S3 and register them in the database
+- Explicit CDN flushes are performed for each S3 put/delete
+- As we do this, we keep count of the total number of inserts + deletions
+- If we have made any inserts or deletions, we scan the index table and output the results as JSON to an `index.json` file in the S3 bucket. Then cache-flush that too.
+
+## How is it used?
+
+- The static S3 bucket is fronted by a Fastly cache distribution.
+- The app client makes a HEAD request to `/index.json`, including the `If-Modified-Since` header with the timestamp of the last successful update
+  - If no update has taken place, the client receives `304 Not Modified` and can wait for the next poll. No data body is transferred.
+  - If an update has taken place since the last update, the client receives `200 OK` with a `Content-Length` header.  It can then decide when/how to obtain the whole content
+- If an update has taken place, the client downloads `/index.json` with a GET request.
+- It then compares the list of version IDs (SHAs, in reality) of each recipe with the one it has locally
+  - If the SHA matches then no action needs to be taken
+  - If the index has a SHA not in the local database then the content must be downloaded. This is done via `GET /content/{sha}`.
+  - If the load database has a SHA that is not in the index then the local version must be deleted.
+
+The underlying assumption is that under "normal operation" there will only be one or two recipe changes in each update, so we minimise the data transfer
+inherent in checking for them.  Furthermore, it's important the the app can work without a persistent internet connection so we don't know how big/small the change delta is.
+
+### Why no search API?
+
+Because it's not (yet) a client requirement.  At the time of writing, the desire is to do all searching client-side because the app feature-set is very much up in the air.
+
+This may be revisited in future.
+
 ## What's in the box?
+
+### lambda/recipes-responder
+
+This is the lambda function which listens to Kinesis updates from crier.  It is responsible for all of the processing and extraction logic, although
+most of the actual logic lives in the library code imported into it
+
+### lambda/test-indexbuild
+
+A lambda function that rebuilds the index on-demand.  This is incorporated from initial testing and will probably be removed.
+
+### lib/capi
+
+Library functions to communicate with the Content Application Programmer's Interface.  This is imported into the lambda code as `@recipes-api/lib/capi`.
+
+### lib/recipes-data
+
+Library functions that hold the actual logic for processing the content.  Parsing of the incoming Thrift content is done by the `@guardian/content-api-models/crier`
+library; these functions take in data structures defined by the Thrift models and perform inspection, checksumming, databasing, storage and CDN interfacing.
+
+### tools/manual-takedown
+
+Runnable script that allows you to forcibly remove all recipes from a given article ID.  This can be run from an npm script: `npm run manual-takedown`.
+
+### tools/fill-db
+
+Runnable script that fills the index table with junk data.  This is from initial testing and will be removed, don't use it.

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -522,7 +522,7 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
             "CAPI_KEY": {
               "Ref": "capiKey",
             },
-            "CONTENT_URL_BASE": "recipes.gutools.co.uk",
+            "CONTENT_URL_BASE": "recipes.guardianapis.com",
             "DEBUG_LOGS": "true",
             "FASTLY_API_KEY": {
               "Ref": "fastlyKey",

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -7,6 +7,7 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuParameter",
+      "GuParameter",
       "GuKinesisLambdaExperimental",
     ],
     "gu:cdk:version": "TEST",
@@ -19,6 +20,10 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
     },
     "capiKey": {
       "Default": "/TEST/content-api/recipes-responder/capi-key",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "fastlyKey": {
+      "Default": "/TEST/content-api/recipes-responder/fastly-key",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
@@ -517,8 +522,20 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
             "CAPI_KEY": {
               "Ref": "capiKey",
             },
+            "CONTENT_URL_BASE": "recipes.gutools.co.uk",
+            "DEBUG_LOGS": "true",
+            "FASTLY_API_KEY": {
+              "Ref": "fastlyKey",
+            },
+            "INDEX_TABLE": {
+              "Ref": "storeRecipeTableC3AD84B7",
+            },
+            "LAST_UPDATED_INDEX": "idxArticleLastUpdated",
             "STACK": "content-api",
             "STAGE": "TEST",
+            "STATIC_BUCKET": {
+              "Ref": "staticstaticServing53194089",
+            },
           },
         },
         "Handler": "main.handler",
@@ -641,6 +658,59 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       "Properties": {
         "PolicyDocument": {
           "Statement": [
+            {
+              "Action": [
+                "s3:PutObject",
+                "s3:DeleteObject",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "staticstaticServing53194089",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "dynamodb:Scan",
+                "dynamodb:Query",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:PutItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "storeRecipeTableC3AD84B7",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "storeRecipeTableC3AD84B7",
+                          "Arn",
+                        ],
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
+            },
             {
               "Action": [
                 "s3:GetObject*",

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -74,7 +74,7 @@ export class RecipesBackend extends GuStack {
         CAPI_KEY: capiKeyParam.valueAsString,
         INDEX_TABLE: store.table.tableName,
         LAST_UPDATED_INDEX: store.lastUpdatedIndexName,
-        CONTENT_URL_BASE: this.stage=="CODE" ? "recipes.code.dev-gutools.co.uk" : "recipes.gutools.co.uk",
+        CONTENT_URL_BASE: this.stage=="CODE" ? "recipes.code.dev-guardianapis.com" : "recipes.guardianapis.com",
         DEBUG_LOGS: "true",
         FASTLY_API_KEY: fastlyKeyParam.valueAsString,
         STATIC_BUCKET: serving.staticBucket.bucketName,

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -56,6 +56,11 @@ export class RecipesBackend extends GuStack {
       default: `/${this.stage}/${this.stack}/recipes-responder/capi-key`
     })
 
+    const fastlyKeyParam = new GuParameter(this, "fastlyKey", {
+      fromSSM: true,
+      default: `/${this.stage}/${this.stack}/recipes-responder/fastly-key`
+    })
+
     new GuKinesisLambdaExperimental(this, "updaterLambda", {
       monitoringConfiguration: {noMonitoring: true},
       existingKinesisStream: {
@@ -67,7 +72,25 @@ export class RecipesBackend extends GuStack {
       },
       environment: {
         CAPI_KEY: capiKeyParam.valueAsString,
+        INDEX_TABLE: store.table.tableName,
+        LAST_UPDATED_INDEX: store.lastUpdatedIndexName,
+        CONTENT_URL_BASE: this.stage=="CODE" ? "recipes.code.dev-gutools.co.uk" : "recipes.gutools.co.uk",
+        DEBUG_LOGS: "true",
+        FASTLY_API_KEY: fastlyKeyParam.valueAsString,
+        STATIC_BUCKET: serving.staticBucket.bucketName,
       },
+      initialPolicy: [
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["s3:PutObject", "s3:DeleteObject"],
+          resources: [serving.staticBucket.bucketArn + "/*"]
+        }),
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["dynamodb:Scan", "dynamodb:Query", "dynamodb:BatchWriteItem", "dynamodb:DeleteItem", "dynamodb:PutItem"],
+          resources: [store.table.tableArn, store.table.tableArn + "/index/*"]
+        })
+      ],
       runtime: Runtime.NODEJS_18_X,
       app: "recipes-responder",
       handler: "main.handler",

--- a/lambda/recipes-responder/src/dynamo_conn.ts
+++ b/lambda/recipes-responder/src/dynamo_conn.ts
@@ -1,3 +1,0 @@
-import {DynamoDBClient} from "@aws-sdk/client-dynamodb";
-
-export const DynamoClient = new DynamoDBClient({region: process.env["AWS_REGION"]});

--- a/lambda/recipes-responder/src/main.test.ts
+++ b/lambda/recipes-responder/src/main.test.ts
@@ -33,6 +33,10 @@ jest.mock("./update_retrievable_processor", ()=>({
   handleContentUpdateRetrievable: jest.fn(),
 }));
 
+jest.mock("@recipes-api/lib/recipes-data", ()=>({
+
+}));
+
 describe("main.processRecord", ()=>{
   beforeEach(()=>{
     jest.resetAllMocks();

--- a/lambda/recipes-responder/src/main.test.ts
+++ b/lambda/recipes-responder/src/main.test.ts
@@ -8,7 +8,13 @@ import formatISO from "date-fns/formatISO";
 import {deserializeEvent} from "@recipes-api/lib/capi";
 import {processRecord} from "./main";
 import {handleDeletedContent, handleTakedown} from "./takedown_processor";
-import {handleContentUpdate, handleContentUpdateRetrievable} from "./update_processor";
+import {handleContentUpdate} from "./update_processor";
+import {handleContentUpdateRetrievable} from "./update_retrievable_processor";
+
+jest.mock("node-fetch", ()=>({
+  __esmodule: true,
+  default: jest.fn(),
+}));
 
 jest.mock("@recipes-api/lib/capi", ()=>({
   deserializeEvent: jest.fn(),
@@ -21,6 +27,9 @@ jest.mock("./takedown_processor", ()=>({
 
 jest.mock("./update_processor", ()=>({
   handleContentUpdate: jest.fn(),
+}));
+
+jest.mock("./update_retrievable_processor", ()=>({
   handleContentUpdateRetrievable: jest.fn(),
 }));
 
@@ -232,7 +241,7 @@ describe("main.processRecord", ()=>{
     deserializeEvent.mockReturnValue(testEvent);
     //@ts-ignore
     const result = await processRecord(testReq);
-    expect(result).toBeNull();
+    expect(result).toEqual(0);
     //@ts-ignore
     expect(handleTakedown.mock.calls.length).toEqual(0);
     //@ts-ignore

--- a/lambda/recipes-responder/src/main.ts
+++ b/lambda/recipes-responder/src/main.ts
@@ -7,6 +7,7 @@ import {DynamoClient} from "./dynamo_conn";
 import {handleDeletedContent, handleTakedown} from "./takedown_processor";
 import {handleContentUpdate} from "./update_processor";
 import {handleContentUpdateRetrievable} from "./update_retrievable_processor";
+import {sendFastlyPurgeRequest} from "../../../lib/recipes-data/src/lib/fastly";
 
 const filterProductionMonitoring:boolean = process.env["FILTER_PRODUCTION_MONITORING"] ? process.env["FILTER_PRODUCTION_MONITORING"].toLowerCase() =="yes" : false;
 
@@ -55,7 +56,7 @@ export const handler:KinesisStreamHandler = async (event) => {
     console.log(`Processed updates for ${updatesTotal} recipes, rebuilding the index json`);
     const indexData = await retrieveIndexData(DynamoClient);
     await writeIndexData(indexData);
-    console.log("Finished rebuilding index")
+    console.log("Finished rebuilding index");
   } else {
     console.log("No updates to recipes, so not touching index");
   }

--- a/lambda/recipes-responder/src/main.ts
+++ b/lambda/recipes-responder/src/main.ts
@@ -3,7 +3,6 @@ import {ItemType} from "@guardian/content-api-models/crier/event/v1/itemType";
 import type {KinesisStreamHandler, KinesisStreamRecord} from "aws-lambda";
 import {deserializeEvent} from "@recipes-api/lib/capi";
 import {retrieveIndexData, writeIndexData} from "@recipes-api/lib/recipes-data";
-import {DynamoClient} from "./dynamo_conn";
 import {handleDeletedContent, handleTakedown} from "./takedown_processor";
 import {handleContentUpdate} from "./update_processor";
 import {handleContentUpdateRetrievable} from "./update_retrievable_processor";
@@ -54,7 +53,7 @@ export const handler:KinesisStreamHandler = async (event) => {
   const updatesTotal = updatesPerEvent.reduce((acc, current)=>acc+current, 0);
   if(updatesTotal>0) {
     console.log(`Processed updates for ${updatesTotal} recipes, rebuilding the index json`);
-    const indexData = await retrieveIndexData(DynamoClient);
+    const indexData = await retrieveIndexData();
     await writeIndexData(indexData);
     console.log("Finished rebuilding index");
   } else {

--- a/lambda/recipes-responder/src/main.ts
+++ b/lambda/recipes-responder/src/main.ts
@@ -2,22 +2,25 @@ import {EventType} from "@guardian/content-api-models/crier/event/v1/eventType";
 import {ItemType} from "@guardian/content-api-models/crier/event/v1/itemType";
 import type {KinesisStreamHandler, KinesisStreamRecord} from "aws-lambda";
 import {deserializeEvent} from "@recipes-api/lib/capi";
+import {retrieveIndexData, writeIndexData} from "@recipes-api/lib/recipes-data";
+import {DynamoClient} from "./dynamo_conn";
 import {handleDeletedContent, handleTakedown} from "./takedown_processor";
-import {handleContentUpdate, handleContentUpdateRetrievable} from "./update_processor";
+import {handleContentUpdate} from "./update_processor";
+import {handleContentUpdateRetrievable} from "./update_retrievable_processor";
 
 const filterProductionMonitoring:boolean = process.env["FILTER_PRODUCTION_MONITORING"] ? process.env["FILTER_PRODUCTION_MONITORING"].toLowerCase() =="yes" : false;
 
-export async function processRecord(r:KinesisStreamRecord) {
+export async function processRecord(r:KinesisStreamRecord):Promise<number> {
   try {
     const evt = deserializeEvent(r.kinesis.data);
 
     //we're only interested in content updates
-    if(evt.itemType!=ItemType.CONTENT) return null;
+    if(evt.itemType!=ItemType.CONTENT) return 0;
 
     console.log(`DEBUG Received event of type ${evt.eventType} for item of type ${evt.itemType}`);
     switch(evt.eventType) {
       case EventType.DELETE:
-        if(filterProductionMonitoring && evt.payloadId.startsWith("production-monitoring")) return null;
+        if(filterProductionMonitoring && evt.payloadId.startsWith("production-monitoring")) return 0;
         return handleTakedown(evt);
       case EventType.UPDATE:
       case EventType.RETRIEVABLEUPDATE:
@@ -38,12 +41,22 @@ export async function processRecord(r:KinesisStreamRecord) {
       default:
         console.error("ERROR Unknown event type ", evt.eventType);
     }
+    return 0; //if we get here, no action was taken
   } catch (err) {
     console.error(`ERROR Could not process data from Kinesis: ${(err as Error).toString()}`);
-    return null;
+    return 0;
   }
 }
 
 export const handler:KinesisStreamHandler = async (event) => {
-  await Promise.all(event.Records.map((r)=>processRecord(r)))
+  const updatesPerEvent = await Promise.all(event.Records.map((r)=>processRecord(r)));
+  const updatesTotal = updatesPerEvent.reduce((acc, current)=>acc+current, 0);
+  if(updatesTotal>0) {
+    console.log(`Processed updates for ${updatesTotal} recipes, rebuilding the index json`);
+    const indexData = await retrieveIndexData(DynamoClient);
+    await writeIndexData(indexData);
+    console.log("Finished rebuilding index")
+  } else {
+    console.log("No updates to recipes, so not touching index");
+  }
 }

--- a/lambda/recipes-responder/src/takedown_processor.test.ts
+++ b/lambda/recipes-responder/src/takedown_processor.test.ts
@@ -22,61 +22,23 @@ describe("takedown_processor.handleTakedown", ()=>{
   });
 
   it("should remove all recipes associated with the given article", async ()=>{
-    const testEvt:Event = {
-      payloadId: "fake-id",
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    removeAllRecipesForArticle.mockReturnValue(Promise.resolve(1));
+    const testEvt:Event = { //DELETE events don't have a payload
+      payloadId: "path/to/article/id",
       eventType: EventType.DELETE,
       itemType: ItemType.CONTENT,
-      payload: {
-        kind: "content",
-        content: {
-          id: "path/to/article/id",
-          type: ContentType.ARTICLE,
-          webTitle: "This is a tesT",
-          webUrl: "https://some/path/to/article/id",
-          apiUrl: "https://some/path/to/article/id",
-          tags: [],
-          references: [],
-          isHosted: false,
-        }
-      },
       dateTime: new Int64(Date.now()),
     }
 
-    await handleTakedown(testEvt);
+    const count = await handleTakedown(testEvt);
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeAllRecipesForArticle.mock.calls.length).toEqual(1);
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(awaitableDelay.mock.calls.length).toEqual(0);
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeAllRecipesForArticle.mock.calls[0][1]).toEqual("path/to/article/id");
-  });
-
-  it("should ignore anything that is not an article", async ()=>{
-    const testEvt:Event = {
-      payloadId: "fake-id",
-      eventType: EventType.DELETE,
-      itemType: ItemType.CONTENT,
-      payload: {
-        kind: "content",
-        content: {
-          id: "path/to/article/id",
-          type: ContentType.GALLERY,
-          webTitle: "This is a tesT",
-          webUrl: "https://some/path/to/article/id",
-          apiUrl: "https://some/path/to/article/id",
-          tags: [],
-          references: [],
-          isHosted: false,
-        }
-      },
-      dateTime: new Int64(Date.now()),
-    }
-
-    await handleTakedown(testEvt);
-    // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeAllRecipesForArticle.mock.calls.length).toEqual(0);
-    // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(awaitableDelay.mock.calls.length).toEqual(0);
+    expect(count).toEqual(1);
   });
 
   it("should ignore anything that is not a 'content' payload", async ()=>{
@@ -84,24 +46,14 @@ describe("takedown_processor.handleTakedown", ()=>{
       payloadId: "fake-id",
       eventType: EventType.DELETE,
       itemType: ItemType.ATOM,
-      payload: {
-        kind: "atom",
-        atom: {
-          id: "some-atom-id",
-          atomType: AtomType.CTA,
-          labels: [],
-          defaultHtml: "",
-          //@ts-ignore -- we are not reading this field
-          data: null,
-        }
-      },
       dateTime: new Int64(Date.now()),
     }
 
-    await handleTakedown(testEvt);
+    const count = await handleTakedown(testEvt);
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeAllRecipesForArticle.mock.calls.length).toEqual(0);
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(awaitableDelay.mock.calls.length).toEqual(0);
+    expect(count).toEqual(0);
   });
 })

--- a/lambda/recipes-responder/src/takedown_processor.test.ts
+++ b/lambda/recipes-responder/src/takedown_processor.test.ts
@@ -1,8 +1,6 @@
 import type {Event} from "@guardian/content-api-models/crier/event/v1/event";
 import {EventType} from "@guardian/content-api-models/crier/event/v1/eventType";
 import {ItemType} from "@guardian/content-api-models/crier/event/v1/itemType";
-import {ContentType} from "@guardian/content-api-models/v1/contentType";
-import {AtomType} from "@guardian/content-atom-model/atomType";
 import Int64 from "node-int64";
 import {awaitableDelay, removeAllRecipesForArticle} from "@recipes-api/lib/recipes-data";
 import {handleTakedown} from "./takedown_processor";
@@ -12,9 +10,6 @@ jest.mock("@recipes-api/lib/recipes-data", ()=>({
   removeAllRecipesForArticle: jest.fn(),
 }));
 
-jest.mock("./dynamo_conn", ()=>({
-  DynamoClient: {},
-}));
 
 describe("takedown_processor.handleTakedown", ()=>{
   beforeEach(()=>{
@@ -37,7 +32,7 @@ describe("takedown_processor.handleTakedown", ()=>{
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(awaitableDelay.mock.calls.length).toEqual(0);
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeAllRecipesForArticle.mock.calls[0][1]).toEqual("path/to/article/id");
+    expect(removeAllRecipesForArticle.mock.calls[0][0]).toEqual("path/to/article/id");
     expect(count).toEqual(1);
   });
 

--- a/lambda/recipes-responder/src/takedown_processor.ts
+++ b/lambda/recipes-responder/src/takedown_processor.ts
@@ -1,26 +1,13 @@
 import type {DeletedContent} from "@guardian/content-api-models/crier/event/v1/deletedContent";
 import type {Event} from "@guardian/content-api-models/crier/event/v1/event"
-import {ContentType} from "@guardian/content-api-models/v1/contentType";
-import {awaitableDelay, removeAllRecipesForArticle} from "@recipes-api/lib/recipes-data";
+import {removeAllRecipesForArticle} from "@recipes-api/lib/recipes-data";
 import {DynamoClient} from "./dynamo_conn";
 
-export async function handleTakedown(evt:Event, attempt?:number):Promise<number> {
-  if(evt.payload?.kind=="content") {  //we don't need to handle if it's not an article
-    const content = evt.payload.content;
-    if(content.type==ContentType.ARTICLE) {  //we don't need to handle if it's not an article
-      try {
-        return removeAllRecipesForArticle(DynamoClient, content.id);
-      } catch(err) {
-        if( (attempt ?? 0) > 10) {
-          throw new Error(`Could not remove recipes for taken-down article ${content.id} after 10 attempts, giving up`);
-        }
-        console.error(`WARNING: Could not remove recipes for taken down article ${content.id}: `, err);
-        await awaitableDelay();
-        return handleTakedown(evt, (attempt ?? 0)+1)
-      }
-    }
-  }
-  return 0; //no action => nothing removed
+export async function handleTakedown(evt:Event):Promise<number> {
+  console.log("takedown payload: ", JSON.stringify(evt));
+
+  //there's no payload in the takedown message!
+  return removeAllRecipesForArticle(DynamoClient, evt.payloadId); //evt.payloadId is the canonical article ref that was taken down
 }
 
 // I don't think that these are relevant to us here. So, I'm logging it out to verify that suspicion

--- a/lambda/recipes-responder/src/takedown_processor.ts
+++ b/lambda/recipes-responder/src/takedown_processor.ts
@@ -4,12 +4,12 @@ import {ContentType} from "@guardian/content-api-models/v1/contentType";
 import {awaitableDelay, removeAllRecipesForArticle} from "@recipes-api/lib/recipes-data";
 import {DynamoClient} from "./dynamo_conn";
 
-export async function handleTakedown(evt:Event, attempt?:number):Promise<void> {
+export async function handleTakedown(evt:Event, attempt?:number):Promise<number> {
   if(evt.payload?.kind=="content") {  //we don't need to handle if it's not an article
     const content = evt.payload.content;
     if(content.type==ContentType.ARTICLE) {  //we don't need to handle if it's not an article
       try {
-        await removeAllRecipesForArticle(DynamoClient, content.id);
+        return removeAllRecipesForArticle(DynamoClient, content.id);
       } catch(err) {
         if( (attempt ?? 0) > 10) {
           throw new Error(`Could not remove recipes for taken-down article ${content.id} after 10 attempts, giving up`);
@@ -20,10 +20,11 @@ export async function handleTakedown(evt:Event, attempt?:number):Promise<void> {
       }
     }
   }
+  return 0; //no action => nothing removed
 }
 
 // I don't think that these are relevant to us here. So, I'm logging it out to verify that suspicion
-export async function handleDeletedContent(evt:DeletedContent):Promise<void> {
+export async function handleDeletedContent(evt:DeletedContent):Promise<number> {
   console.log(`DEBUG received deleted-content-update for ${evt.aliasPaths?.join("/") ?? "(no paths)"}`)
-  return Promise.resolve();
+  return Promise.resolve(0);
 }

--- a/lambda/recipes-responder/src/takedown_processor.ts
+++ b/lambda/recipes-responder/src/takedown_processor.ts
@@ -22,8 +22,8 @@ export async function handleTakedown(evt:Event, attempt?:number):Promise<void> {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/require-await -- not implemented yet
+// I don't think that these are relevant to us here. So, I'm logging it out to verify that suspicion
 export async function handleDeletedContent(evt:DeletedContent):Promise<void> {
-
-  throw new Error("handleTakedown is not implemented yet")
+  console.log(`DEBUG received deleted-content-update for ${evt.aliasPaths?.join("/") ?? "(no paths)"}`)
+  return Promise.resolve();
 }

--- a/lambda/recipes-responder/src/takedown_processor.ts
+++ b/lambda/recipes-responder/src/takedown_processor.ts
@@ -2,12 +2,17 @@ import type {DeletedContent} from "@guardian/content-api-models/crier/event/v1/d
 import type {Event} from "@guardian/content-api-models/crier/event/v1/event"
 import {removeAllRecipesForArticle} from "@recipes-api/lib/recipes-data";
 import {DynamoClient} from "./dynamo_conn";
+import {ItemType} from "@guardian/content-api-models/crier/event/v1/itemType";
 
 export async function handleTakedown(evt:Event):Promise<number> {
   console.log("takedown payload: ", JSON.stringify(evt));
 
-  //there's no payload in the takedown message!
-  return removeAllRecipesForArticle(DynamoClient, evt.payloadId); //evt.payloadId is the canonical article ref that was taken down
+  if(evt.itemType==ItemType.CONTENT) {
+    //there's no payload in the takedown message!
+    return removeAllRecipesForArticle(DynamoClient, evt.payloadId); //evt.payloadId is the canonical article ref that was taken down
+  } else {
+    return 0;
+  }
 }
 
 // I don't think that these are relevant to us here. So, I'm logging it out to verify that suspicion

--- a/lambda/recipes-responder/src/takedown_processor.ts
+++ b/lambda/recipes-responder/src/takedown_processor.ts
@@ -1,7 +1,6 @@
 import type {DeletedContent} from "@guardian/content-api-models/crier/event/v1/deletedContent";
 import type {Event} from "@guardian/content-api-models/crier/event/v1/event"
 import {removeAllRecipesForArticle} from "@recipes-api/lib/recipes-data";
-import {DynamoClient} from "./dynamo_conn";
 import {ItemType} from "@guardian/content-api-models/crier/event/v1/itemType";
 
 export async function handleTakedown(evt:Event):Promise<number> {
@@ -9,7 +8,7 @@ export async function handleTakedown(evt:Event):Promise<number> {
 
   if(evt.itemType==ItemType.CONTENT) {
     //there's no payload in the takedown message!
-    return removeAllRecipesForArticle(DynamoClient, evt.payloadId); //evt.payloadId is the canonical article ref that was taken down
+    return removeAllRecipesForArticle(evt.payloadId); //evt.payloadId is the canonical article ref that was taken down
   } else {
     return 0;
   }

--- a/lambda/recipes-responder/src/update_processor.test.ts
+++ b/lambda/recipes-responder/src/update_processor.test.ts
@@ -60,7 +60,7 @@ describe("update_processor.handleContentUpdate", ()=>{
     ];
 
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    extractAllRecipesFromArticle.mockReturnValue(Promise.resolve(refsInArticle));
+    extractAllRecipesFromArticle.mockReturnValue(refsInArticle);
     // @ts-ignore -- Typescript doesn't know that this is a mock
     recipesToTakeDown.mockReturnValue(refsToRemove);
 
@@ -163,7 +163,7 @@ describe("update_processor.handleContentUpdate", ()=>{
     const refsToRemove:RecipeIndexEntry[] = [];
 
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    extractAllRecipesFromArticle.mockReturnValue(Promise.resolve(refsInArticle));
+    extractAllRecipesFromArticle.mockReturnValue(refsInArticle);
     // @ts-ignore -- Typescript doesn't know that this is a mock
     recipesToTakeDown.mockReturnValue(refsToRemove);
 

--- a/lambda/recipes-responder/src/update_processor.test.ts
+++ b/lambda/recipes-responder/src/update_processor.test.ts
@@ -18,10 +18,6 @@ jest.mock("node-fetch", ()=>({
   default: jest.fn()
 }));
 
-jest.mock("./dynamo_conn", ()=>({
-  DynamoClient: {},
-}));
-
 jest.mock("@recipes-api/lib/recipes-data", ()=>({
   calculateChecksum: jest.fn(),
   extractAllRecipesFromArticle: jest.fn(),
@@ -82,17 +78,17 @@ describe("update_processor.handleContentUpdate", ()=>{
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(insertNewRecipe.mock.calls.length).toEqual(3);
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(insertNewRecipe.mock.calls[0][1]).toEqual("path/to/content");  //canonical article ID
+    expect(insertNewRecipe.mock.calls[0][0]).toEqual("path/to/content");  //canonical article ID
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(insertNewRecipe.mock.calls[0][2]).toEqual({checksum: "abcd1", recipeUID: "uid-recep-1"});  //recipe data
+    expect(insertNewRecipe.mock.calls[0][1]).toEqual({checksum: "abcd1", recipeUID: "uid-recep-1"});  //recipe data
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(insertNewRecipe.mock.calls[1][1]).toEqual("path/to/content");  //canonical article ID
+    expect(insertNewRecipe.mock.calls[1][0]).toEqual("path/to/content");  //canonical article ID
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(insertNewRecipe.mock.calls[1][2]).toEqual({checksum: "efgh", recipeUID: "uid-recep-2"});  //recipe data
+    expect(insertNewRecipe.mock.calls[1][1]).toEqual({checksum: "efgh", recipeUID: "uid-recep-2"});  //recipe data
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(insertNewRecipe.mock.calls[2][1]).toEqual("path/to/content");  //canonical article ID
+    expect(insertNewRecipe.mock.calls[2][0]).toEqual("path/to/content");  //canonical article ID
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(insertNewRecipe.mock.calls[2][2]).toEqual({checksum: "xyzp", recipeUID: "uid-recep-3"});  //recipe data
+    expect(insertNewRecipe.mock.calls[2][1]).toEqual({checksum: "xyzp", recipeUID: "uid-recep-3"});  //recipe data
 
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(publishRecipeContent.mock.calls.length).toEqual(3);
@@ -106,13 +102,13 @@ describe("update_processor.handleContentUpdate", ()=>{
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipeVersion.mock.calls.length).toEqual(2);
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipeVersion.mock.calls[0][1]).toEqual("path/to/content");
+    expect(removeRecipeVersion.mock.calls[0][0]).toEqual("path/to/content");
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipeVersion.mock.calls[0][2]).toEqual({checksum: "xxxyyyzzz", recipeUID: "uid-recep-2"});
+    expect(removeRecipeVersion.mock.calls[0][1]).toEqual({checksum: "xxxyyyzzz", recipeUID: "uid-recep-2"});
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipeVersion.mock.calls[1][1]).toEqual("path/to/content");
+    expect(removeRecipeVersion.mock.calls[1][0]).toEqual("path/to/content");
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipeVersion.mock.calls[1][2]).toEqual({checksum: "zzzyyyqqq", recipeUID: "uid-recep-4"});
+    expect(removeRecipeVersion.mock.calls[1][1]).toEqual({checksum: "zzzyyyqqq", recipeUID: "uid-recep-4"});
   });
 
   it("should ignore a piece of content that is not an article", async ()=>{

--- a/lambda/recipes-responder/src/update_processor.test.ts
+++ b/lambda/recipes-responder/src/update_processor.test.ts
@@ -1,0 +1,186 @@
+import type {Content} from "@guardian/content-api-models/v1/content";
+import {ContentType} from "@guardian/content-api-models/v1/contentType";
+import type {
+  RecipeIndexEntry,
+  RecipeReferenceWithoutChecksum} from "@recipes-api/lib/recipes-data";
+import {
+  calculateChecksum,
+  extractAllRecipesFromArticle,
+  insertNewRecipe,
+  publishRecipeContent,
+  recipesToTakeDown,
+  removeRecipeVersion
+} from "@recipes-api/lib/recipes-data";
+import {handleContentUpdate} from "./update_processor";
+
+jest.mock("node-fetch", ()=>({
+  __esmodule: true,
+  default: jest.fn()
+}));
+
+jest.mock("./dynamo_conn", ()=>({
+  DynamoClient: {},
+}));
+
+jest.mock("@recipes-api/lib/recipes-data", ()=>({
+  calculateChecksum: jest.fn(),
+  extractAllRecipesFromArticle: jest.fn(),
+  insertNewRecipe: jest.fn(),
+  publishRecipeContent: jest.fn(),
+  recipesToTakeDown: jest.fn(),
+  removeRecipeVersion: jest.fn(),
+}));
+
+const fakeContent:Content = {
+  apiUrl: "api://path/to/content",
+  id: "path/to/content",
+  isHosted: false,
+  references: [],
+  tags: [],
+  type: ContentType.ARTICLE,
+  webTitle: "Test Article",
+  webUrl: "web://path/to/content"
+}
+
+describe("update_processor.handleContentUpdate", ()=>{
+  beforeEach(()=>{
+    jest.resetAllMocks();
+  });
+
+  it("should extract recipes from the content, publish those and take-down any that were no longer needed", async ()=>{
+    const refsInArticle:RecipeReferenceWithoutChecksum[] = [
+      { recipeUID: "uid-recep-1", jsonBlob: ""},
+      { recipeUID: "uid-recep-2", jsonBlob: ""},
+      { recipeUID: "uid-recep-3", jsonBlob: ""},
+    ];
+
+    const refsToRemove:RecipeIndexEntry[] = [
+      { recipeUID: "uid-recep-2", checksum: "xxxyyyzzz"},
+      { recipeUID: "uid-recep-4", checksum: "zzzyyyqqq"}
+    ];
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    extractAllRecipesFromArticle.mockReturnValue(Promise.resolve(refsInArticle));
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    recipesToTakeDown.mockReturnValue(refsToRemove);
+
+    calculateChecksum
+      // @ts-ignore -- Typescript doesn't know that this is a mock
+      .mockReturnValueOnce({ recipeUID: "uid-recep-1", jsonBlob: "", checksum: "abcd1"})
+      // @ts-ignore -- Typescript doesn't know that this is a mock
+      .mockReturnValueOnce({ recipeUID: "uid-recep-2", jsonBlob: "", checksum: "efgh"})
+      // @ts-ignore -- Typescript doesn't know that this is a mock
+      .mockReturnValueOnce({ recipeUID: "uid-recep-3", jsonBlob: "", checksum: "xyzp"});
+
+    await handleContentUpdate(fakeContent);
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(extractAllRecipesFromArticle.mock.calls.length).toEqual(1);
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(calculateChecksum.mock.calls.length).toEqual(3);
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(insertNewRecipe.mock.calls.length).toEqual(3);
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(insertNewRecipe.mock.calls[0][1]).toEqual("path/to/content");  //canonical article ID
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(insertNewRecipe.mock.calls[0][2]).toEqual({checksum: "abcd1", recipeUID: "uid-recep-1"});  //recipe data
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(insertNewRecipe.mock.calls[1][1]).toEqual("path/to/content");  //canonical article ID
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(insertNewRecipe.mock.calls[1][2]).toEqual({checksum: "efgh", recipeUID: "uid-recep-2"});  //recipe data
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(insertNewRecipe.mock.calls[2][1]).toEqual("path/to/content");  //canonical article ID
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(insertNewRecipe.mock.calls[2][2]).toEqual({checksum: "xyzp", recipeUID: "uid-recep-3"});  //recipe data
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(publishRecipeContent.mock.calls.length).toEqual(3);
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(publishRecipeContent.mock.calls[0][0]).toEqual({recipeUID: "uid-recep-1", checksum:"abcd1", jsonBlob: ""});
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(publishRecipeContent.mock.calls[1][0]).toEqual({recipeUID: "uid-recep-2", checksum:"efgh", jsonBlob: ""});
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(publishRecipeContent.mock.calls[2][0]).toEqual({recipeUID: "uid-recep-3", checksum:"xyzp", jsonBlob: ""});
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(removeRecipeVersion.mock.calls.length).toEqual(2);
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(removeRecipeVersion.mock.calls[0][1]).toEqual("path/to/content");
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(removeRecipeVersion.mock.calls[0][2]).toEqual({checksum: "xxxyyyzzz", recipeUID: "uid-recep-2"});
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(removeRecipeVersion.mock.calls[1][1]).toEqual("path/to/content");
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(removeRecipeVersion.mock.calls[1][2]).toEqual({checksum: "zzzyyyqqq", recipeUID: "uid-recep-4"});
+  });
+
+  it("should ignore a piece of content that is not an article", async ()=>{
+    const refsInArticle:RecipeReferenceWithoutChecksum[] = [
+      { recipeUID: "uid-recep-1", jsonBlob: ""},
+      { recipeUID: "uid-recep-2", jsonBlob: ""},
+      { recipeUID: "uid-recep-3", jsonBlob: ""},
+    ];
+
+    const refsToRemove:RecipeIndexEntry[] = [
+      { recipeUID: "uid-recep-2", checksum: "xxxyyyzzz"},
+      { recipeUID: "uid-recep-4", checksum: "zzzyyyqqq"}
+    ];
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    extractAllRecipesFromArticle.mockReturnValue(Promise.resolve(refsInArticle));
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    recipesToTakeDown.mockReturnValue(refsToRemove);
+
+    calculateChecksum
+      // @ts-ignore -- Typescript doesn't know that this is a mock
+      .mockReturnValueOnce({ recipeUID: "uid-recep-1", jsonBlob: "", checksum: "abcd1"})
+      // @ts-ignore -- Typescript doesn't know that this is a mock
+      .mockReturnValueOnce({ recipeUID: "uid-recep-2", jsonBlob: "", checksum: "efgh"})
+      // @ts-ignore -- Typescript doesn't know that this is a mock
+      .mockReturnValueOnce({ recipeUID: "uid-recep-3", jsonBlob: "", checksum: "xyzp"});
+
+    await handleContentUpdate({...fakeContent, type: ContentType.GALLERY});
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(extractAllRecipesFromArticle.mock.calls.length).toEqual(0);
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(calculateChecksum.mock.calls.length).toEqual(0);
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(insertNewRecipe.mock.calls.length).toEqual(0);
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(publishRecipeContent.mock.calls.length).toEqual(0);
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(removeRecipeVersion.mock.calls.length).toEqual(0);
+  });
+
+  it("should be fine if there is no recipe content", async ()=>{
+    const refsInArticle:RecipeReferenceWithoutChecksum[] = [];
+
+    const refsToRemove:RecipeIndexEntry[] = [];
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    extractAllRecipesFromArticle.mockReturnValue(Promise.resolve(refsInArticle));
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    recipesToTakeDown.mockReturnValue(refsToRemove);
+
+    await handleContentUpdate(fakeContent);
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(extractAllRecipesFromArticle.mock.calls.length).toEqual(1);
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(calculateChecksum.mock.calls.length).toEqual(0);
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(insertNewRecipe.mock.calls.length).toEqual(0);
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(publishRecipeContent.mock.calls.length).toEqual(0);
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(removeRecipeVersion.mock.calls.length).toEqual(0);
+  });
+});

--- a/lambda/recipes-responder/src/update_processor.ts
+++ b/lambda/recipes-responder/src/update_processor.ts
@@ -10,7 +10,7 @@ import {
   insertNewRecipe,
   publishRecipeContent,
   recipesToTakeDown,
-  removeRecipePermanently
+  removeRecipeVersion
 } from "@recipes-api/lib/recipes-data";
 import {CapiKey} from "./config";
 import {DynamoClient} from "./dynamo_conn";
@@ -59,7 +59,7 @@ export async function handleContentUpdate(content:Content):Promise<number>
 
   const entriesToRemove = await recipesToTakeDown(DynamoClient, content.id, allRecipes.map(recep=>recep.recipeUID));
   console.log(`INFO [${content.id}] - ${entriesToRemove.length} recipes have been removed/superceded`);
-  entriesToRemove.map(recep=>removeRecipePermanently(DynamoClient, content.id, recep));
+  entriesToRemove.map(recep=>removeRecipeVersion(DynamoClient, content.id, recep));
 
   console.log(`INFO [${content.id}] - publishing ${allRecipes.length} recipes to the service`)
   await Promise.all(allRecipes.map(recep=>publishRecipe(content.id, recep)))

--- a/lambda/recipes-responder/src/update_processor.ts
+++ b/lambda/recipes-responder/src/update_processor.ts
@@ -6,7 +6,7 @@ import {
   extractAllRecipesFromArticle,
   insertNewRecipe,
   publishRecipeContent,
-  recipesToTakeDown,
+  recipesToTakeDown, removeRecipePermanently,
   removeRecipeVersion
 } from "@recipes-api/lib/recipes-data";
 import {DynamoClient} from "./dynamo_conn";

--- a/lambda/recipes-responder/src/update_processor.ts
+++ b/lambda/recipes-responder/src/update_processor.ts
@@ -6,7 +6,7 @@ import {
   extractAllRecipesFromArticle,
   insertNewRecipe,
   publishRecipeContent,
-  recipesToTakeDown, removeRecipePermanently,
+  recipesToTakeDown,
   removeRecipeVersion
 } from "@recipes-api/lib/recipes-data";
 import {DynamoClient} from "./dynamo_conn";
@@ -41,7 +41,7 @@ export async function handleContentUpdate(content:Content):Promise<number>
     const entriesToRemove = await recipesToTakeDown(DynamoClient, content.id, allRecipes.map(recep => recep.recipeUID));
     console.log(`INFO [${content.id}] - ${entriesToRemove.length} recipes have been removed/superceded`);
     if (allRecipes.length == 0 && entriesToRemove.length == 0) return 0;  //no point hanging around and noising up the logs
-    entriesToRemove.map(recep => removeRecipeVersion(DynamoClient, content.id, recep));
+    await Promise.all(entriesToRemove.map(recep => removeRecipeVersion(DynamoClient, content.id, recep)));
 
     console.log(`INFO [${content.id}] - publishing ${allRecipes.length} recipes to the service`)
     await Promise.all(allRecipes.map(recep => publishRecipe(content.id, recep)))

--- a/lambda/recipes-responder/src/update_processor.ts
+++ b/lambda/recipes-responder/src/update_processor.ts
@@ -1,9 +1,19 @@
 import type {RetrievableContent} from "@guardian/content-api-models/crier/event/v1/retrievableContent";
 import type {Content} from "@guardian/content-api-models/v1/content";
-import type {PollingResult} from "@recipes-api/lib/capi";
-import {callCAPI, PollingAction} from "@recipes-api/lib/capi";
-import {CapiKey} from "./config";
 import {ContentType} from "@guardian/content-api-models/v1/contentType";
+import {callCAPI, PollingAction} from "@recipes-api/lib/capi";
+import type {PollingResult} from "@recipes-api/lib/capi";
+import type {RecipeReference} from "@recipes-api/lib/recipes-data";
+import {
+  calculateChecksum,
+  extractAllRecipesFromArticle,
+  insertNewRecipe,
+  publishRecipeContent,
+  recipesToTakeDown,
+  removeRecipePermanently
+} from "@recipes-api/lib/recipes-data";
+import {CapiKey} from "./config";
+import {DynamoClient} from "./dynamo_conn";
 
 async function retrieveContent(capiUrl:string) :Promise<PollingResult>{
   if(!CapiKey) {
@@ -21,17 +31,46 @@ async function retrieveContent(capiUrl:string) :Promise<PollingResult>{
   return callCAPI(`${capiUrl}?${params}`);
 }
 
-export async function handleContentUpdate(content:Content):Promise<void>
+/**
+ * Pushes new content into the service
+ * @param canonicalArticleId
+ * @param recep
+ */
+async function publishRecipe(canonicalArticleId:string, recep:RecipeReference):Promise<void>
 {
-  if(content.type!=ContentType.ARTICLE) return;  //no point processing live-blogs etc.
-
-  console.log(`TEST - update for ${content.id} detected`);
-  return Promise.resolve();
+  console.log(`INFO [${canonicalArticleId}] - pushing ${recep.recipeUID} @ ${recep.checksum} to S3...`);
+  await publishRecipeContent(recep);
+  console.log(`INFO [${canonicalArticleId}] - updating index table...`);
+  await insertNewRecipe(DynamoClient, canonicalArticleId, {recipeUID: recep.recipeUID, checksum: recep.checksum});
 }
 
-export async function handleContentUpdateRetrievable(retrievable:RetrievableContent): Promise<void>
+/**
+ * Takes an updated article and updates any recipes from inside it
+ * @param content - Content of an incoming article
+ * @returns a number, representing the number of recipes that were updated
+ */
+export async function handleContentUpdate(content:Content):Promise<number>
 {
-  if(retrievable.contentType!=ContentType.ARTICLE) return;  //no point processing live-blogs etc.
+  if(content.type!=ContentType.ARTICLE) return 0;  //no point processing live-blogs etc.
+
+  const allRecipes:RecipeReference[] = (await extractAllRecipesFromArticle(content)).map(calculateChecksum);
+  console.log(`INFO [${content.id}] - has ${allRecipes.length} recipes`);
+  if(allRecipes.length==0) return 0;  //no point hanging around and noising up the logs
+
+  const entriesToRemove = await recipesToTakeDown(DynamoClient, content.id, allRecipes.map(recep=>recep.recipeUID));
+  console.log(`INFO [${content.id}] - ${entriesToRemove.length} recipes have been removed/superceded`);
+  entriesToRemove.map(recep=>removeRecipePermanently(DynamoClient, content.id, recep));
+
+  console.log(`INFO [${content.id}] - publishing ${allRecipes.length} recipes to the service`)
+  await Promise.all(allRecipes.map(recep=>publishRecipe(content.id, recep)))
+
+  console.log(`INFO [${content.id}] - Done`);
+  return allRecipes.length;
+}
+
+export async function handleContentUpdateRetrievable(retrievable:RetrievableContent): Promise<number>
+{
+  if(retrievable.contentType!=ContentType.ARTICLE) return 0;  //no point processing live-blogs etc.
 
   const capiResponse = await retrieveContent(retrievable.capiUrl);
   switch(capiResponse.action) {
@@ -45,11 +84,12 @@ export async function handleContentUpdateRetrievable(retrievable:RetrievableCont
       } else {
         console.error("Content existed but was empty, this shouldn't happen :(")
       }
-      break;
+      return 0;
     case PollingAction.CONTENT_GONE:
     case PollingAction.CONTENT_MISSING:
+      //FIXME: should we invoke article-deletion here just in case?
       console.log(`INFO Content has gone for this update, assuming that this article was taken down in the meantime.`);
-      break;
+      return 0;
     default:
       //we throw an exception to indicate failure; the lambda runtime will then re-run us and DLQ the message if enough failures happen.
       throw new Error(`Could not handle retrievable update from CAPI: PollingAction code was ${capiResponse.action.toString()}. Allowing the lambda runtime to retry or DLQ.`);

--- a/lambda/recipes-responder/src/update_processor.ts
+++ b/lambda/recipes-responder/src/update_processor.ts
@@ -39,11 +39,12 @@ export async function handleContentUpdate(content:Content):Promise<number>
     console.log(`INFO [${content.id}] - has ${allRecipes.length} recipes`);
 
     const entriesToRemove = await recipesToTakeDown(DynamoClient, content.id, allRecipes.map(recep => recep.recipeUID));
-    console.log(`INFO [${content.id}] - ${entriesToRemove.length} recipes have been removed/superceded`);
+    console.log(`INFO [${content.id}] - ${entriesToRemove.length} recipes have been removed/superceded in the incoming article`);
     if (allRecipes.length == 0 && entriesToRemove.length == 0) return 0;  //no point hanging around and noising up the logs
     await Promise.all(entriesToRemove.map(recep => removeRecipeVersion(DynamoClient, content.id, recep)));
+    console.log(`INFO [${content.id}] - ${entriesToRemove.length} removed/superceded recipes have been removed from the store`);
 
-    console.log(`INFO [${content.id}] - publishing ${allRecipes.length} recipes to the service`)
+    console.log(`INFO [${content.id}] - publishing ${allRecipes.length} new/updated recipes to the service`)
     await Promise.all(allRecipes.map(recep => publishRecipe(content.id, recep)))
 
     console.log(`INFO [${content.id}] - Done`);

--- a/lambda/recipes-responder/src/update_processor.ts
+++ b/lambda/recipes-responder/src/update_processor.ts
@@ -1,8 +1,5 @@
-import type {RetrievableContent} from "@guardian/content-api-models/crier/event/v1/retrievableContent";
 import type {Content} from "@guardian/content-api-models/v1/content";
 import {ContentType} from "@guardian/content-api-models/v1/contentType";
-import {callCAPI, PollingAction} from "@recipes-api/lib/capi";
-import type {PollingResult} from "@recipes-api/lib/capi";
 import type {RecipeReference} from "@recipes-api/lib/recipes-data";
 import {
   calculateChecksum,
@@ -12,24 +9,7 @@ import {
   recipesToTakeDown,
   removeRecipeVersion
 } from "@recipes-api/lib/recipes-data";
-import {CapiKey} from "./config";
 import {DynamoClient} from "./dynamo_conn";
-
-async function retrieveContent(capiUrl:string) :Promise<PollingResult>{
-  if(!CapiKey) {
-    throw new Error("You need to set CAPI_KEY in order to make requests to CAPI");
-  }
-
-  const params = [
-    `show-fields=internalRevision`,
-    `show-blocks=all`,
-    `show-channels=all`,
-    `api-key=${CapiKey}`,
-    `format=thrift`
-  ].filter(v=>!!v).join("&");
-
-  return callCAPI(`${capiUrl}?${params}`);
-}
 
 /**
  * Pushes new content into the service
@@ -68,30 +48,3 @@ export async function handleContentUpdate(content:Content):Promise<number>
   return allRecipes.length;
 }
 
-export async function handleContentUpdateRetrievable(retrievable:RetrievableContent): Promise<number>
-{
-  if(retrievable.contentType!=ContentType.ARTICLE) return 0;  //no point processing live-blogs etc.
-
-  const capiResponse = await retrieveContent(retrievable.capiUrl);
-  switch(capiResponse.action) {
-    case PollingAction.CONTENT_EXISTS:
-      //Great, we have it - but should check if this has now been superceded
-      if(capiResponse.content?.fields?.internalRevision ?? 0 > (retrievable.internalRevision ?? 99) ) {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- it's just a logging line
-        console.log(`INFO Retrievable update was superceded - we expected to see ${retrievable.internalRevision} but got ${capiResponse.content?.fields?.internalRevision}`);
-      } else if(capiResponse.content) {
-        return handleContentUpdate(capiResponse.content)
-      } else {
-        console.error("Content existed but was empty, this shouldn't happen :(")
-      }
-      return 0;
-    case PollingAction.CONTENT_GONE:
-    case PollingAction.CONTENT_MISSING:
-      //FIXME: should we invoke article-deletion here just in case?
-      console.log(`INFO Content has gone for this update, assuming that this article was taken down in the meantime.`);
-      return 0;
-    default:
-      //we throw an exception to indicate failure; the lambda runtime will then re-run us and DLQ the message if enough failures happen.
-      throw new Error(`Could not handle retrievable update from CAPI: PollingAction code was ${capiResponse.action.toString()}. Allowing the lambda runtime to retry or DLQ.`);
-  }
-}

--- a/lambda/recipes-responder/src/update_retrievable_processor.test.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.test.ts
@@ -1,0 +1,95 @@
+import type {RetrievableContent} from "@guardian/content-api-models/crier/event/v1/retrievableContent";
+import type {Content} from "@guardian/content-api-models/v1/content";
+import {ContentType} from "@guardian/content-api-models/v1/contentType";
+import {callCAPI} from "@recipes-api/lib/capi";
+import {handleContentUpdate} from "./update_processor";
+import {handleContentUpdateRetrievable} from "./update_retrievable_processor";
+
+jest.mock("@recipes-api/lib/capi", ()=>({
+  callCAPI: jest.fn(),
+}));
+
+jest.mock("./update_processor", ()=>({
+  handleContentUpdate: jest.fn(),
+}));
+
+jest.mock("./config", ()=>({
+  CapiKey: "fake-api-key",
+}));
+
+const fakeUpdate:RetrievableContent = {
+  capiUrl: "api:///path/to/article",
+  id: "path/to/article",
+  contentType: ContentType.ARTICLE,
+}
+
+const fakeContent:Content = {
+  apiUrl: "api://path/to/content",
+  id: "path/to/content",
+  isHosted: false,
+  references: [],
+  tags: [],
+  type: ContentType.ARTICLE,
+  webTitle: "Test Article",
+  webUrl: "web://path/to/content"
+}
+
+describe('handleContentUpdateRetrievable',  ()=> {
+  beforeEach(()=>{
+    jest.resetAllMocks();
+  });
+
+  it("should retrieve the content from CAPI, then call out to the regular update-processor", async ()=>{
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    callCAPI.mockReturnValue(Promise.resolve({action:0, content: fakeContent}));
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    handleContentUpdate.mockReturnValue(Promise.resolve(3));
+
+    const recordCount = await handleContentUpdateRetrievable(fakeUpdate);
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(callCAPI.mock.calls.length).toEqual(1);
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(callCAPI.mock.calls[0][0]).toEqual(fakeUpdate.capiUrl + "?show-fields=internalRevision&show-blocks=all&show-channels=all&api-key=fake-api-key&format=thrift");
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(handleContentUpdate.mock.calls.length).toEqual(1);
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(handleContentUpdate.mock.calls[0][0]).toEqual(fakeContent);
+    expect(recordCount).toEqual(3); //it should pass back the value returned by handleContentUpdate
+  });
+
+  it("should ignore something that's not an article", async ()=>{
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    callCAPI.mockReturnValue(Promise.resolve({action:0, content: fakeContent}));
+
+    const recordCount = await handleContentUpdateRetrievable({...fakeUpdate, contentType: ContentType.GALLERY});
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(callCAPI.mock.calls.length).toEqual(0);
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(handleContentUpdate.mock.calls.length).toEqual(0);
+    expect(recordCount).toEqual(0);
+  });
+
+  it("should throw if it gets an error response from CAPI", async ()=>{
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    callCAPI.mockReturnValue(Promise.resolve({action:4, content: fakeContent}));
+
+    await expect(handleContentUpdateRetrievable(fakeUpdate)).rejects.toEqual(new Error("Could not handle retrievable update from CAPI: PollingAction code was 4. Allowing the lambda runtime to retry or DLQ."));
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(callCAPI.mock.calls.length).toEqual(1);
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(handleContentUpdate.mock.calls.length).toEqual(0);
+  });
+
+  it("should disregard content that is taken down in the meantime", async ()=>{
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    callCAPI.mockReturnValue(Promise.resolve({action:1, content: fakeContent}));
+
+    const recordCount = await handleContentUpdateRetrievable(fakeUpdate);
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(callCAPI.mock.calls.length).toEqual(1);
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(handleContentUpdate.mock.calls.length).toEqual(0);
+    expect(recordCount).toEqual(0);
+  });
+});

--- a/lambda/recipes-responder/src/update_retrievable_processor.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.ts
@@ -44,9 +44,10 @@ export async function handleContentUpdateRetrievable(retrievable:RetrievableCont
   switch(capiResponse.action) {
     case PollingAction.CONTENT_EXISTS:
       //Great, we have it - but should check if this has now been superceded
-      if(capiResponse.content?.fields?.internalRevision ?? 0 > (retrievable.internalRevision ?? 99) ) {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- it's just a logging line
-        console.log(`INFO Retrievable update was superceded - we expected to see ${retrievable.internalRevision} but got ${capiResponse.content?.fields?.internalRevision}`);
+      if(capiResponse.content?.fields?.internalRevision &&
+        retrievable.internalRevision &&
+        capiResponse.content.fields.internalRevision > retrievable.internalRevision ) {
+        console.log(`INFO Retrievable update was superceded - we expected to see ${retrievable.internalRevision} but got ${capiResponse.content.fields.internalRevision}`);
       } else if(capiResponse.content) {
         return handleContentUpdate(capiResponse.content)
       } else {

--- a/lambda/recipes-responder/src/update_retrievable_processor.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.ts
@@ -1,0 +1,65 @@
+/* eslint @typescript-eslint/naming-convention: "off"  -- PollingAction uses a more CAPI-like convention*/
+import type {RetrievableContent} from "@guardian/content-api-models/crier/event/v1/retrievableContent";
+import {ContentType} from "@guardian/content-api-models/v1/contentType";
+import type { PollingResult} from "@recipes-api/lib/capi";
+import {callCAPI} from "@recipes-api/lib/capi";
+import {CapiKey} from "./config";
+import {handleContentUpdate} from "./update_processor";
+
+// Why are these functions in their own file? To make mocking in tests easier.
+
+// Why can't we just import this from capi module? It appears that the info gets erased at transpile time, so we end up
+//with object undefined errors at runtime :-(
+enum PollingAction {
+  CONTENT_EXISTS,
+  CONTENT_MISSING,
+  CONTENT_GONE,
+  CONCIERGE_UNHAPPY,
+  INTERNAL_BUG,
+  UNEXPECTED_RESPONSE,
+  RATE_LIMITED
+}
+
+async function retrieveContent(capiUrl:string) :Promise<PollingResult>{
+  if(!CapiKey) {
+    throw new Error("You need to set CAPI_KEY in order to make requests to CAPI");
+  }
+
+  const params = [
+    `show-fields=internalRevision`,
+    `show-blocks=all`,
+    `show-channels=all`,
+    `api-key=${CapiKey}`,
+    `format=thrift`
+  ].filter(v=>!!v).join("&");
+
+  return callCAPI(`${capiUrl}?${params}`);
+}
+
+export async function handleContentUpdateRetrievable(retrievable:RetrievableContent): Promise<number>
+{
+  if(retrievable.contentType!=ContentType.ARTICLE) return 0;  //no point processing live-blogs etc.
+
+  const capiResponse = await retrieveContent(retrievable.capiUrl);
+  switch(capiResponse.action) {
+    case PollingAction.CONTENT_EXISTS:
+      //Great, we have it - but should check if this has now been superceded
+      if(capiResponse.content?.fields?.internalRevision ?? 0 > (retrievable.internalRevision ?? 99) ) {
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- it's just a logging line
+        console.log(`INFO Retrievable update was superceded - we expected to see ${retrievable.internalRevision} but got ${capiResponse.content?.fields?.internalRevision}`);
+      } else if(capiResponse.content) {
+        return handleContentUpdate(capiResponse.content)
+      } else {
+        console.error("Content existed but was empty, this shouldn't happen :(")
+      }
+      return 0;
+    case PollingAction.CONTENT_GONE:
+    case PollingAction.CONTENT_MISSING:
+      //FIXME: should we invoke article-deletion here just in case?
+      console.log(`INFO Content has gone for this update, assuming that this article was taken down in the meantime.`);
+      return 0;
+    default:
+      //we throw an exception to indicate failure; the lambda runtime will then re-run us and DLQ the message if enough failures happen.
+      throw new Error(`Could not handle retrievable update from CAPI: PollingAction code was ${capiResponse.action.toString()}. Allowing the lambda runtime to retry or DLQ.`);
+  }
+}

--- a/lambda/test-indexbuild/src/main.ts
+++ b/lambda/test-indexbuild/src/main.ts
@@ -31,7 +31,7 @@ export const handler:Handler = async ()=>{
   console.log("Index test starting up");
 
   console.log("Retrieving index data...");
-  const indexData = await retrieveIndexData(dynamoClient);
+  const indexData = await retrieveIndexData();
   console.log("Done.")
   await writeIndexData(indexData);
   console.log("All completed.");

--- a/lib/capi/src/lib/deserialize.ts
+++ b/lib/capi/src/lib/deserialize.ts
@@ -6,7 +6,7 @@ import type { TProtocol} from "thrift";
 import {TCompactProtocol, TFramedTransport} from "thrift";
 
 function feedToThrift(content:string|Buffer):TProtocol {
-  const buffer = Buffer.isBuffer(content) ? content : new Buffer(content, 'base64');
+  const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content, 'base64');
   const transport = new TFramedTransport(buffer)
   return new TCompactProtocol(transport);
 }

--- a/lib/recipes-data/src/index.ts
+++ b/lib/recipes-data/src/index.ts
@@ -1,4 +1,14 @@
+import type {Content} from "@guardian/content-api-models/v1/content";
+import type {RecipeReferenceWithoutChecksum} from "./lib/models";
+
 export * from './lib/models';
 export * from './lib/dynamo';
 export * from './lib/takedown';
-export {awaitableDelay} from './lib/utils';
+export * from './lib/s3';
+
+//FIXME temporary stub function, don't merge
+export async function extractAllRecipesFromArticle(content:Content):Promise<RecipeReferenceWithoutChecksum[]> {
+  return Promise.reject(new Error("extractAllRecipesFromArticle is not implemented yet"));
+}
+
+export {awaitableDelay, calculateChecksum} from './lib/utils';

--- a/lib/recipes-data/src/index.ts
+++ b/lib/recipes-data/src/index.ts
@@ -1,14 +1,7 @@
-import type {Content} from "@guardian/content-api-models/v1/content";
-import type {RecipeReferenceWithoutChecksum} from "./lib/models";
-
 export * from './lib/models';
 export * from './lib/dynamo';
 export * from './lib/takedown';
 export * from './lib/s3';
+export * from './lib/extract-recipes';
 
-//FIXME temporary stub function, don't merge
-export async function extractAllRecipesFromArticle(content:Content):Promise<RecipeReferenceWithoutChecksum[]> {
-  return Promise.reject(new Error("extractAllRecipesFromArticle is not implemented yet"));
-}
-
-export {awaitableDelay, calculateChecksum} from './lib/utils';
+export {awaitableDelay, calculateChecksum, makeCapiDateTime} from './lib/utils';

--- a/lib/recipes-data/src/lib/config.ts
+++ b/lib/recipes-data/src/lib/config.ts
@@ -1,10 +1,12 @@
 //Used by dynamo.ts
+import * as process from "process";
+
 export const indexTableName = process.env["INDEX_TABLE"]
 export const lastUpdatedIndex = process.env["LAST_UPDATED_INDEX"]
 
 //Used by fastly.ts
 const UrlPrefix = /^http(s)?:\/\//;
-export const ContentUrlBase = process.env["CONTENT_URL_BASE"];
+export const ContentUrlBase = mandatoryParameter("CONTENT_URL_BASE");
 export const ContentPrefix = ContentUrlBase ? ContentUrlBase.replace(UrlPrefix, "") : undefined;
 export const DebugLogsEnabled = process.env["DEBUG_LOGS"] ? process.env["DEBUG_LOGS"].toLowerCase()==="true" : false;
 export const MaximumRetries = process.env["MAX_RETRIES"] ? parseInt(process.env["MAX_RETRIES"]) : 10;
@@ -12,4 +14,12 @@ export const RetryDelaySeconds = process.env["RETRY_DELAY"] ? parseInt(process.e
 export const FastlyApiKey = process.env["FASTLY_API_KEY"];
 
 //Used by s3.ts
-export const StaticBucketName = process.env["STATIC_BUCKET"];
+export const StaticBucketName = mandatoryParameter("STATIC_BUCKET");
+
+function mandatoryParameter(name:string):string {
+  if(process.env[name]) {
+    return process.env[name] as string;
+  } else {
+    throw new Error(`You need to define the environment variable ${name} in the lambda config`)
+  }
+}

--- a/lib/recipes-data/src/lib/dynamo.test.ts
+++ b/lib/recipes-data/src/lib/dynamo.test.ts
@@ -9,7 +9,6 @@ import {mockClient} from "aws-sdk-client-mock";
 import {bulkRemoveRecipe, removeAllRecipeIndexEntriesForArticle, removeRecipe} from './dynamo';
 import type {RecipeDatabaseEntry, RecipeDatabaseKey} from './models';
 import {RecipeDatabaseEntryToDynamo, RecipeDatabaseEntryToIndex} from "./models";
-import {removeAllRecipesForArticle} from "@recipes-api/lib/recipes-data";
 
 jest.mock("node-fetch");
 
@@ -43,7 +42,7 @@ describe("dynamodb", ()=>{
     it("should make a Dynamo request to remove the relevant record", async ()=>{
       mockDynamoClient.on(DeleteItemCommand).resolves({});
 
-      await removeRecipe(ddbClient, "path/to/some/article-id", "xxxyyyzzz");
+      await removeRecipe("path/to/some/article-id", "xxxyyyzzz");
       expect(mockDynamoClient.commandCalls(DeleteItemCommand).length).toEqual(1);
       const call = mockDynamoClient.commandCalls(DeleteItemCommand)[0];
       const req = call.firstArg as DeleteItemCommand;
@@ -61,7 +60,7 @@ describe("dynamodb", ()=>{
         UnprocessedItems: {"TestTable": []},
       });
 
-      await bulkRemoveRecipe(ddbClient, makeRecptBatch(6));
+      await bulkRemoveRecipe(makeRecptBatch(6));
       expect(mockDynamoClient.commandCalls(BatchWriteItemCommand).length).toEqual(1);
       const call = mockDynamoClient.commandCalls(BatchWriteItemCommand)[0];
       const req = call.firstArg as BatchWriteItemCommand;
@@ -79,7 +78,7 @@ describe("dynamodb", ()=>{
         UnprocessedItems: {"TestTable": []},
       });
 
-      await bulkRemoveRecipe(ddbClient, makeRecptBatch(93));
+      await bulkRemoveRecipe(makeRecptBatch(93));
       expect(mockDynamoClient.commandCalls(BatchWriteItemCommand).length).toEqual(4);
 
       //for brevity, we're just checking the last page of calls
@@ -115,7 +114,7 @@ describe("dynamodb", ()=>{
         })
         .resolves({});
 
-      await bulkRemoveRecipe(ddbClient, items);
+      await bulkRemoveRecipe(items);
 
       //We expect two write calls, one with all 8 of the items and the second with the two that were skipped
       expect(mockDynamoClient.commandCalls(BatchWriteItemCommand).length).toEqual(2);
@@ -171,7 +170,7 @@ describe("dynamodb", ()=>{
       });
       mockDynamoClient.on(BatchWriteItemCommand).resolves({});
 
-      const result = await removeAllRecipeIndexEntriesForArticle(ddbClient, "path/to/article");
+      const result = await removeAllRecipeIndexEntriesForArticle("path/to/article");
       expect(result).toEqual(fakeRecords.map(RecipeDatabaseEntryToIndex));
       expect(mockDynamoClient.commandCalls(QueryCommand).length).toEqual(1);
       expect(mockDynamoClient.commandCalls(BatchWriteItemCommand).length).toEqual(1);
@@ -198,7 +197,7 @@ describe("dynamodb", ()=>{
       });
       mockDynamoClient.on(BatchWriteItemCommand).resolves({});
 
-      const result = await removeAllRecipeIndexEntriesForArticle(ddbClient, "path/to/article");
+      const result = await removeAllRecipeIndexEntriesForArticle("path/to/article");
       expect(result).toEqual(fakeRecords.map(RecipeDatabaseEntryToIndex));
       expect(mockDynamoClient.commandCalls(QueryCommand).length).toEqual(1);
       expect(mockDynamoClient.commandCalls(BatchWriteItemCommand).length).toEqual(0);

--- a/lib/recipes-data/src/lib/dynamo.ts
+++ b/lib/recipes-data/src/lib/dynamo.ts
@@ -1,16 +1,18 @@
-import type {AttributeValue, DeleteItemCommandOutput, DynamoDBClient, WriteRequest} from "@aws-sdk/client-dynamodb";
+import type {AttributeValue, DeleteItemCommandOutput, WriteRequest} from "@aws-sdk/client-dynamodb";
 import {
   BatchWriteItemCommand, ConditionalCheckFailedException,
-  DeleteItemCommand,
+  DeleteItemCommand, DynamoDBClient,
   PutItemCommand,
   QueryCommand,
   ScanCommand
 } from "@aws-sdk/client-dynamodb";
+import {formatISO} from "date-fns";
 import {lastUpdatedIndex as IndexName, MaximumRetries, indexTableName as TableName} from "./config";
 import type {RecipeDatabaseKey, RecipeIndex, RecipeIndexEntry} from './models';
 import {RecipeIndexEntryFromDynamo} from "./models";
 import {awaitableDelay, nowTime} from "./utils";
-import {formatISO} from "date-fns";
+
+const client = new DynamoDBClient({region: process.env["AWS_REGION"]});
 
 type DynamoRecord =  Record<string, AttributeValue>;
 
@@ -19,7 +21,7 @@ interface DataPage {
   recipes: RecipeIndexEntry[];
 }
 
-async function retrieveIndexPage(client: DynamoDBClient, ExclusiveStartKey? : DynamoRecord): Promise<DataPage>
+async function retrieveIndexPage(ExclusiveStartKey? : DynamoRecord): Promise<DataPage>
 {
   const req = new ScanCommand({
     ExclusiveStartKey,
@@ -34,12 +36,12 @@ async function retrieveIndexPage(client: DynamoDBClient, ExclusiveStartKey? : Dy
   };
 }
 
-export async function retrieveIndexData(client: DynamoDBClient) : Promise<RecipeIndex> {
+export async function retrieveIndexData() : Promise<RecipeIndex> {
    let nextKey: DynamoRecord|undefined = undefined;
    const recipes: RecipeIndexEntry[] = [];
 
    do {
-      const page = await retrieveIndexPage(client, nextKey);
+      const page = await retrieveIndexPage(nextKey);
       nextKey = page.ExclusiveStartKey;
       recipes.push(...page.recipes);
     } while (nextKey);
@@ -47,7 +49,7 @@ export async function retrieveIndexData(client: DynamoDBClient) : Promise<Recipe
    return {schemaVersion: 1, recipes, lastUpdated: new Date()}
 }
 
-export async function recipesforArticle(client:DynamoDBClient, articleCanonicalId: string): Promise<RecipeIndexEntry[]>
+export async function recipesforArticle(articleCanonicalId: string): Promise<RecipeIndexEntry[]>
 {
   const req = new QueryCommand({
     TableName,
@@ -71,7 +73,7 @@ export async function recipesforArticle(client:DynamoDBClient, articleCanonicalI
  * @param recipeUID uid of the recipe to remove
  * @param recipeChecksum if this is set, then we perform a "conditional delete" that will only remove the record if the recipeVersion field matches this value
  */
-export async function removeRecipe(client: DynamoDBClient, canonicalArticleId:string, recipeUID: string, recipeChecksum?:string):Promise<DeleteItemCommandOutput|null>
+export async function removeRecipe(canonicalArticleId:string, recipeUID: string, recipeChecksum?:string):Promise<DeleteItemCommandOutput|null>
 {
   const ExpressionAttributeValues:Record<string,AttributeValue> = {};
   if(recipeChecksum) {
@@ -107,7 +109,7 @@ export async function removeRecipe(client: DynamoDBClient, canonicalArticleId:st
  * @param client
  * @param canonicalArticleId
  */
-export async function removeAllRecipeIndexEntriesForArticle(client: DynamoDBClient, canonicalArticleId: string): Promise<RecipeIndexEntry[]>
+export async function removeAllRecipeIndexEntriesForArticle(canonicalArticleId: string): Promise<RecipeIndexEntry[]>
 {
   const req = new QueryCommand({
     TableName,
@@ -135,12 +137,12 @@ export async function removeAllRecipeIndexEntriesForArticle(client: DynamoDBClie
         recipeUID: dbEntry["recipeUID"].S as string
       }));
     console.log(`${recepts.length} recipes to remove for article ${canonicalArticleId}`);
-    await bulkRemoveRecipe(client, recepts);
+    await bulkRemoveRecipe(recepts);
     return entries
   }
 }
 
-async function bulkRemovePage(client:DynamoDBClient, page:WriteRequest[], others:WriteRequest[], retryCount:number):Promise<void>
+async function bulkRemovePage(page:WriteRequest[], others:WriteRequest[], retryCount:number):Promise<void>
 {
   if(page.length==0) {
     if(others.length==0) {
@@ -148,7 +150,7 @@ async function bulkRemovePage(client:DynamoDBClient, page:WriteRequest[], others
       return
     } else {
       //ok for some weird reason we got an empty array to process but more to do.
-      return bulkRemovePage(client, others, [], 0);
+      return bulkRemovePage(others, [], 0);
     }
   }
 
@@ -168,11 +170,11 @@ async function bulkRemovePage(client:DynamoDBClient, page:WriteRequest[], others
     }
     console.log(`WARNING Could not remove all items on attempt ${retryCount}. Pausing before trying again...`);
     await awaitableDelay();
-    return bulkRemovePage(client, result.UnprocessedItems[TableName as string], others, retryCount+1);
+    return bulkRemovePage(result.UnprocessedItems[TableName as string], others, retryCount+1);
   } else if(others.length>0) {
     const nextPage = others.slice(0, 25);
     const nextOthers = others.length>25 ? others.slice(25) : [];
-    return bulkRemovePage(client, nextPage, nextOthers, 0);
+    return bulkRemovePage(nextPage, nextOthers, 0);
   } else {
     return
   }
@@ -181,10 +183,9 @@ async function bulkRemovePage(client:DynamoDBClient, page:WriteRequest[], others
 /**
  * Utilise the batch write functionality of Dynamo to remove a bunch of recipes in one go.
  * This is more efficient than removing each one manually.
- * @param client DynamoDB client
  * @param receps array of RecipeDatabaseKey[] identifying the recipes to remove from the index
  */
-export async function bulkRemoveRecipe(client: DynamoDBClient, receps:RecipeDatabaseKey[]):Promise<void>
+export async function bulkRemoveRecipe(receps:RecipeDatabaseKey[]):Promise<void>
 {
   const requests:WriteRequest[] = receps.map(recep=>({
     DeleteRequest: {
@@ -196,13 +197,13 @@ export async function bulkRemoveRecipe(client: DynamoDBClient, receps:RecipeData
   }));
 
   if(requests.length>25) {
-    return bulkRemovePage(client, requests.slice(0, 25), requests.slice(25), 0)
+    return bulkRemovePage(requests.slice(0, 25), requests.slice(25), 0)
   } else {
-    return bulkRemovePage(client, requests, [], 0);
+    return bulkRemovePage(requests, [], 0);
   }
 }
 
-export async function insertNewRecipe(client: DynamoDBClient, canonicalArticleId: string, entry:RecipeIndexEntry):Promise<void>
+export async function insertNewRecipe(canonicalArticleId: string, entry:RecipeIndexEntry):Promise<void>
 {
   const req = new PutItemCommand({
     TableName,

--- a/lib/recipes-data/src/lib/extract-all-recipes.test.ts
+++ b/lib/recipes-data/src/lib/extract-all-recipes.test.ts
@@ -5,6 +5,10 @@ import {ElementType} from "@guardian/content-api-models/v1/elementType";
 import {extractAllRecipesFromArticle} from "./extract-recipes";
 import {makeCapiDateTime} from "./utils";
 
+jest.mock("./config", ()=>({
+
+}));
+
 describe("extractAllRecipesFromAnArticle", () => {
 
   it("should work if main and body block contains one recipe each", () => {

--- a/lib/recipes-data/src/lib/extract-recipes.test.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.test.ts
@@ -91,7 +91,7 @@ describe("extractRecipeData", () => {
     }
     const result = extractRecipeData(canonicalId, block)
     expect(result.length).toEqual(1)
-    expect(result[0]?.recipeUID).toEqual("1")
+    expect(result[0]?.recipeUID).toEqual("62ac3f0f98f6495cbefd72c11fac6d1e26390e99")
     expect(result[0]?.jsonBlob).toEqual(block.elements[1].recipeTypeData?.recipeJson)
   })
 
@@ -195,7 +195,7 @@ describe("extractRecipeData", () => {
     }
     const result = extractRecipeData(canonicalId, block)
     expect(result.length).toEqual(3)
-    expect(result[2]?.recipeUID).toEqual("3")
+    expect(result[2]?.recipeUID).toEqual("ffe7319af2c4a1b209e0c4a44f8acf7d7c3d88c4")
     expect(result[2]?.jsonBlob).toEqual(block.elements[3].recipeTypeData?.recipeJson)
   })
 

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -50,8 +50,7 @@ function parseJsonBlob(canonicalId: string, recipeJson: string): RecipeReference
   try {
     const recipeData = JSON.parse(recipeJson) as Record<string, unknown>
     if (!recipeData.id) {
-      console.error(`Recipe from ${canonicalId} has no ID field. Content was:`);
-      console.error(recipeJson);
+      console.error(`Recipe from ${canonicalId} has no ID field. Content was: ${recipeJson}`);
       return null //TODO: we should incorporate a metric for failed recipes so we can have an indication of upstream issues.
     } else {
       return <RecipeReferenceWithoutChecksum>{

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -10,8 +10,8 @@ export function extractAllRecipesFromArticle(content: Content): RecipeReferenceW
   if (content.type == ContentType.ARTICLE && content.blocks) {
     const articleBlocks: Blocks = content.blocks
     const getAllMainBlockRecipesIfPresent: RecipeReferenceWithoutChecksum[] = extractRecipeData(content.id, articleBlocks.main)
-    const bodyBlocks = articleBlocks.body as Block[]
-    const getAllBodyBlocksRecipesIfPresent: RecipeReferenceWithoutChecksum[] = bodyBlocks.flatMap(bodyBlock => extractRecipeData(content.id, bodyBlock))
+    const bodyBlocks = articleBlocks.body
+    const getAllBodyBlocksRecipesIfPresent: RecipeReferenceWithoutChecksum[] = bodyBlocks? bodyBlocks.flatMap(bodyBlock => extractRecipeData(content.id, bodyBlock)) : [];
     return getAllMainBlockRecipesIfPresent.concat(getAllBodyBlocksRecipesIfPresent)
   } else {
     return Array<RecipeReferenceWithoutChecksum>()

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -18,6 +18,9 @@ export function extractAllRecipesFromArticle(content: Content): RecipeReferenceW
 }
 
 export function extractRecipeData(canonicalId: string, block: Block): RecipeReferenceWithoutChecksum[] {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- real life disagrees with the typings here. No elements => block.elements undefined.
+  if(!block.elements) return [];
+
   return block.elements
     .filter(elem => elem.type === ElementType.RECIPE)
     .map(recp => parseJsonBlob(canonicalId, recp.recipeTypeData?.recipeJson as string))

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -1,10 +1,10 @@
+import {createHash} from "crypto";
 import type {Block} from "@guardian/content-api-models/v1/block";
 import type {Blocks} from "@guardian/content-api-models/v1/blocks";
 import type {Content} from "@guardian/content-api-models/v1/content";
 import {ContentType} from "@guardian/content-api-models/v1/contentType";
 import {ElementType} from "@guardian/content-api-models/v1/elementType";
 import type {RecipeReferenceWithoutChecksum} from './models';
-import {createHash} from "crypto";
 
 export function extractAllRecipesFromArticle(content: Content): RecipeReferenceWithoutChecksum[] {
   if (content.type == ContentType.ARTICLE && content.blocks) {

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -8,7 +8,7 @@ import type {RecipeReferenceWithoutChecksum} from './models';
 export function extractAllRecipesFromArticle(content: Content): RecipeReferenceWithoutChecksum[] {
   if (content.type == ContentType.ARTICLE && content.blocks) {
     const articleBlocks: Blocks = content.blocks
-    const getAllMainBlockRecipesIfPresent: RecipeReferenceWithoutChecksum[] = extractRecipeData(content.id, articleBlocks.main as Block)
+    const getAllMainBlockRecipesIfPresent: RecipeReferenceWithoutChecksum[] = extractRecipeData(content.id, articleBlocks.main)
     const bodyBlocks = articleBlocks.body as Block[]
     const getAllBodyBlocksRecipesIfPresent: RecipeReferenceWithoutChecksum[] = bodyBlocks.flatMap(bodyBlock => extractRecipeData(content.id, bodyBlock))
     return getAllMainBlockRecipesIfPresent.concat(getAllBodyBlocksRecipesIfPresent)
@@ -17,9 +17,8 @@ export function extractAllRecipesFromArticle(content: Content): RecipeReferenceW
   }
 }
 
-export function extractRecipeData(canonicalId: string, block: Block): RecipeReferenceWithoutChecksum[] {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- real life disagrees with the typings here. No elements => block.elements undefined.
-  if(!block.elements) return [];
+export function extractRecipeData(canonicalId: string, block?: Block): RecipeReferenceWithoutChecksum[] {
+  if(! block?.elements) return [];
 
   return block.elements
     .filter(elem => elem.type === ElementType.RECIPE)

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -4,6 +4,7 @@ import type {Content} from "@guardian/content-api-models/v1/content";
 import {ContentType} from "@guardian/content-api-models/v1/contentType";
 import {ElementType} from "@guardian/content-api-models/v1/elementType";
 import type {RecipeReferenceWithoutChecksum} from './models';
+import {createHash} from "crypto";
 
 export function extractAllRecipesFromArticle(content: Content): RecipeReferenceWithoutChecksum[] {
   if (content.type == ContentType.ARTICLE && content.blocks) {
@@ -26,13 +27,32 @@ export function extractRecipeData(canonicalId: string, block?: Block): RecipeRef
     .filter(recp => !!recp) as RecipeReferenceWithoutChecksum[]
 }
 
+/**
+ * Most recipes have a UUID-style `id` field, so we pass that through.
+ * However some of the ones that were extracted by D&I have a numeric field still.
+ * In that case, we concatenate the canonical ID onto the numeric value and then sha1 the lot.
+ * @param contentIdField
+ * @param canonicalId
+ */
+function determineRecipeUID(contentIdField:string, canonicalId: string): string
+{
+  if(contentIdField.match(/^\d+$/)) {
+    const hasher = createHash("sha1");
+    //do the same as https://github.com/guardian/flexible-content/blob/6e963d9027d02a4f3af4637dbe6498934d904a4f/flexible-content-integration/src/main/scala/com/gu/flexiblecontent/integration/dispatcher/RecipesImportDispatcher.scala#L213
+    const stringToHash = `${contentIdField}-${canonicalId}`;
+    return hasher.update(stringToHash).digest("hex");
+  } else {
+    return contentIdField;
+  }
+}
+
 function parseJsonBlob(canonicalId: string, recipeJson: string): RecipeReferenceWithoutChecksum | null {
   const recipeData = JSON.parse(recipeJson) as Record<string, unknown>
   if (!recipeData.id) {
     return null //TODO: we should incorporate a metric for failed recipes so we can have an indication of upstream issues.
   } else {
     return <RecipeReferenceWithoutChecksum>{
-      recipeUID: `${recipeData.id as string}`,
+      recipeUID: determineRecipeUID(recipeData.id as string, canonicalId),
       jsonBlob: recipeJson
     }
   }

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -47,13 +47,22 @@ function determineRecipeUID(contentIdField:string, canonicalId: string): string
 }
 
 function parseJsonBlob(canonicalId: string, recipeJson: string): RecipeReferenceWithoutChecksum | null {
-  const recipeData = JSON.parse(recipeJson) as Record<string, unknown>
-  if (!recipeData.id) {
-    return null //TODO: we should incorporate a metric for failed recipes so we can have an indication of upstream issues.
-  } else {
-    return <RecipeReferenceWithoutChecksum>{
-      recipeUID: determineRecipeUID(recipeData.id as string, canonicalId),
-      jsonBlob: recipeJson
+  try {
+    const recipeData = JSON.parse(recipeJson) as Record<string, unknown>
+    if (!recipeData.id) {
+      console.error(`Recipe from ${canonicalId} has no ID field. Content was:`);
+      console.error(recipeJson);
+      return null //TODO: we should incorporate a metric for failed recipes so we can have an indication of upstream issues.
+    } else {
+      return <RecipeReferenceWithoutChecksum>{
+        recipeUID: determineRecipeUID(recipeData.id as string, canonicalId),
+        jsonBlob: recipeJson
+      }
     }
+  } catch(err) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/restrict-template-expressions -- err.toString() is untyped but OK
+    console.error(`Recipe from ${canonicalId} was not parsable: ${err.toString()}`);
+    console.error(`Content was ${recipeJson}`);
+    return null;
   }
 }

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -31,18 +31,19 @@ export function extractRecipeData(canonicalId: string, block?: Block): RecipeRef
  * Most recipes have a UUID-style `id` field, so we pass that through.
  * However some of the ones that were extracted by D&I have a numeric field still.
  * In that case, we concatenate the canonical ID onto the numeric value and then sha1 the lot.
- * @param contentIdField
- * @param canonicalId
+ * @param recipeIdField incoming ID of the recipe
+ * @param canonicalId canonical ID of the article
+ * @returns a useful unique ID for the recipe
  */
-function determineRecipeUID(contentIdField:string, canonicalId: string): string
+function determineRecipeUID(recipeIdField:string, canonicalId: string): string
 {
-  if(contentIdField.match(/^\d+$/)) {
+  if(recipeIdField.match(/^\d+$/)) {
     const hasher = createHash("sha1");
     //do the same as https://github.com/guardian/flexible-content/blob/6e963d9027d02a4f3af4637dbe6498934d904a4f/flexible-content-integration/src/main/scala/com/gu/flexiblecontent/integration/dispatcher/RecipesImportDispatcher.scala#L213
-    const stringToHash = `${contentIdField}-${canonicalId}`;
+    const stringToHash = `${recipeIdField}-${canonicalId}`;
     return hasher.update(stringToHash).digest("hex");
   } else {
-    return contentIdField;
+    return recipeIdField;
   }
 }
 

--- a/lib/recipes-data/src/lib/s3.test.ts
+++ b/lib/recipes-data/src/lib/s3.test.ts
@@ -45,7 +45,7 @@ describe("s3.publishRecipeContent", ()=>{
     const uploadArgs = s3Mock.call(0).firstArg as PutObjectCommand;
     expect(uploadArgs.input.Body).toEqual("this-is-json");
     expect(uploadArgs.input.Key).toEqual(`content/xxxyyyzzz`);
-    expect(uploadArgs.input.ChecksumSHA256).toEqual("xxxyyyzzz");
+    //expect(uploadArgs.input.ChecksumSHA256).toEqual("xxxyyyzzz");
     expect(uploadArgs.input.Bucket).toEqual("contentbucket");
     expect(s3Mock.commandCalls(DeleteObjectCommand).length).toEqual(0);
     //@ts-ignore -- Typescript doesn't know that this is a mock

--- a/lib/recipes-data/src/lib/s3.test.ts
+++ b/lib/recipes-data/src/lib/s3.test.ts
@@ -45,7 +45,6 @@ describe("s3.publishRecipeContent", ()=>{
     const uploadArgs = s3Mock.call(0).firstArg as PutObjectCommand;
     expect(uploadArgs.input.Body).toEqual("this-is-json");
     expect(uploadArgs.input.Key).toEqual(`content/xxxyyyzzz`);
-    //expect(uploadArgs.input.ChecksumSHA256).toEqual("xxxyyyzzz");
     expect(uploadArgs.input.Bucket).toEqual("contentbucket");
     expect(s3Mock.commandCalls(DeleteObjectCommand).length).toEqual(0);
     //@ts-ignore -- Typescript doesn't know that this is a mock

--- a/lib/recipes-data/src/lib/s3.ts
+++ b/lib/recipes-data/src/lib/s3.ts
@@ -41,7 +41,7 @@ export async function publishRecipeContent(recipe: RecipeReference, attempt?: nu
     Key,
     Body: recipe.jsonBlob,
     ContentType: "application/json",
-    //ChecksumSHA256: recipe.checksum,
+    //ChecksumSHA256: recipe.checksum,  //This is commented out because the format is wrong. Left here because we want to fix it but not hold up PR approval.
     CacheControl: DefaultCacheControlParams,
   });
 
@@ -69,7 +69,7 @@ export async function removeRecipeContent(recipeSHA: string, purgeType?:"soft"|"
   const realAttempt = attempt ?? 1;
 
   const Key = `content/${recipeSHA}`;
-  console.debug(`DEBUG: removeRecipeContent path is s3://${Bucket}/${Key}`);
+  console.debug(`DEBUG: removeRecipeContent path is s3://${Bucket ?? "(no bucket)"}/${Key}`);
 
   const req = new DeleteObjectCommand({
     Bucket,

--- a/lib/recipes-data/src/lib/s3.ts
+++ b/lib/recipes-data/src/lib/s3.ts
@@ -1,8 +1,8 @@
 import * as process from "process";
 import {DeleteObjectCommand, NoSuchKey, PutObjectCommand, S3Client, S3ServiceException} from "@aws-sdk/client-s3";
 import {StaticBucketName as Bucket, FastlyApiKey, MaximumRetries} from "./config";
-import {sendFastlyPurgeRequestWithRetries} from "./fastly";
-import type { RecipeReference ,RecipeIndex} from './models';
+import {sendFastlyPurgeRequest, sendFastlyPurgeRequestWithRetries} from "./fastly";
+import type { RecipeIndex ,RecipeReference} from './models';
 import {awaitableDelay} from "./utils";
 
 const s3Client = new S3Client({region: process.env["AWS_REGION"]});
@@ -116,5 +116,7 @@ export async function writeIndexData(indexData:RecipeIndex)
   });
 
   await s3Client.send(req);
-  console.log("Done.")
+  console.log("Done. Purging CDN...");
+  await sendFastlyPurgeRequest("index.json", FastlyApiKey ?? "");
+  console.log("Done.");
 }

--- a/lib/recipes-data/src/lib/s3.ts
+++ b/lib/recipes-data/src/lib/s3.ts
@@ -69,7 +69,7 @@ export async function removeRecipeContent(recipeSHA: string, purgeType?:"soft"|"
   const realAttempt = attempt ?? 1;
 
   const Key = `content/${recipeSHA}`;
-  console.debug(`DEBUG: removeRecipeContent path is s3://${Bucket ?? "(no bucket)"}/${Key}`);
+  console.debug(`DEBUG: removeRecipeContent path is s3://${Bucket}/${Key}`);
 
   const req = new DeleteObjectCommand({
     Bucket,

--- a/lib/recipes-data/src/lib/s3.ts
+++ b/lib/recipes-data/src/lib/s3.ts
@@ -41,7 +41,7 @@ export async function publishRecipeContent(recipe: RecipeReference, attempt?: nu
     Key,
     Body: recipe.jsonBlob,
     ContentType: "application/json",
-    ChecksumSHA256: recipe.checksum,
+    //ChecksumSHA256: recipe.checksum,
     CacheControl: DefaultCacheControlParams,
   });
 

--- a/lib/recipes-data/src/lib/s3.ts
+++ b/lib/recipes-data/src/lib/s3.ts
@@ -2,11 +2,21 @@ import * as process from "process";
 import {DeleteObjectCommand, NoSuchKey, PutObjectCommand, S3Client, S3ServiceException} from "@aws-sdk/client-s3";
 import {StaticBucketName as Bucket, FastlyApiKey, MaximumRetries} from "./config";
 import {sendFastlyPurgeRequestWithRetries} from "./fastly";
-import type { RecipeReference } from './models';
+import type { RecipeReference ,RecipeIndex} from './models';
 import {awaitableDelay} from "./utils";
 
 const s3Client = new S3Client({region: process.env["AWS_REGION"]});
 
+const DefaultCacheControlParams = makeCacheControl();
+
+function makeCacheControl(maxAge?: number, staleRevalidate?: number, staleError?: number):string
+{
+  return [
+    `max-age=${maxAge ?? 31557600}`,
+    `stale-while-revalidate=${staleRevalidate ?? 60}`,
+    `stale-if-error=${staleError ?? 300}`
+  ].join("; ");
+}
 
 /**
  * Publishes the given recipe data into the output bucket.
@@ -32,7 +42,7 @@ export async function publishRecipeContent(recipe: RecipeReference, attempt?: nu
     Body: recipe.jsonBlob,
     ContentType: "application/json",
     ChecksumSHA256: recipe.checksum,
-    CacheControl: "max-age=31557600; stale-while-revalidate=60; stale-if-error=300"
+    CacheControl: DefaultCacheControlParams,
   });
 
   try {
@@ -85,4 +95,26 @@ export async function removeRecipeContent(recipeSHA: string, purgeType?:"soft"|"
       throw err;
     }
   }
+}
+
+/**
+ * Writes the built index data out to S3
+ * @param indexData built indexdata object. Get this from `retrieveIndexData`
+ */
+export async function writeIndexData(indexData:RecipeIndex)
+{
+  console.log("Marshalling data...");
+  const formattedData = JSON.stringify(indexData);
+
+  console.log("Done. Writing to S3...");
+  const req = new PutObjectCommand({
+    Bucket,
+    Key: "index.json",
+    Body: formattedData,
+    ContentType: "application/json",
+    CacheControl: makeCacheControl(3600), //cache for up to 60mins
+  });
+
+  await s3Client.send(req);
+  console.log("Done.")
 }

--- a/lib/recipes-data/src/lib/takedown.test.ts
+++ b/lib/recipes-data/src/lib/takedown.test.ts
@@ -120,7 +120,7 @@ describe("takedown.recipesToTakeDown", ()=>{
       },
     ];
 
-    const fakeUpdateIds:string[] = ["number1","number3","number4"];
+    const fakeUpdateIds:string[] = ["vers938","vers346","vers432"];
 
     // @ts-ignore -- Typescript doesn't know that this is a mock
     recipesforArticle.mockReturnValue(Promise.resolve(fakeDbContent));
@@ -155,7 +155,7 @@ describe("takedown.recipesToTakeDown", ()=>{
       },
     ];
 
-    const fakeUpdateIds:string[] = ["number1","number3","number4"];
+    const fakeUpdateIds:string[] = ["vers938","vers346","vers432"];
 
     // @ts-ignore -- Typescript doesn't know that this is a mock
     recipesforArticle.mockReturnValue(Promise.resolve(fakeDbContent));

--- a/lib/recipes-data/src/lib/takedown.test.ts
+++ b/lib/recipes-data/src/lib/takedown.test.ts
@@ -6,7 +6,6 @@ import {removeRecipeContent} from "./s3";
 import {recipesToTakeDown, removeAllRecipesForArticle, removeRecipePermanently, removeRecipeVersion} from './takedown';
 
 mockClient(DynamoDBClient);
-const ddbClient = new DynamoDBClient(); //this is a mock object due to `mockClient` above
 
 jest.mock("./s3", ()=>({
   removeRecipeContent: jest.fn(),
@@ -28,38 +27,38 @@ describe("takedown", ()=>{
   });
 
   it("removeRecipePermanently should delete the given recipe from the index and from the content bucket", async ()=>{
-    await removeRecipePermanently(ddbClient, "path/to/some/article", {recipeUID: "some-uid", checksum: "xxxyyyzzz"});
+    await removeRecipePermanently("path/to/some/article", {recipeUID: "some-uid", checksum: "xxxyyyzzz"});
 
     //@ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipe.mock.calls.length).toEqual(1);
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipe.mock.calls[0][1]).toEqual("path/to/some/article");
+    expect(removeRecipe.mock.calls[0][0]).toEqual("path/to/some/article");
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipe.mock.calls[0][2]).toEqual("some-uid");
+    expect(removeRecipe.mock.calls[0][1]).toEqual("some-uid");
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipe.mock.calls[0][3]).toBeUndefined();
+    expect(removeRecipe.mock.calls[0][2]).toBeUndefined();
     //@ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipeContent.mock.calls.length).toEqual(1);
 
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipe.mock.calls[0][1]).toEqual("path/to/some/article");
+    expect(removeRecipe.mock.calls[0][0]).toEqual("path/to/some/article");
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipe.mock.calls[0][2]).toEqual("some-uid");
+    expect(removeRecipe.mock.calls[0][1]).toEqual("some-uid");
     //@ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipeContent.mock.calls[0][0]).toEqual("xxxyyyzzz");
   });
 
   it("removeRecipeVersion should delete the given recipe from the content bucket but not the index", async ()=>{
-    await removeRecipeVersion(ddbClient, "path/to/some/article", {recipeUID: "some-uid", checksum: "xxxyyyzzz"});
+    await removeRecipeVersion("path/to/some/article", {recipeUID: "some-uid", checksum: "xxxyyyzzz"});
 
     //@ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipe.mock.calls.length).toEqual(1);
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipe.mock.calls[0][1]).toEqual("path/to/some/article");
+    expect(removeRecipe.mock.calls[0][0]).toEqual("path/to/some/article");
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipe.mock.calls[0][2]).toEqual("some-uid");
+    expect(removeRecipe.mock.calls[0][1]).toEqual("some-uid");
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipe.mock.calls[0][3]).toEqual("xxxyyyzzz");
+    expect(removeRecipe.mock.calls[0][2]).toEqual("xxxyyyzzz");
 
     //@ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipeContent.mock.calls.length).toEqual(1);
@@ -87,20 +86,20 @@ describe("takedown", ()=>{
     //@ts-ignore -- Typescript doesn't know that this is a mock
     removeAllRecipeIndexEntriesForArticle.mockReturnValue(Promise.resolve(knownArticles));
 
-    await removeAllRecipesForArticle(ddbClient, "path/to/some/article");
+    await removeAllRecipesForArticle("path/to/some/article");
 
     //@ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeAllRecipeIndexEntriesForArticle.mock.calls.length).toEqual(1);
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeAllRecipeIndexEntriesForArticle.mock.calls[0][1]).toEqual("path/to/some/article");
+    expect(removeAllRecipeIndexEntriesForArticle.mock.calls[0][0]).toEqual("path/to/some/article");
     //@ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipeContent.mock.calls.length).toEqual(3);
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipeContent.mock.calls[0]).toEqual(["abcd", "soft"]);
+    expect(removeRecipeContent.mock.calls[0]).toEqual(["abcd", "hard"]);
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipeContent.mock.calls[1]).toEqual(["efg", "soft"]);
+    expect(removeRecipeContent.mock.calls[1]).toEqual(["efg", "hard"]);
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipeContent.mock.calls[2]).toEqual(["hij", "soft"]);
+    expect(removeRecipeContent.mock.calls[2]).toEqual(["hij", "hard"]);
   });
 });
 
@@ -138,7 +137,7 @@ describe("takedown.recipesToTakeDown", ()=>{
     // @ts-ignore -- Typescript doesn't know that this is a mock
     recipesforArticle.mockReturnValue(Promise.resolve(fakeDbContent));
 
-    const result = await recipesToTakeDown(ddbClient, "some-article-id", fakeUpdateIds);
+    const result = await recipesToTakeDown("some-article-id", fakeUpdateIds);
     expect(result).toEqual([
       {checksum: "vers963", recipeUID:"number2"},
       {checksum: "vers9789", recipeUID: "number5"}
@@ -147,9 +146,7 @@ describe("takedown.recipesToTakeDown", ()=>{
     //@ts-ignore -- Typescript doesn't know that this is a mock
     expect(recipesforArticle.mock.calls.length).toEqual(1);
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(recipesforArticle.mock.calls[0][0]).toEqual(ddbClient);
-    //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(recipesforArticle.mock.calls[0][1]).toEqual("some-article-id");
+    expect(recipesforArticle.mock.calls[0][0]).toEqual("some-article-id");
   });
 
   it("should return an empty list if there is nothing to take down", async ()=>{
@@ -173,15 +170,13 @@ describe("takedown.recipesToTakeDown", ()=>{
     // @ts-ignore -- Typescript doesn't know that this is a mock
     recipesforArticle.mockReturnValue(Promise.resolve(fakeDbContent));
 
-    const result = await recipesToTakeDown(ddbClient, "some-article-id", fakeUpdateIds);
+    const result = await recipesToTakeDown("some-article-id", fakeUpdateIds);
     expect(result).toEqual([]);
 
     //@ts-ignore -- Typescript doesn't know that this is a mock
     expect(recipesforArticle.mock.calls.length).toEqual(1);
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(recipesforArticle.mock.calls[0][0]).toEqual(ddbClient);
-    //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(recipesforArticle.mock.calls[0][1]).toEqual("some-article-id");
+    expect(recipesforArticle.mock.calls[0][0]).toEqual("some-article-id");
   });
 
   it("should return an empty list if both input and current state are empty", async ()=>{
@@ -192,14 +187,12 @@ describe("takedown.recipesToTakeDown", ()=>{
     // @ts-ignore -- Typescript doesn't know that this is a mock
     recipesforArticle.mockReturnValue(Promise.resolve(fakeDbContent));
 
-    const result = await recipesToTakeDown(ddbClient, "some-article-id", fakeUpdateIds);
+    const result = await recipesToTakeDown("some-article-id", fakeUpdateIds);
     expect(result).toEqual([]);
 
     //@ts-ignore -- Typescript doesn't know that this is a mock
     expect(recipesforArticle.mock.calls.length).toEqual(1);
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(recipesforArticle.mock.calls[0][0]).toEqual(ddbClient);
-    //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(recipesforArticle.mock.calls[0][1]).toEqual("some-article-id");
+    expect(recipesforArticle.mock.calls[0][0]).toEqual("some-article-id");
   });
 })

--- a/lib/recipes-data/src/lib/takedown.test.ts
+++ b/lib/recipes-data/src/lib/takedown.test.ts
@@ -33,6 +33,12 @@ describe("takedown", ()=>{
     //@ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipe.mock.calls.length).toEqual(1);
     //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(removeRecipe.mock.calls[0][1]).toEqual("path/to/some/article");
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(removeRecipe.mock.calls[0][2]).toEqual("some-uid");
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(removeRecipe.mock.calls[0][3]).toBeUndefined();
+    //@ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipeContent.mock.calls.length).toEqual(1);
 
     //@ts-ignore -- Typescript doesn't know that this is a mock
@@ -47,7 +53,14 @@ describe("takedown", ()=>{
     await removeRecipeVersion(ddbClient, "path/to/some/article", {recipeUID: "some-uid", checksum: "xxxyyyzzz"});
 
     //@ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipe.mock.calls.length).toEqual(0);
+    expect(removeRecipe.mock.calls.length).toEqual(1);
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(removeRecipe.mock.calls[0][1]).toEqual("path/to/some/article");
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(removeRecipe.mock.calls[0][2]).toEqual("some-uid");
+    //@ts-ignore -- Typescript doesn't know that this is a mock
+    expect(removeRecipe.mock.calls[0][3]).toEqual("xxxyyyzzz");
+
     //@ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipeContent.mock.calls.length).toEqual(1);
 

--- a/lib/recipes-data/src/lib/takedown.ts
+++ b/lib/recipes-data/src/lib/takedown.ts
@@ -40,11 +40,12 @@ export async function removeRecipeVersion(client: DynamoDBClient, canonicalArtic
   return takeRecipeDown(client, canonicalArticleId, recipe, false);
 }
 
-export async function removeAllRecipesForArticle(client: DynamoDBClient, canonicalArticleId: string): Promise<void>
+export async function removeAllRecipesForArticle(client: DynamoDBClient, canonicalArticleId: string): Promise<number>
 {
   const removedEntries = await removeAllRecipeIndexEntriesForArticle(client, canonicalArticleId);
   console.log(`Taken down article ${canonicalArticleId} had ${removedEntries.length} recipes in it which will also be removed`);
   await Promise.all(removedEntries.map(recep=>removeRecipeContent(recep.checksum, "soft")));
+  return removedEntries.length;
 }
 
 /**

--- a/lib/recipes-data/src/lib/takedown.ts
+++ b/lib/recipes-data/src/lib/takedown.ts
@@ -35,6 +35,8 @@ export async function removeRecipePermanently(client: DynamoDBClient, canonicalA
  */
 export async function removeRecipeVersion(client: DynamoDBClient, canonicalArticleId: string, recipe: RecipeIndexEntry)
 {
+  //FIXME this is wrong wrong wrong! We should still remove from database, but with a conditional delete that
+  //will not remove if the version ID has already changed.
   return takeRecipeDown(client, canonicalArticleId, recipe, false);
 }
 

--- a/lib/recipes-data/src/lib/takedown.ts
+++ b/lib/recipes-data/src/lib/takedown.ts
@@ -16,10 +16,10 @@ enum TakedownMode {
  * @param mode Takedown mode. If `TakedownMode.AllVersions`, then any occurence of the content's uid is removed.
  * If `TakedownMode.SpecificVersion`, then the recipe is only removed if its checksum matches the one given in `recipe`
  */
-async function takeRecipeDown(client: DynamoDBClient, canonicalArticleId: string, recipe: RecipeIndexEntry, mode:TakedownMode):Promise<void>
+async function takeRecipeDown(canonicalArticleId: string, recipe: RecipeIndexEntry, mode:TakedownMode):Promise<void>
 {
   console.log(`takeRecipeDown: removing recipe ${recipe.recipeUID} for ${canonicalArticleId} from the index`);
-  await removeRecipe(client, canonicalArticleId, recipe.recipeUID, mode==TakedownMode.AllVersions ? undefined : recipe.checksum);
+  await removeRecipe(canonicalArticleId, recipe.recipeUID, mode==TakedownMode.AllVersions ? undefined : recipe.checksum);
 
   console.log(`takeRecipeDown: removing content version ${recipe.checksum} for ${recipe.recipeUID} on ${canonicalArticleId} from the store`);
   await removeRecipeContent(recipe.checksum);
@@ -33,9 +33,9 @@ async function takeRecipeDown(client: DynamoDBClient, canonicalArticleId: string
  * @param canonicalArticleId
  * @param recipe
  */
-export async function removeRecipePermanently(client: DynamoDBClient, canonicalArticleId: string, recipe: RecipeIndexEntry)
+export async function removeRecipePermanently(canonicalArticleId: string, recipe: RecipeIndexEntry)
 {
-  return takeRecipeDown(client, canonicalArticleId, recipe, TakedownMode.AllVersions);
+  return takeRecipeDown(canonicalArticleId, recipe, TakedownMode.AllVersions);
 }
 
 /**
@@ -45,14 +45,14 @@ export async function removeRecipePermanently(client: DynamoDBClient, canonicalA
  * @param canonicalArticleId
  * @param recipe
  */
-export async function removeRecipeVersion(client: DynamoDBClient, canonicalArticleId: string, recipe: RecipeIndexEntry)
+export async function removeRecipeVersion(canonicalArticleId: string, recipe: RecipeIndexEntry)
 {
-  return takeRecipeDown(client, canonicalArticleId, recipe, TakedownMode.SpecificVersion);
+  return takeRecipeDown(canonicalArticleId, recipe, TakedownMode.SpecificVersion);
 }
 
-export async function removeAllRecipesForArticle(client: DynamoDBClient, canonicalArticleId: string): Promise<number>
+export async function removeAllRecipesForArticle(canonicalArticleId: string): Promise<number>
 {
-  const removedEntries = await removeAllRecipeIndexEntriesForArticle(client, canonicalArticleId);
+  const removedEntries = await removeAllRecipeIndexEntriesForArticle(canonicalArticleId);
   console.log(`Taken down article ${canonicalArticleId} had ${removedEntries.length} recipes in it which will also be removed`);
   await Promise.all(removedEntries.map(recep=>removeRecipeContent(recep.checksum, "hard")));
   return removedEntries.length;
@@ -66,10 +66,10 @@ export async function removeAllRecipesForArticle(client: DynamoDBClient, canonic
  * @param recipeChecksumsToKeep list of the "new" recipes that are in the update (and should therefore be kept)
  * @return list of the recipes that were present in the current version but not in the update. These should be taken down.
  */
-export async function recipesToTakeDown(dynamoClient:DynamoDBClient, canonicalArticleId:string, recipeChecksumsToKeep: string[]):Promise<RecipeIndexEntry[]>
+export async function recipesToTakeDown(canonicalArticleId:string, recipeChecksumsToKeep: string[]):Promise<RecipeIndexEntry[]>
 {
   const toKeepSet = new Set(recipeChecksumsToKeep);
-  const currentSet = await recipesforArticle(dynamoClient, canonicalArticleId);
+  const currentSet = await recipesforArticle(canonicalArticleId);
 
   //ES6 does not give us a Set.difference method, unfortunately. So we have to do it here.
   return currentSet.filter(rec=>!toKeepSet.has(rec.checksum));

--- a/lib/recipes-data/src/lib/takedown.ts
+++ b/lib/recipes-data/src/lib/takedown.ts
@@ -53,14 +53,14 @@ export async function removeAllRecipesForArticle(client: DynamoDBClient, canonic
  * currently present.  If we are missing any of the "current" recipes then these should be taken down.
  * @param dynamoClient DynamoDB client so we can query the index database
  * @param canonicalArticleId ID of the article that's being updated
- * @param recipeIdsToKeep list of the "new" recipes that are in the update (and should therefore be kept)
+ * @param recipeChecksumsToKeep list of the "new" recipes that are in the update (and should therefore be kept)
  * @return list of the recipes that were present in the current version but not in the update. These should be taken down.
  */
-export async function recipesToTakeDown(dynamoClient:DynamoDBClient, canonicalArticleId:string, recipeIdsToKeep: string[]):Promise<RecipeIndexEntry[]>
+export async function recipesToTakeDown(dynamoClient:DynamoDBClient, canonicalArticleId:string, recipeChecksumsToKeep: string[]):Promise<RecipeIndexEntry[]>
 {
-  const toKeepSet = new Set(recipeIdsToKeep);
+  const toKeepSet = new Set(recipeChecksumsToKeep);
   const currentSet = await recipesforArticle(dynamoClient, canonicalArticleId);
 
   //ES6 does not give us a Set.difference method, unfortunately. So we have to do it here.
-  return currentSet.filter(rec=>!toKeepSet.has(rec.recipeUID));
+  return currentSet.filter(rec=>!toKeepSet.has(rec.checksum));
 }

--- a/lib/recipes-data/src/lib/utils.test.ts
+++ b/lib/recipes-data/src/lib/utils.test.ts
@@ -1,5 +1,9 @@
+import type { RecipeReferenceWithoutChecksum } from './models';
 import {calculateChecksum} from "./utils";
-import {RecipeReference, RecipeReferenceWithoutChecksum} from "@recipes-api/lib/recipes-data";
+
+jest.mock("./config", ()=>({
+
+}));
 
 describe("calculateChecksum", ()=>{
   it("should checksum the content into base64", ()=>{

--- a/lib/recipes-data/src/lib/utils.ts
+++ b/lib/recipes-data/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import {createHash} from "crypto";
 import type {CapiDateTime} from "@guardian/content-api-models/v1/capiDateTime";
 import {parseISO} from "date-fns";
-import Int64 from "node-int64"; 
+import Int64 from "node-int64";
 import {RetryDelaySeconds} from "./config";
 import type {RecipeReference, RecipeReferenceWithoutChecksum} from './models';
 

--- a/lib/recipes-data/src/lib/utils.ts
+++ b/lib/recipes-data/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import {createHash} from "crypto";
 import type {CapiDateTime} from "@guardian/content-api-models/v1/capiDateTime";
 import {parseISO} from "date-fns";
-import Int64 from "node-int64"; //Changes done in tsconfig.json as well to run this package and also made "makeCapiDateTime" as default export
+import Int64 from "node-int64"; 
 import {RetryDelaySeconds} from "./config";
 import type {RecipeReference, RecipeReferenceWithoutChecksum} from './models';
 
@@ -21,7 +21,7 @@ export function calculateChecksum(src: RecipeReferenceWithoutChecksum): RecipeRe
   return {...src, checksum,};
 }
 
-function makeCapiDateTime(from: string): CapiDateTime {
+export function makeCapiDateTime(from: string): CapiDateTime {
   const date = parseISO(from);
   const int64Format = new Int64(date.getTime());
   return {
@@ -30,6 +30,10 @@ function makeCapiDateTime(from: string): CapiDateTime {
   }
 }
 
-export {makeCapiDateTime}
-
+/**
+ * Returns new Date().  Why? So we can mock it out easily in testing.
+ */
+export function nowTime():Date {
+  return new Date();
+}
 

--- a/tools/manual-takedown/.eslintrc.json
+++ b/tools/manual-takedown/.eslintrc.json
@@ -13,7 +13,7 @@
       ],
       "parserOptions": {
         "project": [
-          "tools/db-test-stuff/tsconfig.app.json"
+          "tools/manual-takedown/tsconfig.app.json"
         ]
       },
       "rules": {}
@@ -25,7 +25,7 @@
       ],
       "parserOptions": {
         "project": [
-          "tools/db-test-stuff/tsconfig.spec.json"
+          "tools/manual-takedown/tsconfig.spec.json"
         ]
       },
       "rules": {}

--- a/tools/manual-takedown/project.json
+++ b/tools/manual-takedown/project.json
@@ -11,12 +11,13 @@
 			"options": {
 				"platform": "node",
 				"outputPath": "dist/tools/manual-takedown",
-				"format": ["esm"],
+				"format": ["cjs"],
 				"bundle": true,
 				"main": "tools/manual-takedown/src/main.ts",
 				"tsConfig": "tools/manual-takedown/tsconfig.app.json",
 				"assets": ["tools/manual-takedown/src/assets"],
 				"generatePackageJson": true,
+        "thirdParty": true,
 				"esbuildOptions": {
 					"sourcemap": true,
 					"outExtension": {
@@ -29,6 +30,7 @@
 				"production": {
 					"esbuildOptions": {
 						"sourcemap": false,
+            "minify": true,
 						"outExtension": {
 							".js": ".js"
 						}

--- a/tools/manual-takedown/src/main.ts
+++ b/tools/manual-takedown/src/main.ts
@@ -4,12 +4,18 @@ import {removeAllRecipesForArticle} from "@recipes-api/lib/recipes-data";
 
 const dynamoClient = new DynamoDBClient();
 
+function checkArgs(args:string[]) {
+  args.forEach(arg=>{
+    if(!process.env[arg]) {
+      console.error(`You must specify ${arg} as an environment variable`);
+      process.exit(2);
+    }
+  })
+}
+
 async function main() {
-  const articleId = process.env["ARTICLE_ID"];
-  if(!articleId || articleId=="") {
-    console.error("You must specify an article ID as a commandline argument");
-    process.exit(2);
-  }
+  checkArgs(["ARTICLE_ID","INDEX_TABLE","STATIC_BUCKET","CONTENT_URL_BASE"]);
+  const articleId = process.env["ARTICLE_ID"] as string;  //checkArgs ensures that this is valid
 
   console.log("Attempting takedown on ", articleId);
   await removeAllRecipesForArticle(dynamoClient, articleId);

--- a/tools/manual-takedown/src/main.ts
+++ b/tools/manual-takedown/src/main.ts
@@ -18,7 +18,7 @@ async function main() {
   const articleId = process.env["ARTICLE_ID"] as string;  //checkArgs ensures that this is valid
 
   console.log("Attempting takedown on ", articleId);
-  await removeAllRecipesForArticle(dynamoClient, articleId);
+  await removeAllRecipesForArticle(articleId);
 }
 
 main().then(()=>process.exit(0)).catch(err=>{


### PR DESCRIPTION
## What does this change?

Implements https://trello.com/c/msTNa5WY.

With this, the first version of the content pipeline is complete!

### Content update

- extract recipes from article (#12 )
- find recipes to remove/update
- takedown superceded recipes
- upload new versions
- update the index if we've made any content changes

### Content update (retrievable)

- mostly already implemented in #9 
- adding tests, separating from the content-update handler to make the test mocking easier

### Content delete

- already implemented in #11 

## How to test

1. Take a snapshot of the current index state: `curl https://recipes.code.dev-guardianapis.com/index.json | jq > before.json`
2. Go into Composer CODE and create a new article with a recipe in it.  Alternatively, edit the recipe blob of an existing one.
3. Launch your changes
4. Wait for it to propagate.... 60s should be more than enough.  If you're curious, open the Content Platforms space in Central ELK; go to Discover; then open the saved search "Recipe responder"
5. The index should be updated by now.  Take a snapshot of the updated index: `curl https://recipes.code.dev-guardianapis.com/index.json | jq > after.json`
6. Run `diff -u after.json before.json`
7. You should see the timestamp in the index.json has moved and at least one recipe blob has changed.  If you don't, then reload a couple of times more - there are a couple of levels of CDN for it to get through.
8. Retrieve your recipe content from `https://recipes.code.dev-guardianapis.com/content/{checksum-value}`
9. Delete the recipe from your article
10. Re-launch
11. Repeat steps 4-7.  The content should now be gone.
12. Add a recipe again
13. Re-launch
14. Verify it's present in the index
15. Take down the article
16. Repeat steps 4-7.  The content should now be gone. 

## How can we measure success?

Basecamp are able to consume recipes published from Composer

