### PR TITLE
Version bucket

### DIFF
--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -904,6 +904,9 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
             "Value": "TEST",
           },
         ],
+        "VersioningConfiguration": {
+          "Status": "Enabled",
+        },
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",

--- a/cdk/lib/static-serving.ts
+++ b/cdk/lib/static-serving.ts
@@ -18,6 +18,7 @@ export class StaticServing extends Construct {
       bucketName: `recipes-backend${maybePreview}-static-${scope.stage.toLowerCase()}`,
       enforceSSL: true,
       removalPolicy: RemovalPolicy.DESTROY,
+      versioned: true
     });
 
     const cdnReadUser = new User(this, "cdnRead", {


### PR DESCRIPTION
## What does this change?

Versions our recipe bucket, to permit the possibility of recovering data if updates to recipes go wrong. May not need it.

## How to test

Ronseal.