### PR TITLE
Add CW runtime alarm

### DIFF
--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -51,12 +51,53 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       "Default": "/TEST/content-api/recipes-responder/capi-key",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "externalscrierindexstreamParameter23A8B068": {
+      "Default": "/TEST/content-api/crier/index-stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "externalsnonurgentalarmarnParameter3CDDBCA7": {
+      "Default": "/account/content-api-common/alarms/non-urgent-alarm-topic",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "externalsurgentalarmarnParameterCE71CB92": {
+      "Default": "/account/content-api-common/alarms/urgent-alarm-topic",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "fastlyKey": {
       "Default": "/TEST/content-api/recipes-responder/fastly-key",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
   "Resources": {
+    "DurationRuntimeAlarmC21C10E0": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Ref": "externalsnonurgentalarmarnParameter3CDDBCA7",
+          },
+        ],
+        "AlarmDescription": "Notify when the lambda exceeds 75%",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "updaterLambdaE2EB52D9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 3,
+        "MetricName": "Duration",
+        "Namespace": "AWS/Lambda",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 22500,
+        "TreatMissingData": "ignore",
+        "Unit": "Milliseconds",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "LambdaD247545B": {
       "DependsOn": [
         "LambdaServiceRoleDefaultPolicyDAE46E21",

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -51,10 +51,6 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       "Default": "/TEST/content-api/recipes-responder/capi-key",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "externalscrierindexstreamParameter23A8B068": {
-      "Default": "/TEST/content-api/crier/index-stream",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
     "externalsnonurgentalarmarnParameter3CDDBCA7": {
       "Default": "/account/content-api-common/alarms/non-urgent-alarm-topic",
       "Type": "AWS::SSM::Parameter::Value<String>",
@@ -77,7 +73,7 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
             "Ref": "externalsnonurgentalarmarnParameter3CDDBCA7",
           },
         ],
-        "AlarmDescription": "Notify when the lambda exceeds 75%",
+        "AlarmDescription": "Recipe backend ingest lambda at 75% of allowed duration",
         "ComparisonOperator": "GreaterThanThreshold",
         "Dimensions": [
           {
@@ -90,8 +86,8 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
         "EvaluationPeriods": 3,
         "MetricName": "Duration",
         "Namespace": "AWS/Lambda",
-        "Period": 60,
-        "Statistic": "Average",
+        "Period": 180,
+        "Statistic": "Maximum",
         "Threshold": 22500,
         "TreatMissingData": "ignore",
         "Unit": "Milliseconds",
@@ -1056,7 +1052,7 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
             "Value": "TEST",
           },
         ],
-        "Timeout": 60,
+        "Timeout": 30,
       },
       "Type": "AWS::Lambda::Function",
     },

--- a/cdk/lib/alarms.ts
+++ b/cdk/lib/alarms.ts
@@ -1,0 +1,3 @@
+/*
+TODO : need to check whether to refactor and write seperate file if more alarms needed?
+ */

--- a/cdk/lib/alarms.ts
+++ b/cdk/lib/alarms.ts
@@ -1,3 +1,0 @@
-/*
-TODO : need to check whether to refactor and write seperate file if more alarms needed?
- */

--- a/cdk/lib/external_parameters.ts
+++ b/cdk/lib/external_parameters.ts
@@ -14,17 +14,11 @@ import {Construct} from "constructs";
 export class ExternalParameters extends Construct {
   urgentAlarmTopicArn: IStringParameter;
   nonUrgentAlarmTopicArn: IStringParameter;
-  crierIndexStream: IStringParameter;
 
   constructor(scope: GuStack, id: string) {
     super(scope, id);
 
     this.urgentAlarmTopicArn = aws_ssm.StringParameter.fromStringParameterName(this, "urgent-alarm-arn", "/account/content-api-common/alarms/urgent-alarm-topic");
     this.nonUrgentAlarmTopicArn = aws_ssm.StringParameter.fromStringParameterName(this, "non-urgent-alarm-arn", "/account/content-api-common/alarms/non-urgent-alarm-topic");
-    const crierStack = scope.stack.endsWith("preview") ? "content-api-preview" : "content-api";
-    /**
-     * crierIndexStream is expected to be set in SSM by Crier
-     */
-    this.crierIndexStream = aws_ssm.StringParameter.fromStringParameterName(this, "crier-index-stream", `/${scope.stage}/${crierStack}/crier/index-stream`);
   }
 }

--- a/cdk/lib/external_parameters.ts
+++ b/cdk/lib/external_parameters.ts
@@ -1,0 +1,30 @@
+import type {GuStack} from "@guardian/cdk/lib/constructs/core";
+import {aws_ssm} from "aws-cdk-lib";
+import type {IStringParameter} from "aws-cdk-lib/aws-ssm";
+import {Construct} from "constructs";
+
+/**
+ * ExternalParameters encapsulates values that are not specific to this stack, i.e. are set by other stacks or
+ * are properties of the account setup itself.
+ *
+ * The CDK formulation here actually creates a Cloudformation parameter, whose default value is then obtained from
+ * SSM _at deploy time_.  Therefore, the values that are used for these will be that of the SSM parameter value at the
+ * time of deployment rather than the time at which the stack was built.
+ */
+export class ExternalParameters extends Construct {
+  urgentAlarmTopicArn: IStringParameter;
+  nonUrgentAlarmTopicArn: IStringParameter;
+  crierIndexStream: IStringParameter;
+
+  constructor(scope: GuStack, id: string) {
+    super(scope, id);
+
+    this.urgentAlarmTopicArn = aws_ssm.StringParameter.fromStringParameterName(this, "urgent-alarm-arn", "/account/content-api-common/alarms/urgent-alarm-topic");
+    this.nonUrgentAlarmTopicArn = aws_ssm.StringParameter.fromStringParameterName(this, "non-urgent-alarm-arn", "/account/content-api-common/alarms/non-urgent-alarm-topic");
+    const crierStack = scope.stack.endsWith("preview") ? "content-api-preview" : "content-api";
+    /**
+     * crierIndexStream is expected to be set in SSM by Crier
+     */
+    this.crierIndexStream = aws_ssm.StringParameter.fromStringParameterName(this, "crier-index-stream", `/${scope.stage}/${crierStack}/crier/index-stream`);
+  }
+}

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -3,11 +3,14 @@ import {GuParameter, GuStack} from "@guardian/cdk/lib/constructs/core";
 import {GuLambdaFunction} from "@guardian/cdk/lib/constructs/lambda";
 import {GuKinesisLambdaExperimental} from "@guardian/cdk/lib/experimental/patterns";
 import {StreamRetry} from "@guardian/cdk/lib/utils/lambda";
-import {type App, Duration} from "aws-cdk-lib";
+import {type App, aws_sns, Duration} from "aws-cdk-lib";
+import {Alarm, ComparisonOperator, TreatMissingData, Unit} from "aws-cdk-lib/aws-cloudwatch";
+import {SnsAction} from "aws-cdk-lib/aws-cloudwatch-actions";
 import {Effect, PolicyStatement} from "aws-cdk-lib/aws-iam";
 import {Architecture, Runtime} from "aws-cdk-lib/aws-lambda";
 import {DataStore} from "./datastore";
 import {RestEndpoints} from "./rest-endpoints";
+import {ExternalParameters} from "./external_parameters";
 import {StaticServing} from "./static-serving";
 
 export class RecipesBackend extends GuStack {
@@ -64,7 +67,7 @@ export class RecipesBackend extends GuStack {
 
     const contentUrlBase = this.stage === "CODE" ? "recipes.code.dev-guardianapis.com" : "recipes.guardianapis.com";
 
-    new GuKinesisLambdaExperimental(this, "updaterLambda", {
+    const updaterLambda = new GuKinesisLambdaExperimental(this, "updaterLambda", {
       monitoringConfiguration: {noMonitoring: true},
       existingKinesisStream: {
         externalKinesisStreamName: `content-api-firehose-v2-${this.stage}`,
@@ -111,5 +114,25 @@ export class RecipesBackend extends GuStack {
       fastlyKey: fastlyKeyParam.valueAsString,
       contentUrlBase,
     });
+
+    const durationAlarm = new Alarm(this, "DurationRuntimeAlarm", {
+      alarmDescription: "Notify when the lambda exceeds 75%",
+      actionsEnabled: true,
+      threshold: 22500, //in milliseconds which means 22.5 seconds (which is 75% near to 30 seconds timout of lambda)
+      treatMissingData: TreatMissingData.IGNORE,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      metric: updaterLambda.metricDuration({
+        period: Duration.minutes(1),
+        statistic: "Average",
+        unit: Unit.MILLISECONDS// "percent" as we are tyring to use 75 "%" to check against threshold, TODO: Need to check this if it should be Unit.milliseconds to see time wise?
+      }),
+      evaluationPeriods: 3,// when happens atleast 3 times
+    })
+
+    const externalParameters = new ExternalParameters(this, "externals");
+    const urgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "urgent-alarm", externalParameters.urgentAlarmTopicArn.stringValue);
+    //const nonUrgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "nonurgent-alarm", externalParameters.nonUrgentAlarmTopicArn.stringValue);
+    durationAlarm.addAlarmAction(new SnsAction(urgentAlarmTopic))
   }
+
 }

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -131,8 +131,8 @@ export class RecipesBackend extends GuStack {
 
     const externalParameters = new ExternalParameters(this, "externals");
     const urgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "urgent-alarm", externalParameters.urgentAlarmTopicArn.stringValue);
-    //const nonUrgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "nonurgent-alarm", externalParameters.nonUrgentAlarmTopicArn.stringValue);
-    durationAlarm.addAlarmAction(new SnsAction(urgentAlarmTopic))
+    const nonUrgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "nonurgent-alarm", externalParameters.nonUrgentAlarmTopicArn.stringValue);
+    durationAlarm.addAlarmAction(new SnsAction(nonUrgentAlarmTopic))
   }
 
 }

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -130,7 +130,7 @@ export class RecipesBackend extends GuStack {
     })
 
     const externalParameters = new ExternalParameters(this, "externals");
-    const urgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "urgent-alarm", externalParameters.urgentAlarmTopicArn.stringValue);
+    //const urgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "urgent-alarm", externalParameters.urgentAlarmTopicArn.stringValue);
     const nonUrgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "nonurgent-alarm", externalParameters.nonUrgentAlarmTopicArn.stringValue);
     durationAlarm.addAlarmAction(new SnsAction(nonUrgentAlarmTopic))
   }

