### PR TITLE
Bump image width

### DIFF
--- a/lib/recipes-data/src/lib/config.ts
+++ b/lib/recipes-data/src/lib/config.ts
@@ -29,6 +29,6 @@ export const TelemetryXAR = process.env["TELEMETRY_XAR"]
 export const TelemetryTopic = process.env["TELEMETRY_TOPIC"]
 
 //Used by content transforms
-export const PreviewImageWidth = process.env["PREVIEW_IMAGE_WIDTH"] ? parseInt(process.env["PREVIEW_IMAGE_WIDTH"]) : 300;
-export const FeaturedImageWidth = process.env["FEATURED_IMAGE_WIDTH"] ? parseInt(process.env["FEATURED_IMAGE_WIDTH"]) : 700;
+export const PreviewImageWidth = process.env["PREVIEW_IMAGE_WIDTH"] ? parseInt(process.env["PREVIEW_IMAGE_WIDTH"]) : 1600;
+export const FeaturedImageWidth = process.env["FEATURED_IMAGE_WIDTH"] ? parseInt(process.env["FEATURED_IMAGE_WIDTH"]) : 1600;
 export const ImageDpr = process.env["IMAGE_DPR"] ? parseInt(process.env["IMAGE_DPR"]) : 1;


### PR DESCRIPTION
## What does this change?

After #27, bumps the image width to 1600px for both image types, to better fit featured recipes on larger devices. 

In conversation with @robindorpe-guardian, we think this should be a manageable size for the app. 
