### PR TITLE
Regionalise curation

### DIFF
--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -230,7 +230,7 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
                         "Arn",
                       ],
                     },
-                    "/curation.json",
+                    "/*/*/curation.json",
                   ],
                 ],
               },

--- a/cdk/lib/rest-endpoints.ts
+++ b/cdk/lib/rest-endpoints.ts
@@ -50,7 +50,7 @@ export class RestEndpoints extends Construct {
       initialPolicy: [new PolicyStatement({
         effect: Effect.ALLOW,
         actions: ["s3:PutObject"],
-        resources: [`${servingBucket.bucketArn}/curation.json`]
+        resources: [`${servingBucket.bucketArn}/*/*/curation.json`]
       })]
     });
 

--- a/lib/recipes-data/src/index.ts
+++ b/lib/recipes-data/src/index.ts
@@ -4,4 +4,5 @@ export * from './lib/takedown';
 export * from './lib/s3';
 export * from './lib/extract-recipes';
 
+export {sendFastlyPurgeRequestWithRetries} from './lib/fastly';
 export {awaitableDelay, calculateChecksum, makeCapiDateTime} from './lib/utils';


### PR DESCRIPTION
## What does this change?

- The URL for both pulling and pushing curation data has changed:
  - from `POST /api/curation` to `POST /api/curation/:region/:variant`
  - from `GET /curation.json` to `GET /:region/:variant/curation.json`

This is in response to a request from the frontend team to be able to serve different curation for different markets.
The `:region` and `:variant` parameters are deliberately left free; the only stipulation is that they must be "word" characters (i.e. alphanumeric, but no punctutation)

## How to test

- Deploy to CODE
- Making a POST to `/api/curation` will now return 404
- Making a POST to the new endpoint will return 200
- Your new data can be retrieved by using the new GET endpoint
- `GET /curation.json` should continue to return the old data (this will be manually removed once the frontend team give the go-ahead)

@guardian-ben 

## How can we measure success?

Able to serve regionalised curation

## Have we considered potential risks?

The free-text nature of the parameters is not ideal, but not really open to abuse as "special" characters are denied.  Spamming the endpoint can be dealt with easily from an admin perspective by cancelling the API key and removing the excess data