--- a/lambda/recipes-responder/src/main.ts
+++ b/lambda/recipes-responder/src/main.ts
@@ -4,7 +4,6 @@ import type {KinesisStreamHandler, KinesisStreamRecord} from "aws-lambda";
 import {registerMetric} from "@recipes-api/cwmetrics";
 import {deserializeEvent} from "@recipes-api/lib/capi";
 import {retrieveIndexData, writeIndexData} from "@recipes-api/lib/recipes-data";
-import {sendFastlyPurgeRequest} from "../../../lib/recipes-data/src/lib/fastly";
 import {handleDeletedContent, handleTakedown} from "./takedown_processor";
 import {handleContentUpdate} from "./update_processor";
 import {handleContentUpdateRetrievable} from "./update_retrievable_processor";
@@ -54,12 +53,12 @@ export const handler: KinesisStreamHandler = async (event) => {
   const updatesTotal = updatesPerEvent.reduce((acc, current) => acc + current, 0);
   if (updatesTotal > 0) {
     console.log(`Processed updates for ${updatesTotal} recipes, rebuilding the index json`);
-    await registerMetric("UpdatesTotalOfRecipes", updatesTotal)
+    await registerMetric("UpdatesTotalOfArticle", updatesTotal)
     const indexData = await retrieveIndexData();
     await writeIndexData(indexData);
     console.log("Finished rebuilding index");
   } else {
     console.log("No updates to recipes, so not touching index");
-    await registerMetric("UpdatesTotalOfRecipes", 0)
+    await registerMetric("UpdatesTotalOfArticle", 0)
   }
 }

