### PR TITLE
Re-indexing tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
+environ-*
+
 # compiled output
 dist
 tmp

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ caches flushed.
 
 You will need to force an update on the app to actually see the changes.
 
+You _can_ run with `--all` to republish _every single article in the system_.  But be careful; 
+- **one** the index is only regenerated at the end, so it must complete or the index may point to recipe versions that don't exist any more
+- **two** if material content updates are made to all recipes that could be a large update for the clients to handle.
+
+## How do I republish only the index JSON?
+
+If you suspect that the index JSON has got out of sync somehow (of _course_, that could never happen!) then you can re-generate it by running:
+`npm run commandline-reindex -- --index-only`
+
 ## How do I manually force a takedown?
 
 1. Set up for local operations, as above

--- a/get-local-config.sh
+++ b/get-local-config.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+if [ "$STAGE" == "" ]; then
+  STAGE=CODE
+fi
+
+STACK_NAME=$(aws cloudformation describe-stacks --query 'Stacks[?Tags[?Key == `App` && Value == `recipes-backend`] && Tags[?Key == `Stage` && Value == `'$STAGE'`]].{StackName: StackName}' --output text)
+
+if [ "$STACK_NAME" == "" ]; then
+  echo No stack was found, check you have the right permissions and are looking at the right region. Looking for App=recipes-backend and Stage=${STAGE}
+  exit 1
+fi
+
+echo Found stack "$STACK_NAME"
+
+LAMBDA_FUNCTION=$(aws cloudformation describe-stack-resources --stack-name content-api-CODE-recipes-backend --query 'StackResources[?ResourceType == `AWS::Lambda::Function` && starts_with(LogicalResourceId, `updater`)]' | jq -r '.[].PhysicalResourceId')
+
+if [ "$LAMBDA_FUNCTION" == "" ]; then
+  echo Could not find updater lambda in the stack definition.  These are the lambdas available:
+  aws cloudformation describe-stack-resources --stack-name content-api-CODE-recipes-backend --query 'StackResources[?ResourceType == `AWS::Lambda::Function`]'
+  exit 2
+fi
+
+echo Found lambda function "$LAMBDA_FUNCTION". Outputting environment...
+aws lambda get-function --function-name content-api-CODE-recipes-bac-updaterLambdaE2EB52D9-96E3fkPw4vbx --query 'Configuration.Environment.Variables' | perl -n -e'/\"([\w_]+)\": \"(.+)\"/ && print "export $1=$2\n"' | grep -v TELEMETRY > "environ-${STAGE}"
+
+echo You can now run \`source environ-${STAGE}\` to get hold of the environment configuration for $STAGE

--- a/get-local-config.sh
+++ b/get-local-config.sh
@@ -13,7 +13,7 @@ fi
 
 echo Found stack "$STACK_NAME"
 
-LAMBDA_FUNCTION=$(aws cloudformation describe-stack-resources --stack-name content-api-CODE-recipes-backend --query 'StackResources[?ResourceType == `AWS::Lambda::Function` && starts_with(LogicalResourceId, `updater`)]' | jq -r '.[].PhysicalResourceId')
+LAMBDA_FUNCTION=$(aws cloudformation describe-stack-resources --stack-name $STACK_NAME --query 'StackResources[?ResourceType == `AWS::Lambda::Function` && starts_with(LogicalResourceId, `updater`)]' | jq -r '.[].PhysicalResourceId')
 
 if [ "$LAMBDA_FUNCTION" == "" ]; then
   echo Could not find updater lambda in the stack definition.  These are the lambdas available:
@@ -22,6 +22,6 @@ if [ "$LAMBDA_FUNCTION" == "" ]; then
 fi
 
 echo Found lambda function "$LAMBDA_FUNCTION". Outputting environment...
-aws lambda get-function --function-name content-api-CODE-recipes-bac-updaterLambdaE2EB52D9-96E3fkPw4vbx --query 'Configuration.Environment.Variables' | perl -n -e'/\"([\w_]+)\": \"(.+)\"/ && print "export $1=$2\n"' | grep -v TELEMETRY > "environ-${STAGE}"
+aws lambda get-function --function-name "$LAMBDA_FUNCTION" --query 'Configuration.Environment.Variables' | perl -n -e'/\"([\w_]+)\": \"(.+)\"/ && print "export $1=$2\n"' | grep -v TELEMETRY > "environ-${STAGE}"
 
 echo You can now run \`source environ-${STAGE}\` to get hold of the environment configuration for $STAGE

--- a/lambda/recipes-responder/project.json
+++ b/lambda/recipes-responder/project.json
@@ -4,6 +4,13 @@
 	"sourceRoot": "lambda/recipes-responder/src",
 	"projectType": "application",
 	"targets": {
+    "commandline-reindex": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["ts-node --project tsconfig.exec.json -r tsconfig-paths/register src/commandline-reindex.ts"],
+        "cwd": "lambda/recipes-responder"
+      }
+    },
     "build": {
       "executor": "nx:run-commands",
       "options": {

--- a/lambda/recipes-responder/src/commandline-reindex.ts
+++ b/lambda/recipes-responder/src/commandline-reindex.ts
@@ -1,0 +1,79 @@
+import {parseArgs} from "node:util";
+import {CapiKey} from "./config";
+import {handleContentUpdate} from "./update_processor";
+import {PollingAction, retrieveContent} from "./update_retrievable_processor";
+
+const oldLog = console.log;
+const oldError = console.error;
+const oldDebug = console.debug;
+
+global.console.log = (...args: unknown[])=>oldLog("\x1b[34m ", ...args, "\x1b[0m")
+global.console.error = (...args: unknown[]) => oldError("\x1b[31m ", ...args, "\x1b[0m")
+global.console.debug = (...args: unknown[]) => oldDebug("\x1b[30m ", ...args, "\x1b[0m")
+async function main() {
+//Parse the commandline arguments
+  const {
+    values: {help, composerId, capiId},
+  } = parseArgs({
+    options: {
+      help: {
+        type: "boolean",
+        short: "h"
+      },
+      recipeVersion: {
+        type: "string"
+      },
+      recipeUid: {
+        type: "string"
+      },
+      composerId: {
+        type: "string",
+      },
+      capiId: {
+        type: "string",
+      },
+      test: {
+        type: "boolean",
+        short: "t"
+      }
+    }
+  });
+
+  if (help) {
+    console.log("Performs a re-index of the specified recipes in the recipe backend. Requires CAPI dev privileges to run.");
+    console.log("This expects the following environment variables to be set:");
+    console.log(" - CONTENT_URL_BASE  - base URL of the Guardian content API (e.g. https://content.guardianapis.com)");
+    console.log(" - CAPI_KEY          - valid Content API key for internal-tier access to the CAPI environment given by the base URL");
+    console.log("You must specify exactly one of --recipeVersion {checksumId} / --recipeUid {uid} / --composerId {composerId} / --capiId {capiId} ");
+    process.exit(0);
+  }
+
+  if (!CapiKey || CapiKey == "") {
+    console.error("You need to set the CAPI_KEY environment variable to a valid, internal-tier CAPI key for this to work");
+    process.exit(1);
+  }
+
+  if (capiId) {
+    const pollingResult = await retrieveContent(capiId);
+    switch(pollingResult.action) {
+      case PollingAction.CONTENT_EXISTS:
+        console.log(`Found article with title '${pollingResult.content?.webTitle ?? ""}' published ${pollingResult.content?.webPublicationDate?.iso8601 ?? ""}`);
+        if(pollingResult.content) {
+          await handleContentUpdate(pollingResult.content);
+        } else {
+          throw new Error("Got a positive result but no content?? This must be a bug :(");
+        }
+        break;
+      default:
+        throw new Error(`Unable to retrieve content from ${capiId}`)
+    }
+  }
+}
+
+main().then(()=>{
+  console.log("Completed");
+  process.exit(0);
+}).catch((err)=>{
+  console.error(err);
+  process.exit(2);
+})

--- a/lambda/recipes-responder/src/commandline-reindex.ts
+++ b/lambda/recipes-responder/src/commandline-reindex.ts
@@ -2,7 +2,7 @@ import {parseArgs} from "node:util";
 import {CapiKey} from "./config";
 import {handleContentUpdate} from "./update_processor";
 import {PollingAction, retrieveContent} from "./update_retrievable_processor";
-import {recipeByUID} from "@recipes-api/lib/recipes-data";
+import {recipeByUID, retrieveIndexData} from "@recipes-api/lib/recipes-data";
 
 const oldLog = console.log;
 const oldError = console.error;
@@ -24,7 +24,11 @@ async function getQueryUri(maybeCapiUri?:string, maybeComposerId?:string, maybeR
       throw new Error(`Could not find a recipe with ID ${maybeRecipeUid}. Are you sure you are querying the right environment?`)
     }
   } else if(maybeCapiUri) {
-    return maybeCapiUri
+    if(maybeCapiUri.startsWith("http")) {
+      return maybeCapiUri;
+    } else {
+      return `${capiBase}/${maybeCapiUri}`;
+    }
   } else if(maybeComposerId) {
     return `${capiBase}/internal-code/composer/${maybeComposerId}`
   } else {
@@ -32,50 +36,7 @@ async function getQueryUri(maybeCapiUri?:string, maybeComposerId?:string, maybeR
   }
 }
 
-async function main() {
-//Parse the commandline arguments
-  const {
-    values: {help, composerId, capiUri, recipeUid, recipeVersion},
-  } = parseArgs({
-    options: {
-      help: {
-        type: "boolean",
-        short: "h"
-      },
-      recipeVersion: {
-        type: "string"
-      },
-      recipeUid: {
-        type: "string"
-      },
-      composerId: {
-        type: "string",
-      },
-      capiUri: {
-        type: "string",
-      },
-      test: {
-        type: "boolean",
-        short: "t"
-      }
-    }
-  });
-
-  if (help) {
-    console.log("Performs a re-index of the specified recipes in the recipe backend. Requires CAPI dev privileges to run.");
-    console.log("This expects the following environment variables to be set:");
-    console.log(" - CONTENT_URL_BASE  - base URL of the Guardian content API (e.g. https://content.guardianapis.com)");
-    console.log(" - CAPI_KEY          - valid Content API key for internal-tier access to the CAPI environment given by the base URL");
-    console.log("You must specify exactly one of --recipeVersion {checksumId} / --recipeUid {uid} / --composerId {composerId} / --capiId {capiId} ");
-    process.exit(0);
-  }
-
-  if (!CapiKey || CapiKey == "") {
-    console.error("You need to set the CAPI_KEY environment variable to a valid, internal-tier CAPI key for this to work");
-    process.exit(1);
-  }
-
-  const queryUri = await getQueryUri(capiUri, composerId, recipeUid)
+async function reindex(queryUri:string):Promise<void> {
   const pollingResult = await retrieveContent(queryUri);
   switch(pollingResult.action) {
     case PollingAction.CONTENT_EXISTS:
@@ -88,6 +49,98 @@ async function main() {
       break;
     default:
       throw new Error(`Unable to retrieve content from ${queryUri}`)
+  }
+}
+
+async function main() {
+//Parse the commandline arguments
+  const {
+    values: {help, composerId, capiUri, recipeUid, all, test},
+  } = parseArgs({
+    options: {
+      help: {
+        type: "boolean",
+        short: "h"
+      },
+      recipeUid: {
+        type: "string"
+      },
+      composerId: {
+        type: "string",
+      },
+      capiUri: {
+        type: "string",
+      },
+      all: {
+        type: "boolean",
+        short: "a"
+      },
+      test: {
+        type: "boolean",
+        short: "t"
+      }
+    }
+  });
+
+  if (help) {
+    console.log("Performs a re-index of the specified recipes in the recipe backend. Requires CAPI dev privileges to run.");
+    console.log("This expects the following environment variables to be set. You can get the values by running `./get-local-config.sh`:");
+    console.log(" - STACK              - deployment stack, required as it's a metrics param");
+    console.log(" - LAST_UPDATED_INDEX - name of the Dynamo index for querying `lastUpdated");
+    console.log(" - INDEX_TABLE        - Dynamo table that holds the index");
+    console.log(" - STATIC_BUCKET      - bucket that holds the static content");
+    console.log(" - STAGE              - choose whether to target CODE or PROD");
+    console.log(" - CONTENT_URL_BASE   - base URL of the Recipes API");
+    console.log(" - FASTLY_API_KEY     - API key to allow flush of the Fastly cache");
+    console.log(" - CAPI_KEY           - valid Content API key for internal-tier access to the CAPI environment given by the base URL");
+
+    console.log("You must specify exactly one of  --recipeUid {uid} / --composerId {composerId} / --capiUri {capi-uri} / --all to indicate which content to re-index");
+    process.exit(0);
+  }
+
+  if (!CapiKey || CapiKey == "") {
+    console.error("You need to set the CAPI_KEY environment variable to a valid, internal-tier CAPI key for this to work");
+    process.exit(1);
+  }
+
+  if(process.env["STACK"]) {
+    const msg = `Performing re-index operations on ${process.env["STAGE"]}`;
+
+    if(process.env["STAGE"]=="PROD") console.error(msg); else console.log(msg);
+    console.log("------------------------------------------------------\n");
+  }
+
+  if(all) {
+    const index = await retrieveIndexData();
+    console.log(`Re-index all: index was last updated at ${index.lastUpdated.toISOString()}`);
+    const articleIdSet = index.recipes.reduce<Set<string>>((idSet, entry)=>(
+      idSet.add(entry.capiArticleId)
+    ), new Set<string>());
+
+    const articleIdList = Array.from(articleIdSet.values());
+
+    console.log(`Re-index all: Found ${index.recipes.length} recipes to re-index across ${articleIdList.length} articles`);
+    if(test) {
+      console.log("Not performing any operations as --test was specified")
+    } else {
+      const total = articleIdList.length;
+      let i = 1;
+      for (const articleId of articleIdList) {
+        console.log("------------------------------------------------------");
+        console.log(`Article ${i} / ${total}...\n`);
+        const queryUri = await getQueryUri(articleId, undefined, undefined);
+        await reindex(queryUri);
+        console.log("------------------------------------------------------\n");
+        i++;
+      }
+    }
+  } else {
+    const queryUri = await getQueryUri(capiUri, composerId, recipeUid);
+    if(test) {
+      console.log("Not performing any operations as --test was specified")
+    } else {
+      await reindex(queryUri);
+    }
   }
 }
 

