### PR TITLE
Update to actions-riff-raff@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build on PR
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
   workflow_dispatch: {}
 
 jobs:
@@ -27,14 +27,14 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
-#      - run: npm run lint
+      #      - run: npm run lint
       - run: npm test
       - run: npm run build
 
       - uses: guardian/actions-riff-raff@v4
         with:
           projectName: Content Platforms::recipes-backend
-          configPath: "cdk/cdk.out/riff-raff.yaml"
+          configPath: 'cdk/cdk.out/riff-raff.yaml'
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           contentDirectories: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,15 +31,12 @@ jobs:
       - run: npm test
       - run: npm run build
 
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-
-      - uses: guardian/actions-riff-raff@v2
+      - uses: guardian/actions-riff-raff@v4
         with:
           projectName: Content Platforms::recipes-backend
           configPath: "cdk/cdk.out/riff-raff.yaml"
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           contentDirectories: |
             cdk.out:
               - cdk/cdk.out/RecipesBackend-euwest-1-CODE.template.json


### PR DESCRIPTION
Saw a recent email from DevX about upgrading, figured I’d do it quickly. Version 4 means we can get rid of the AWS credentials step and leaves us less vulnerable to credentials access by malicious dependencies

See [the release notes for version 4](https://github.com/guardian/actions-riff-raff/releases/tag/v4) and [those for version 3](https://github.com/guardian/actions-riff-raff/releases/tag/v3.0.0) (the latter necessary because we’re coming from version 2.)

(Have also committed auto-formatting done by my editor, hope that’s ok)