--- a/lib/cwmetrics/src/lib/cloudwatch.ts
+++ b/lib/cwmetrics/src/lib/cloudwatch.ts
@@ -3,7 +3,7 @@ import {CloudWatchClient, PutMetricDataCommand, StandardUnit} from "@aws-sdk/cli
 
 const cwClient = new CloudWatchClient({region: process.env["AWS_REGION"]});
 
-export type KnownMetric = "FailedRecipes" | "SuccessfulRecipes" | "UpdatesTotalOfRecipes";
+export type KnownMetric = "FailedRecipes" | "SuccessfulRecipes" | "UpdatesTotalOfArticle";
 
 export async function registerMetric(metricName: KnownMetric, value: number) {
   const req = new PutMetricDataCommand({

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -16,7 +16,8 @@ export async function extractAllRecipesFromArticle(content: Content): Promise<Re
     const recipes = getAllMainBlockRecipesIfPresent.concat(getAllBodyBlocksRecipesIfPresent)
     const failureCount = recipes.filter(recp => !recp).length
     await registerMetric("FailedRecipes", failureCount)
-    await registerMetric("SuccessfulRecipes", recipes.length)
+    const successfulCount = recipes.length - failureCount
+    await registerMetric("SuccessfulRecipes", successfulCount)
     return recipes.filter(recp => !!recp) as RecipeReferenceWithoutChecksum[]
   } else {
     return Array<RecipeReferenceWithoutChecksum>()


### PR DESCRIPTION
## What does this change?

Alarm to get notification if `recipe-responder` lambda runs more than threshold limit. we taking 75% near to its lambdatimeout as threshold at the moment.

ref:https://trello.com/c/GlPWaSrz/2469-metrics-for-recipes-publisher

(related to PR #16: will be close to avoid any uncertainty due to occurrence of several commits after rebase with `main` )

## How to test

Deploy on CODE

In AWS Content-API account, Cloudwatch -> All alarms -> Search "duration" 

## How can we measure success?

We should be able to see DurationAlarm listed (with word `CODE-recipes-backed`)