--- a/lambda/recipes-responder/src/main.test.ts
+++ b/lambda/recipes-responder/src/main.test.ts
@@ -12,11 +12,6 @@ import {handleDeletedContent, handleTakedown} from "./takedown_processor";
 import {handleContentUpdate} from "./update_processor";
 import {handleContentUpdateRetrievable} from "./update_retrievable_processor";
 
-jest.mock("node-fetch", () => ({
-  __esmodule: true,
-  default: jest.fn(),
-}));
-
 jest.mock("@recipes-api/lib/capi", () => ({
   deserializeEvent: jest.fn(),
 }));
@@ -43,6 +38,7 @@ jest.mock("@recipes-api/cwmetrics", () => ({
 describe("main.processRecord", () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    jest.spyOn(global, "fetch").mockImplementation(jest.fn());
   });
 
   //@ts-ignore

--- a/lambda/recipes-responder/src/update_processor.test.ts
+++ b/lambda/recipes-responder/src/update_processor.test.ts
@@ -54,8 +54,8 @@ describe("update_processor.handleContentUpdate", ()=>{
     ];
 
     const refsToRemove:RecipeIndexEntry[] = [
-      { recipeUID: "uid-recep-2", checksum: "xxxyyyzzz"},
-      { recipeUID: "uid-recep-4", checksum: "zzzyyyqqq"}
+      { recipeUID: "uid-recep-2", checksum: "xxxyyyzzz", capiArticleId: "path/to/article"},
+      { recipeUID: "uid-recep-4", checksum: "zzzyyyqqq", capiArticleId: "path/to/article"}
     ];
 
     // @ts-ignore -- Typescript doesn't know that this is a mock
@@ -126,8 +126,8 @@ describe("update_processor.handleContentUpdate", ()=>{
     ];
 
     const refsToRemove:RecipeIndexEntry[] = [
-      { recipeUID: "uid-recep-2", checksum: "xxxyyyzzz"},
-      { recipeUID: "uid-recep-4", checksum: "zzzyyyqqq"}
+      { recipeUID: "uid-recep-2", checksum: "xxxyyyzzz", capiArticleId: "path/to/article"},
+      { recipeUID: "uid-recep-4", checksum: "zzzyyyqqq", capiArticleId: "path/to/article"}
     ];
 
     // @ts-ignore -- Typescript doesn't know that this is a mock
@@ -199,8 +199,8 @@ describe("update_processor.handleContentUpdate", ()=>{
     ];
 
     const refsToRemove:RecipeIndexEntry[] = [
-      { recipeUID: "uid-recep-2", checksum: "xxxyyyzzz"},
-      { recipeUID: "uid-recep-4", checksum: "zzzyyyqqq"}
+      { recipeUID: "uid-recep-2", checksum: "xxxyyyzzz", capiArticleId: "path/to/article"},
+      { recipeUID: "uid-recep-4", checksum: "zzzyyyqqq", capiArticleId: "path/to/article"}
     ];
 
     // @ts-ignore -- Typescript doesn't know that this is a mock

--- a/lambda/recipes-responder/src/update_processor.test.ts
+++ b/lambda/recipes-responder/src/update_processor.test.ts
@@ -15,11 +15,6 @@ import {
 import {handleContentUpdate} from "./update_processor";
 import Mock = jest.Mock;
 
-jest.mock("node-fetch", ()=>({
-  __esmodule: true,
-  default: jest.fn()
-}));
-
 jest.mock("@recipes-api/lib/recipes-data", ()=>({
   calculateChecksum: jest.fn(),
   extractAllRecipesFromArticle: jest.fn(),
@@ -44,6 +39,7 @@ const fakeContent:Content = {
 describe("update_processor.handleContentUpdate", ()=>{
   beforeEach(()=>{
     jest.resetAllMocks();
+    jest.spyOn(global, "fetch").mockImplementation(jest.fn());
   });
 
   it("should extract recipes from the content, publish those and take-down any that were no longer needed", async ()=>{
@@ -84,15 +80,15 @@ describe("update_processor.handleContentUpdate", ()=>{
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(insertNewRecipe.mock.calls[0][0]).toEqual("path/to/content");  //canonical article ID
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(insertNewRecipe.mock.calls[0][1]).toEqual({checksum: "abcd1", recipeUID: "uid-recep-1"});  //recipe data
+    expect(insertNewRecipe.mock.calls[0][1]).toEqual({checksum: "abcd1", recipeUID: "uid-recep-1", capiArticleId: "path/to/content"});  //recipe data
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(insertNewRecipe.mock.calls[1][0]).toEqual("path/to/content");  //canonical article ID
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(insertNewRecipe.mock.calls[1][1]).toEqual({checksum: "efgh", recipeUID: "uid-recep-2"});  //recipe data
+    expect(insertNewRecipe.mock.calls[1][1]).toEqual({checksum: "efgh", recipeUID: "uid-recep-2", capiArticleId: "path/to/content"});  //recipe data
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(insertNewRecipe.mock.calls[2][0]).toEqual("path/to/content");  //canonical article ID
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(insertNewRecipe.mock.calls[2][1]).toEqual({checksum: "xyzp", recipeUID: "uid-recep-3"});  //recipe data
+    expect(insertNewRecipe.mock.calls[2][1]).toEqual({checksum: "xyzp", recipeUID: "uid-recep-3", capiArticleId: "path/to/content"});  //recipe data
 
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(publishRecipeContent.mock.calls.length).toEqual(3);
@@ -108,11 +104,11 @@ describe("update_processor.handleContentUpdate", ()=>{
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipeVersion.mock.calls[0][0]).toEqual("path/to/content");
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipeVersion.mock.calls[0][1]).toEqual({checksum: "xxxyyyzzz", recipeUID: "uid-recep-2"});
+    expect(removeRecipeVersion.mock.calls[0][1]).toEqual({checksum: "xxxyyyzzz", recipeUID: "uid-recep-2", capiArticleId: "path/to/article"});
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipeVersion.mock.calls[1][0]).toEqual("path/to/content");
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipeVersion.mock.calls[1][1]).toEqual({checksum: "zzzyyyqqq", recipeUID: "uid-recep-4"});
+    expect(removeRecipeVersion.mock.calls[1][1]).toEqual({checksum: "zzzyyyqqq", recipeUID: "uid-recep-4", capiArticleId: "path/to/article"});
 
     expect((sendTelemetryEvent as Mock).mock.calls.length).toEqual(3);
     expect((sendTelemetryEvent as Mock).mock.calls[0][0]).toEqual("PublishedData");
@@ -231,15 +227,15 @@ describe("update_processor.handleContentUpdate", ()=>{
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(insertNewRecipe.mock.calls[0][0]).toEqual("path/to/content");  //canonical article ID
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(insertNewRecipe.mock.calls[0][1]).toEqual({checksum: "abcd1", recipeUID: "uid-recep-1"});  //recipe data
+    expect(insertNewRecipe.mock.calls[0][1]).toEqual({checksum: "abcd1", recipeUID: "uid-recep-1", capiArticleId: "path/to/content"});  //recipe data
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(insertNewRecipe.mock.calls[1][0]).toEqual("path/to/content");  //canonical article ID
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(insertNewRecipe.mock.calls[1][1]).toEqual({checksum: "efgh", recipeUID: "uid-recep-2"});  //recipe data
+    expect(insertNewRecipe.mock.calls[1][1]).toEqual({checksum: "efgh", recipeUID: "uid-recep-2", capiArticleId: "path/to/content"});  //recipe data
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(insertNewRecipe.mock.calls[2][0]).toEqual("path/to/content");  //canonical article ID
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(insertNewRecipe.mock.calls[2][1]).toEqual({checksum: "xyzp", recipeUID: "uid-recep-3"});  //recipe data
+    expect(insertNewRecipe.mock.calls[2][1]).toEqual({checksum: "xyzp", recipeUID: "uid-recep-3", capiArticleId: "path/to/content"});  //recipe data
 
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(publishRecipeContent.mock.calls.length).toEqual(3);
@@ -255,11 +251,11 @@ describe("update_processor.handleContentUpdate", ()=>{
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipeVersion.mock.calls[0][0]).toEqual("path/to/content");
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipeVersion.mock.calls[0][1]).toEqual({checksum: "xxxyyyzzz", recipeUID: "uid-recep-2"});
+    expect(removeRecipeVersion.mock.calls[0][1]).toEqual({checksum: "xxxyyyzzz", recipeUID: "uid-recep-2", capiArticleId: "path/to/article"});
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(removeRecipeVersion.mock.calls[1][0]).toEqual("path/to/content");
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(removeRecipeVersion.mock.calls[1][1]).toEqual({checksum: "zzzyyyqqq", recipeUID: "uid-recep-4"});
+    expect(removeRecipeVersion.mock.calls[1][1]).toEqual({checksum: "zzzyyyqqq", recipeUID: "uid-recep-4", capiArticleId: "path/to/article"});
 
     expect((sendTelemetryEvent as Mock).mock.calls.length).toEqual(3);
     expect((sendTelemetryEvent as Mock).mock.calls[0][0]).toEqual("PublishedData");

--- a/lambda/recipes-responder/src/update_processor.ts
+++ b/lambda/recipes-responder/src/update_processor.ts
@@ -57,7 +57,8 @@ export async function handleContentUpdate(content:Content):Promise<number>
     return allRecipes.length + entriesToRemove.length;
   } catch(err) {
     //log out what actually caused the breakage
-    //console.error("Failed article was: ", JSON.stringify(content));
+    console.error("Failed article was: ", JSON.stringify(content));
+    console.error("------------");
     console.error(err);
     throw err;
   }

--- a/lambda/recipes-responder/src/update_processor.ts
+++ b/lambda/recipes-responder/src/update_processor.ts
@@ -57,7 +57,7 @@ export async function handleContentUpdate(content:Content):Promise<number>
     return allRecipes.length + entriesToRemove.length;
   } catch(err) {
     //log out what actually caused the breakage
-    console.error("Failed article was: ", JSON.stringify(content));
+    //console.error("Failed article was: ", JSON.stringify(content));
     console.error(err);
     throw err;
   }

--- a/lambda/recipes-responder/src/update_processor.ts
+++ b/lambda/recipes-responder/src/update_processor.ts
@@ -26,7 +26,7 @@ async function publishRecipe(canonicalArticleId:string, recep:RecipeReference):P
   console.log(`INFO [${canonicalArticleId}] - pushing ${recep.recipeUID} @ ${recep.checksum} to S3...`);
   await publishRecipeContent(recep);
   console.log(`INFO [${canonicalArticleId}] - updating index table...`);
-  await insertNewRecipe(canonicalArticleId, {recipeUID: recep.recipeUID, checksum: recep.checksum});
+  await insertNewRecipe(canonicalArticleId, {recipeUID: recep.recipeUID, checksum: recep.checksum, capiArticleId: canonicalArticleId});
 }
 
 /**

--- a/lambda/recipes-responder/src/update_retrievable_processor.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.ts
@@ -10,7 +10,7 @@ import {handleContentUpdate} from "./update_processor";
 
 // Why can't we just import this from capi module? It appears that the info gets erased at transpile time, so we end up
 //with object undefined errors at runtime :-(
-enum PollingAction {
+export enum PollingAction {
   CONTENT_EXISTS,
   CONTENT_MISSING,
   CONTENT_GONE,
@@ -20,7 +20,7 @@ enum PollingAction {
   RATE_LIMITED
 }
 
-async function retrieveContent(capiUrl:string) :Promise<PollingResult>{
+export async function retrieveContent(capiUrl:string) :Promise<PollingResult>{
   if(!CapiKey) {
     throw new Error("You need to set CAPI_KEY in order to make requests to CAPI");
   }

--- a/lambda/recipes-responder/tsconfig.exec.json
+++ b/lambda/recipes-responder/tsconfig.exec.json
@@ -1,0 +1,15 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"module": "commonjs",
+		"types": ["node"],
+    "paths": {
+      "@recipes-api/cwmetrics": ["lib/cwmetrics/src/index.ts"],
+      "@recipes-api/lib/capi": ["lib/capi/src/index.ts"],
+      "@recipes-api/lib/recipes-data": ["lib/recipes-data/src/index.ts"]
+    }
+	},
+	"exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+	"include": ["src/**/*.ts"]
+}

--- a/lambda/recipes-responder/tsconfig.json
+++ b/lambda/recipes-responder/tsconfig.json
@@ -8,7 +8,10 @@
 		},
 		{
 			"path": "./tsconfig.spec.json"
-		}
+		},
+    {
+      "path": "./tsconfig.exec.json"
+    }
 	],
 	"compilerOptions": {
 		"esModuleInterop": true

--- a/lib/capi/src/lib/capi.test.ts
+++ b/lib/capi/src/lib/capi.test.ts
@@ -1,11 +1,5 @@
-import fetch from "node-fetch";
 import { callCAPI, PollingAction } from './capi';
 import {deserializeItemResponse} from "@recipes-api/lib/capi";
-
-jest.mock("node-fetch", ()=>({
-  __esmodule: true,
-  default: jest.fn()
-}));
 
 jest.mock("./deserialize", ()=>({
   deserializeItemResponse: jest.fn()
@@ -17,15 +11,13 @@ describe("capi.callCAPI", ()=>{
   });
 
   const empty = new ArrayBuffer(0);
-  const makeFetchResponse = (status:number, content:ArrayBuffer)=> ({
+  const makeFetchResponse = (status:number, content:ArrayBuffer)=> Promise.resolve({
     arrayBuffer: ()=>Promise.resolve(content),
     status,
-  });
+  } as Response);
 
   it("should return PollingActon.CONTENT_MISSING on 404", async ()=>{
-
-    //@ts-ignore - Typescript doesn't know that this is a mock
-    fetch.mockReturnValue(makeFetchResponse(404, empty));
+    jest.spyOn(global, "fetch").mockReturnValue(makeFetchResponse(404, empty));
 
     const result = await callCAPI("https://path-to-some-thing");
     expect(result.content).toBeUndefined();
@@ -40,8 +32,7 @@ describe("capi.callCAPI", ()=>{
   });
 
   it("should return PollingActon.CONTENT_EXISTS with content on 200", async ()=>{
-    //@ts-ignore - Typescript doesn't know that this is a mock
-    fetch.mockReturnValue(makeFetchResponse(200, empty));
+    jest.spyOn(global, "fetch").mockReturnValue(makeFetchResponse(200, empty));
 
     //@ts-ignore - Typescript doesn't know that this is a mock
     deserializeItemResponse.mockReturnValue({content: {key: "some-content-here"}});
@@ -61,9 +52,7 @@ describe("capi.callCAPI", ()=>{
   });
 
   it("should return PollingActon.CONTENT_GONE on 410", async ()=>{
-
-    //@ts-ignore - Typescript doesn't know that this is a mock
-    fetch.mockReturnValue(makeFetchResponse(410, empty));
+    jest.spyOn(global, "fetch").mockReturnValue(makeFetchResponse(410, empty));
 
     const result = await callCAPI("https://path-to-some-thing");
     expect(result.content).toBeUndefined();
@@ -78,9 +67,7 @@ describe("capi.callCAPI", ()=>{
   });
 
   it("should return PollingActon.RATE_LIMITED on 429", async ()=>{
-
-    //@ts-ignore - Typescript doesn't know that this is a mock
-    fetch.mockReturnValue(makeFetchResponse(429, empty));
+    jest.spyOn(global, "fetch").mockReturnValue(makeFetchResponse(429, empty));
 
     const result = await callCAPI("https://path-to-some-thing");
     expect(result.content).toBeUndefined();

--- a/lib/capi/src/lib/capi.ts
+++ b/lib/capi/src/lib/capi.ts
@@ -1,6 +1,5 @@
 /* eslint @typescript-eslint/naming-convention: "off"  -- PollingAction uses a more CAPI-like convention*/
 import type {Content} from "@guardian/content-api-models/v1/content";
-import fetch from "node-fetch";
 import {deserializeItemResponse} from "./deserialize";
 
 export enum PollingAction {

--- a/lib/cwmetrics/src/lib/cloudwatch.ts
+++ b/lib/cwmetrics/src/lib/cloudwatch.ts
@@ -5,6 +5,7 @@ const cwClient = new CloudWatchClient({region: process.env["AWS_REGION"]});
 
 export type KnownMetric = "FailedRecipes" | "SuccessfulRecipes" | "UpdatesTotalOfArticle";
 
+
 export async function registerMetric(metricName: KnownMetric, value: number) {
   const req = new PutMetricDataCommand({
     Namespace: "RecipeBackend",
@@ -28,5 +29,5 @@ export async function registerMetric(metricName: KnownMetric, value: number) {
   });
 
   const response = await cwClient.send(req);
-  console.log(`Updated ${metricName} metric after ${response.$metadata.attempts ?? 1} attempts`);
+  console.debug(`Updated ${metricName} metric after ${response.$metadata.attempts ?? 1} attempts`);
 }

--- a/lib/recipes-data/src/lib/dynamo.test.ts
+++ b/lib/recipes-data/src/lib/dynamo.test.ts
@@ -3,14 +3,11 @@ import {
   DeleteItemCommand,
   DynamoDBClient,
   QueryCommand,
-  QueryCommandInput
 } from "@aws-sdk/client-dynamodb";
 import {mockClient} from "aws-sdk-client-mock";
 import {bulkRemoveRecipe, removeAllRecipeIndexEntriesForArticle, removeRecipe} from './dynamo';
 import type {RecipeDatabaseEntry, RecipeDatabaseKey} from './models';
 import {RecipeDatabaseEntryToDynamo, RecipeDatabaseEntryToIndex} from "./models";
-
-jest.mock("node-fetch");
 
 jest.mock("./config", ()=>({
   indexTableName: "TestTable"
@@ -36,6 +33,7 @@ describe("dynamodb", ()=>{
   beforeEach(()=>{
     mockDynamoClient.reset();
     jest.resetAllMocks();
+    jest.spyOn(global, "fetch").mockImplementation(jest.fn());
   });
 
   describe("dynamodb.removeRecipe", ()=>{

--- a/lib/recipes-data/src/lib/fastly.test.ts
+++ b/lib/recipes-data/src/lib/fastly.test.ts
@@ -1,4 +1,3 @@
-import fetch from "node-fetch";
 import {FastlyError, sendFastlyPurgeRequest} from "./fastly";
 
 jest.mock("./config", ()=>({
@@ -6,10 +5,6 @@ jest.mock("./config", ()=>({
 
 }));
 
-jest.mock("node-fetch", ()=>({
-  __esModule: true,
-  default: jest.fn()
-}));
 
 describe("sendFastlyPurgeRequest", ()=>{
   beforeEach(()=>{
@@ -18,11 +13,11 @@ describe("sendFastlyPurgeRequest", ()=>{
 
   it("should POST to the Fastly API with the right URL and headers, using soft-purge at the default", async ()=>{
     const fakeData = JSON.stringify({id: "1234xyz", status: "ok"});
-    //@ts-ignore
-    fetch.mockReturnValue(Promise.resolve({
+
+    jest.spyOn(global, "fetch").mockReturnValue(Promise.resolve({
       text: ()=>Promise.resolve(fakeData),
       status: 200,
-    }))
+    } as Response))
     await sendFastlyPurgeRequest("/path/to/content","fake-key");
 
     //@ts-ignore

--- a/lib/recipes-data/src/lib/fastly.ts
+++ b/lib/recipes-data/src/lib/fastly.ts
@@ -1,6 +1,5 @@
 //This file is based on https://github.com/guardian/fastly-cache-purger/blob/5b718fd827acf2eabb94884d9df59645999fc2f5/src/main/scala/com/gu/fastly/Lambda.scala#L162
 //with reference to https://developer.fastly.com/reference/api/purging/ and https://docs.fastly.com/en/guides/authenticating-api-purge-requests
-import fetch from "node-fetch";
 import {ContentPrefix, DebugLogsEnabled, MaximumRetries} from "./config";
 import {awaitableDelay} from "./utils";
 

--- a/lib/recipes-data/src/lib/models.ts
+++ b/lib/recipes-data/src/lib/models.ts
@@ -24,6 +24,7 @@ interface RecipeDatabaseEntry extends RecipeDatabaseKey{
 export interface RecipeIndexEntry {
   checksum: string;
   recipeUID: string;
+  capiArticleId: string;
 }
 
 export function RecipeDatabaseEntryToIndex(from:RecipeDatabaseEntry):RecipeIndexEntry
@@ -31,6 +32,7 @@ export function RecipeDatabaseEntryToIndex(from:RecipeDatabaseEntry):RecipeIndex
   return {
     checksum: from.recipeVersion,
     recipeUID: from.recipeUID,
+    capiArticleId: from.capiArticleId,
   }
 }
 /**
@@ -101,6 +103,7 @@ export function RecipeIndexEntryFromDynamo(raw:Record<string, AttributeValue>): 
   return {
     checksum: raw["recipeVersion"].S ?? "",
     recipeUID: raw["recipeUID"].S ?? "",
+    capiArticleId: raw["capiArticleId"].S ?? ""
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,9 @@
         "date-fns": "^2.30.0",
         "express": "^4.18.2",
         "express-async-handler": "^1.2.0",
-        "node-fetch": "^3.3.2",
         "tslib": "^2.3.0",
-        "uuid": "^9.0.1"
+        "uuid": "^9.0.1",
+        "winston": "^3.13.0"
       },
       "devDependencies": {
         "@guardian/cdk": "52.0.0",
@@ -62,6 +62,7 @@
         "source-map-support": "^0.5.20",
         "ts-jest": "^29.1.0",
         "ts-node": "10.9.1",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "~5.1.3"
       },
       "optionalDependencies": {
@@ -5393,6 +5394,14 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -5413,6 +5422,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
@@ -8001,6 +8020,11 @@
         "@types/q": "*"
       }
     },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.29",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.29.tgz",
@@ -8527,8 +8551,7 @@
     "node_modules/async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-      "dev": true
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/async-limiter": {
       "version": "1.0.1",
@@ -9778,6 +9801,15 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -9793,14 +9825,44 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "node_modules/columnify": {
       "version": "1.6.0",
@@ -9994,14 +10056,6 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==",
       "dev": true
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
@@ -10475,6 +10529,11 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -10654,6 +10713,342 @@
         "@esbuild/win32-arm64": "0.19.5",
         "@esbuild/win32-ia32": "0.19.5",
         "@esbuild/win32-x64": "0.19.5"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.5.tgz",
+      "integrity": "sha512-bhvbzWFF3CwMs5tbjf3ObfGqbl/17ict2/uwOSfr3wmxDE6VdS2GqY/FuzIPe0q0bdhj65zQsvqfArI9MY6+AA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.5.tgz",
+      "integrity": "sha512-5d1OkoJxnYQfmC+Zd8NBFjkhyCNYwM4n9ODrycTFY6Jk1IGiZ+tjVJDDSwDt77nK+tfpGP4T50iMtVi4dEGzhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.5.tgz",
+      "integrity": "sha512-9t+28jHGL7uBdkBjL90QFxe7DVA+KGqWlHCF8ChTKyaKO//VLuoBricQCgwhOjA1/qOczsw843Fy4cbs4H3DVA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.5.tgz",
+      "integrity": "sha512-Ly8cn6fGLNet19s0X4unjcniX24I0RqjPv+kurpXabZYSXGM4Pwpmf85WHJN3lAgB8GSth7s5A0r856S+4DyiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.5.tgz",
+      "integrity": "sha512-GGDNnPWTmWE+DMchq1W8Sd0mUkL+APvJg3b11klSGUDvRXh70JqLAO56tubmq1s2cgpVCSKYywEiKBfju8JztQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.5.tgz",
+      "integrity": "sha512-1CCwDHnSSoA0HNwdfoNY0jLfJpd7ygaLAp5EHFos3VWJCRX9DMwWODf96s9TSse39Br7oOTLryRVmBoFwXbuuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.5.tgz",
+      "integrity": "sha512-lrWXLY/vJBzCPC51QN0HM71uWgIEpGSjSZZADQhq7DKhPcI6NH1IdzjfHkDQws2oNpJKpR13kv7/pFHBbDQDwQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.5.tgz",
+      "integrity": "sha512-o3vYippBmSrjjQUCEEiTZ2l+4yC0pVJD/Dl57WfPwwlvFkrxoSO7rmBZFii6kQB3Wrn/6GwJUPLU5t52eq2meA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.5.tgz",
+      "integrity": "sha512-MkjHXS03AXAkNp1KKkhSKPOCYztRtK+KXDNkBa6P78F8Bw0ynknCSClO/ztGszILZtyO/lVKpa7MolbBZ6oJtQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.5.tgz",
+      "integrity": "sha512-42GwZMm5oYOD/JHqHska3Jg0r+XFb/fdZRX+WjADm3nLWLcIsN27YKtqxzQmGNJgu0AyXg4HtcSK9HuOk3v1Dw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.5.tgz",
+      "integrity": "sha512-kcjndCSMitUuPJobWCnwQ9lLjiLZUR3QLQmlgaBfMX23UEa7ZOrtufnRds+6WZtIS9HdTXqND4yH8NLoVVIkcg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.5.tgz",
+      "integrity": "sha512-yJAxJfHVm0ZbsiljbtFFP1BQKLc8kUF6+17tjQ78QjqjAQDnhULWiTA6u0FCDmYT1oOKS9PzZ2z0aBI+Mcyj7Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.5.tgz",
+      "integrity": "sha512-5u8cIR/t3gaD6ad3wNt1MNRstAZO+aNyBxu2We8X31bA8XUNyamTVQwLDA1SLoPCUehNCymhBhK3Qim1433Zag==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.5.tgz",
+      "integrity": "sha512-Z6JrMyEw/EmZBD/OFEFpb+gao9xJ59ATsoTNlj39jVBbXqoZm4Xntu6wVmGPB/OATi1uk/DB+yeDPv2E8PqZGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.5.tgz",
+      "integrity": "sha512-psagl+2RlK1z8zWZOmVdImisMtrUxvwereIdyJTmtmHahJTKb64pAcqoPlx6CewPdvGvUKe2Jw+0Z/0qhSbG1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.5.tgz",
+      "integrity": "sha512-kL2l+xScnAy/E/3119OggX8SrWyBEcqAh8aOY1gr4gPvw76la2GlD4Ymf832UCVbmuWeTf2adkZDK+h0Z/fB4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.5.tgz",
+      "integrity": "sha512-sPOfhtzFufQfTBgRnE1DIJjzsXukKSvZxloZbkJDG383q0awVAq600pc1nfqBcl0ice/WN9p4qLc39WhBShRTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.5.tgz",
+      "integrity": "sha512-dGZkBXaafuKLpDSjKcB0ax0FL36YXCvJNnztjKV+6CO82tTYVDSH2lifitJ29jxRMoUhgkg9a+VA/B03WK5lcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.5.tgz",
+      "integrity": "sha512-dWVjD9y03ilhdRQ6Xig1NWNgfLtf2o/STKTS+eZuF90fI2BhbwD6WlaiCGKptlqXlURVB5AUOxUj09LuwKGDTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.5.tgz",
+      "integrity": "sha512-4liggWIA4oDgUxqpZwrDhmEfAH4d0iljanDOK7AnVU89T6CzHon/ony8C5LeOdfgx60x5cnQJFZwEydVlYx4iw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.5.tgz",
+      "integrity": "sha512-czTrygUsB/jlM8qEW5MD8bgYU2Xg14lo6kBDXW6HdxKjh8M5PzETGiSHaz9MtbXBYDloHNUAUW2tMiKW4KM9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/escalade": {
@@ -11506,27 +11901,10 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -11679,6 +12057,11 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.4",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
@@ -11717,17 +12100,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -12693,7 +13065,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -13668,6 +14039,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -13797,6 +14173,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+      "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/lru-cache": {
@@ -14061,8 +14453,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -14113,41 +14504,6 @@
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-int64": {
@@ -14421,6 +14777,14 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -15112,7 +15476,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -15429,6 +15792,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -15605,6 +15976,19 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/sinon": {
       "version": "14.0.2",
@@ -15914,6 +16298,14 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -15956,7 +16348,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -16213,6 +16604,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -16306,6 +16702,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/ts-jest": {
@@ -16745,8 +17149,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -16854,14 +17257,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -16940,6 +17335,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
+      "integrity": "sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
+      "integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
+      "dependencies": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/wordwrap": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "express": "^4.18.2",
     "express-async-handler": "^1.2.0",
     "tslib": "^2.3.0",
-    "uuid": "^9.0.1",
-    "winston": "^3.13.0"
+    "uuid": "^9.0.1"
   },
   "prettier": "@guardian/prettier",
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "nx run-many --target=build --skip-nx-cache",
     "test": "nx run-many --target=test",
     "lint": "nx run-many --target=lint",
-    "manual-takedown": "nx run tools-manual-takedown:run"
+    "manual-takedown": "nx run tools-manual-takedown:run",
+    "commandline-reindex": "nx run lambda-recipes-responder:commandline-reindex -- "
   },
   "private": true,
   "dependencies": {
@@ -24,9 +25,9 @@
     "date-fns": "^2.30.0",
     "express": "^4.18.2",
     "express-async-handler": "^1.2.0",
-    "node-fetch": "^3.3.2",
     "tslib": "^2.3.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "winston": "^3.13.0"
   },
   "prettier": "@guardian/prettier",
   "eslintConfig": {
@@ -96,6 +97,7 @@
     "source-map-support": "^0.5.20",
     "ts-jest": "^29.1.0",
     "ts-node": "10.9.1",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "~5.1.3"
   }
 }


### PR DESCRIPTION
## What does this change?

- Adds a commandline tool to allow re-indexing of content in the Recipe Backend by grabbing the current published articles from CAPI rather than waiting for them to be re-launched and picked up through Crier in the usual way
- Adds a simple little script to grab the current environment-variable configuration from PROD or CODE environments so that the tool can be easily used
- Remove requirement for node-fetch because we can use built-in `fetch` in Node.js now
- Update tests to mock built-in fetch, also add checks for telemetry calls during take-down that were not previously there
- Add in a telemetry call for a takedown path that was missed

### To Do
- [x] Document

## How to test

- Set up your local environment as per the README
- Choose a recipe ID from CODE. (easiest way is to do `curl https://recipes.code.dev-guardianapis.com/index.json | jq .` and then just pick one
- Download the content `curl https://recipes.code.dev-guaredianapis.com/content/{checksum} | jq . > before.json`
- Run `npm run commandline-reindex --recipe-uid {uid}` and watch the logs
- You should see it load up the article, extract all recipes and re-publish.
- Crucially, the SHA value should not change.
- If the SHA does change, download the new version `curl https://recipes.code.dev-guaredianapis.com/content/{checksum} | jq . > after.json` and then check it at https://www.jsondiff.com/

If you're feeling thorough, then run the test again for a valid CAPI path and a valid Composer article ID, as per the README.

**Finally, don't forget**
- structurise and publish a new recipe on CODE, just to prove that it is still publishing properly

## How can we measure success?

Able to push through changes from downstream of Composer more easily

## Have we considered potential risks?

This is not a tool that should be used often.  As long as it's done in accordance with the instructions, there is minimal risk; notes are in the README for higher-risk operations.