### PR TITLE
Populate contributors or byline

### DIFF
--- a/lambda/recipes-responder/src/update_processor.test.ts
+++ b/lambda/recipes-responder/src/update_processor.test.ts
@@ -45,9 +45,9 @@ describe("update_processor.handleContentUpdate", ()=>{
 
   it("should extract recipes from the content, publish those and take-down any that were no longer needed", async ()=>{
     const refsInArticle:RecipeReferenceWithoutChecksum[] = [
-      { recipeUID: "uid-recep-1", jsonBlob: ""},
-      { recipeUID: "uid-recep-2", jsonBlob: ""},
-      { recipeUID: "uid-recep-3", jsonBlob: ""},
+      { recipeUID: "uid-recep-1", jsonData: {}},
+      { recipeUID: "uid-recep-2", jsonData: {}},
+      { recipeUID: "uid-recep-3", jsonData: {}},
     ];
 
     const refsToRemove:RecipeIndexEntry[] = [
@@ -114,9 +114,9 @@ describe("update_processor.handleContentUpdate", ()=>{
 
   it("should ignore a piece of content that is not an article", async ()=>{
     const refsInArticle:RecipeReferenceWithoutChecksum[] = [
-      { recipeUID: "uid-recep-1", jsonBlob: ""},
-      { recipeUID: "uid-recep-2", jsonBlob: ""},
-      { recipeUID: "uid-recep-3", jsonBlob: ""},
+      { recipeUID: "uid-recep-1", jsonData: {}},
+      { recipeUID: "uid-recep-2", jsonData: {}},
+      { recipeUID: "uid-recep-3", jsonData: {}},
     ];
 
     const refsToRemove:RecipeIndexEntry[] = [

--- a/lib/recipes-data/src/lib/extract-recipes.test.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.test.ts
@@ -92,7 +92,8 @@ describe("extractRecipeData", () => {
     const result = extractRecipeData(canonicalId, block)
     expect(result.length).toEqual(1)
     expect(result[0]?.recipeUID).toEqual("62ac3f0f98f6495cbefd72c11fac6d1e26390e99")
-    expect(result[0]?.jsonBlob).toEqual(block.elements[1].recipeTypeData?.recipeJson)
+    const expectedData = block.elements[1].recipeTypeData?.recipeJson ? JSON.parse(block.elements[1].recipeTypeData.recipeJson) as Record<string, unknown> : {};
+    expect(result[0]?.jsonData).toEqual(expectedData)
   })
 
   it("should work when block containing multiple recipe elements", () => {
@@ -195,8 +196,9 @@ describe("extractRecipeData", () => {
     }
     const result = extractRecipeData(canonicalId, block)
     expect(result.length).toEqual(3)
-    expect(result[2]?.recipeUID).toEqual("ffe7319af2c4a1b209e0c4a44f8acf7d7c3d88c4")
-    expect(result[2]?.jsonBlob).toEqual(block.elements[3].recipeTypeData?.recipeJson)
+    expect(result[2]?.recipeUID).toEqual("ffe7319af2c4a1b209e0c4a44f8acf7d7c3d88c4");
+    const expectedData = block.elements[3].recipeTypeData?.recipeJson ? JSON.parse(block.elements[3].recipeTypeData.recipeJson) as Record<string, unknown> : {};
+    expect(result[2]?.jsonData).toEqual(expectedData);
   })
 
   it("should work when block containing no recipe elements ", () => {

--- a/lib/recipes-data/src/lib/models.ts
+++ b/lib/recipes-data/src/lib/models.ts
@@ -48,14 +48,15 @@ interface RecipeIndex {
  */
 interface RecipeReferenceWithoutChecksum {
   recipeUID: string;
-  jsonBlob: string;
+  jsonData: Record<string, unknown>;
 }
 
 /**
  * RecipeReference has all three main constituents for a recipe - the immutable ID, the version ID and the json content
  */
-interface RecipeReference extends RecipeReferenceWithoutChecksum{
+interface RecipeReference extends Omit<RecipeReferenceWithoutChecksum, "jsonData">{
   checksum: string;
+  jsonBlob: string;
 }
 
 /**

--- a/lib/recipes-data/src/lib/models.ts
+++ b/lib/recipes-data/src/lib/models.ts
@@ -2,6 +2,18 @@ import type { AttributeValue } from "@aws-sdk/client-dynamodb";
 import {formatISO, parseISO} from "date-fns";
 
 /**
+ * This is a proposed schema update that should come into effect in Jan '24 for a more structured
+ * representation in the `contributors` array
+ */
+export type ContributorChef = {
+  type: "text";
+  text: string;
+} | {
+  type: "tag";
+  tagId: string;
+}
+
+/**
  * RecipeDatabaseKey contains the fields necessary to uniquely identify a recipe in the index
  */
 interface RecipeDatabaseKey {

--- a/lib/recipes-data/src/lib/recipe_fields_updater.test.ts
+++ b/lib/recipes-data/src/lib/recipe_fields_updater.test.ts
@@ -1,5 +1,5 @@
 import type {Content} from "@guardian/content-api-models/v1/content";
-import {updateContributors} from "./recipe_fields_updater";
+import {updateByline, updateContributors} from "./recipe_fields_updater";
 
 describe("recipe_fields_updater.updateContributors", () => {
   it("should update the `contributors` array in the recipe from the article data", ()=>{
@@ -42,3 +42,65 @@ describe("recipe_fields_updater.updateContributors", () => {
     expect(result.contributors).toEqual(['profile/uyen-luu','profile/giorgiolocatelli','profile/meera-sodha','profile/jose-pizarro','profile/jane-baxter']);
   })
 });
+
+describe("recipe_fields_updater.updateByline", ()=>{
+  it("should take the content byline if there is no byline nor contributors array", ()=>{
+    // @ts-ignore
+    const partialArticle:Content = {
+      fields: {
+        bylineHtml: '<a href="https://www.booktrust.org.uk/book/b/barry-the-fish-with-fingers-and-the-hairy-scary-monster/">Barry</a>, Norman, Keith and NoBot',
+        byline: 'Barry, Norman, Keith and NoBot'
+      }
+    }
+
+    const result = updateByline(partialArticle, {
+
+    });
+    expect(result.byline).toEqual("Barry, Norman, Keith and NoBot");
+  });
+
+  it("should ignore the content byline if there is already a byline", ()=>{
+    // @ts-ignore
+    const partialArticle:Content = {
+      fields: {
+        bylineHtml: '<a href="https://www.booktrust.org.uk/book/b/barry-the-fish-with-fingers-and-the-hairy-scary-monster/">Barry</a>, Norman, Keith and NoBot',
+        byline: 'Barry, Norman, Keith and NoBot'
+      }
+    }
+
+    const result = updateByline(partialArticle, {
+      byline: 'NoBot, the robot with no bottom'
+    });
+    expect(result.byline).toEqual("NoBot, the robot with no bottom");
+  });
+
+  it("should ignore the content byline if there is a populated contributors array", ()=>{
+    // @ts-ignore
+    const partialArticle:Content = {
+      fields: {
+        bylineHtml: '<a href="https://www.booktrust.org.uk/book/b/barry-the-fish-with-fingers-and-the-hairy-scary-monster/">Barry</a>, Norman, Keith and NoBot',
+        byline: 'Barry, Norman, Keith and NoBot'
+      }
+    }
+
+    const result = updateByline(partialArticle, {
+      contributors: ["https://booksforbugs.co.uk/product/norman-the-slug-with-the-silly-shell/"]
+    });
+    expect(result.byline).toBeUndefined();
+  });
+
+  it("should take the content byline if there is an un-populated contributors array", ()=>{
+    // @ts-ignore
+    const partialArticle:Content = {
+      fields: {
+        bylineHtml: '<a href="https://www.booktrust.org.uk/book/b/barry-the-fish-with-fingers-and-the-hairy-scary-monster/">Barry</a>, Norman, Keith and NoBot',
+        byline: 'Barry, Norman, Keith and NoBot'
+      }
+    }
+
+    const result = updateByline(partialArticle, {
+      contributors: [" "]
+    });
+    expect(result.byline).toEqual('Barry, Norman, Keith and NoBot');
+  });
+})

--- a/lib/recipes-data/src/lib/recipe_fields_updater.test.ts
+++ b/lib/recipes-data/src/lib/recipe_fields_updater.test.ts
@@ -1,0 +1,44 @@
+import type {Content} from "@guardian/content-api-models/v1/content";
+import {updateContributors} from "./recipe_fields_updater";
+
+describe("recipe_fields_updater.updateContributors", () => {
+  it("should update the `contributors` array in the recipe from the article data", ()=>{
+    // @ts-ignore
+    const partialArticle:Content = {
+      fields: {
+        bylineHtml: '<a href="profile/uyen-luu">Uyen Luu</a>, <a href="profile/giorgiolocatelli">Giorgio Locatelli</a>, <a href="profile/meera-sodha">Meera Sodha</a>, <a href="profile/jose-pizarro">José Pizarro</a>, <a href="profile/jane-baxter">Jane Baxter</a>',
+      }
+    };
+
+    const result = updateContributors(partialArticle, {});
+    expect(result.contributors).toEqual(['profile/uyen-luu','profile/giorgiolocatelli','profile/meera-sodha','profile/jose-pizarro','profile/jane-baxter']);
+  })
+
+  it("should not touch 'contributors' if there is already data", ()=>{
+    // @ts-ignore
+    const partialArticle:Content = {
+      fields: {
+        bylineHtml: '<a href="profile/uyen-luu">Uyen Luu</a>, <a href="profile/giorgiolocatelli">Giorgio Locatelli</a>, <a href="profile/meera-sodha">Meera Sodha</a>, <a href="profile/jose-pizarro">José Pizarro</a>, <a href="profile/jane-baxter">Jane Baxter</a>',
+      }
+    };
+
+    const result = updateContributors(partialArticle, {
+      contributors: ["profile/xyz"]
+    });
+    expect(result.contributors).toEqual(["profile/xyz"])
+  })
+
+  it("should overwrite the `contributors` array if it only has empty entries", ()=>{
+    // @ts-ignore
+    const partialArticle:Content = {
+      fields: {
+        bylineHtml: '<a href="profile/uyen-luu">Uyen Luu</a>, <a href="profile/giorgiolocatelli">Giorgio Locatelli</a>, <a href="profile/meera-sodha">Meera Sodha</a>, <a href="profile/jose-pizarro">José Pizarro</a>, <a href="profile/jane-baxter">Jane Baxter</a>',
+      }
+    };
+
+    const result = updateContributors(partialArticle, {
+      contributors: [" "]
+    });
+    expect(result.contributors).toEqual(['profile/uyen-luu','profile/giorgiolocatelli','profile/meera-sodha','profile/jose-pizarro','profile/jane-baxter']);
+  })
+});

--- a/lib/recipes-data/src/lib/recipe_fields_updater.ts
+++ b/lib/recipes-data/src/lib/recipe_fields_updater.ts
@@ -1,0 +1,77 @@
+import type {Content} from "@guardian/content-api-models/v1/content";
+import type { RecipeReferenceWithoutChecksum } from './models';
+
+type ParsedRecipe = Record<string, unknown>;
+type FieldsUpdaterFunction = (article:Content, recipe:ParsedRecipe) => ParsedRecipe;
+const isEmptyRegex = /^\s*$/;  //"empty" can mean zero-length or consisting entirely of whitespace
+
+/**
+ * Internal function that is called from updateRecipeFields; only exported for tests. Don't use directly.
+ */
+const updateByline:FieldsUpdaterFunction = (article, recipe)=> {
+  const existingByline = recipe["byline"] as (string[]|string|undefined);
+
+  if(!existingByline    //is it null?
+    || (Array.isArray(existingByline) && existingByline.filter(str=>!str.match(isEmptyRegex)).length==0)  //or an array consisting of zero or only empty strings?
+    || (typeof existingByline==="string" && existingByline.match(isEmptyRegex))  //or an empty string?
+  ) {
+    return {
+      ...recipe,
+      byline: article.fields?.byline ?? ""
+    }
+  } else {
+    return recipe
+  }
+}
+
+function grokBylineHtml(bylineHtml:string):string[]
+{
+  const searcher = /href="([\w/-]+)"/g;
+  const matches = Array.from(bylineHtml.matchAll(searcher));
+  const profileTags = matches.map(arr=>{
+    try {
+      return arr[1]
+    } catch(err) {
+      return null
+    }
+  }).filter(t=>!!t);
+  return profileTags as string[];
+}
+
+/**
+ * Internal function that is called from updateRecipeFields; only exported for tests. Don't use directly.
+ */
+export const updateContributors:FieldsUpdaterFunction = (article, recipe) => {
+  const existingContribs = recipe["contributors"] as string[]|undefined;
+
+  if(!existingContribs || existingContribs.filter(str=>!str.match(isEmptyRegex)).length==0) {
+    //the contributors list is either not defined or empty or contains only whitespace strings
+    return {
+      ...recipe,
+      contributors: article.fields?.bylineHtml ? grokBylineHtml(article.fields.bylineHtml) : [],
+    }
+  } else {
+    return recipe
+  }
+}
+
+/**
+ * There are some fields which are optional in Composer and whose values should be filled in from the article meta-data
+ * during publication.
+ * Call this function to check the fields and populate them if necessary
+ * @param article entire article Content containing the meta-data
+ * @param recipe recipe to inject the data into
+ */
+export function updateRecipeFields(article:Content, recipe: RecipeReferenceWithoutChecksum):RecipeReferenceWithoutChecksum {
+  const updaterChain:FieldsUpdaterFunction[] = [
+    updateByline,
+    updateContributors
+  ];
+
+  const updated = updaterChain.reduce((currentRecipe, updater)=>updater(article, currentRecipe), recipe.jsonData);
+
+  return {
+    ...recipe,
+    jsonData: updated,
+  }
+}

--- a/lib/recipes-data/src/lib/recipe_fields_updater.ts
+++ b/lib/recipes-data/src/lib/recipe_fields_updater.ts
@@ -24,6 +24,10 @@ const updateByline:FieldsUpdaterFunction = (article, recipe)=> {
   }
 }
 
+/**
+ * Internal function to extract out the profile links from the byline html
+ * @param bylineHtml
+ */
 function grokBylineHtml(bylineHtml:string):string[]
 {
   const searcher = /href="([\w/-]+)"/g;

--- a/lib/recipes-data/src/lib/utils.test.ts
+++ b/lib/recipes-data/src/lib/utils.test.ts
@@ -9,11 +9,11 @@ describe("calculateChecksum", ()=>{
   it("should checksum the content into base64", ()=>{
     const input:RecipeReferenceWithoutChecksum = {
       recipeUID: "blahblah",
-      jsonBlob: "foodisgoodwatchitburn"
+      jsonData: {msg: "foodisgoodwatchitburn"}
     };
     const result = calculateChecksum(input);
     expect(result.recipeUID).toEqual(input.recipeUID);
-    expect(result.jsonBlob).toEqual(input.jsonBlob);
-    expect(result.checksum).toEqual("6rIHocBjte3q9jPnLtzQhtFsDabFUKQGVk3VMuorRB8")
+    expect(result.jsonBlob).toEqual('{"msg":"foodisgoodwatchitburn"}');
+    expect(result.checksum).toEqual("6ev4GHjOZEoa3L-iznZI64gFJozVpwBYjmFsAVEE4UY")
   })
 });

--- a/lib/recipes-data/src/lib/utils.ts
+++ b/lib/recipes-data/src/lib/utils.ts
@@ -15,10 +15,11 @@ export async function awaitableDelay(): Promise<void> {
 
 export function calculateChecksum(src: RecipeReferenceWithoutChecksum): RecipeReference {
   const hasher = createHash('sha256');
-  hasher.update(src.jsonBlob);
+  const jsonBlob = JSON.stringify(src.jsonData);
+  hasher.update(jsonBlob);
   const checksum = hasher.digest("base64url");  //base64 encoding should be more byte-efficient
 
-  return {...src, checksum,};
+  return {...src, checksum, jsonBlob};
 }
 
 export function makeCapiDateTime(from: string): CapiDateTime {

--- a/lib/recipes-data/src/lib/utils.ts
+++ b/lib/recipes-data/src/lib/utils.ts
@@ -19,7 +19,11 @@ export function calculateChecksum(src: RecipeReferenceWithoutChecksum): RecipeRe
   hasher.update(jsonBlob);
   const checksum = hasher.digest("base64url");  //base64 encoding should be more byte-efficient
 
-  return {...src, checksum, jsonBlob};
+  return {
+    recipeUID: src.recipeUID,
+    checksum,
+    jsonBlob
+  };
 }
 
 export function makeCapiDateTime(from: string): CapiDateTime {


### PR DESCRIPTION
## What does this change?

We have discussed how to apply "sensible defaults" for contributor lists, both in the pipeline team and with the app developers.

The conclusion is that these fields will be optional coming out of Composer, and if they are null/blank at reception in the recipe backend they will be filled in there. (ref: https://trello.com/c/6wZib7MB)

This PR builds that feature.

- We now (potentially) need to update recipe content.  So, instead of a parse-and-throwaway that we did before it's necessary to hold the whole parsed content while we update and then take a checksum afterwards.  `RecipeReferenceWithoutChecksum` has been updated to accomodate this; when the checksum is calculated, the parsed data is stringified.
- a new library function is created, `updateRecipeFields`, which defines a list of "filter functions" to be applied, in order, to the recipe data.
- filter functions are then provided for both updating the contributors array and byline field.


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

