### PR TITLE
Use correct dimensions for master crop image

### DIFF
--- a/lib/recipes-data/src/lib/recipe-fixtures.ts
+++ b/lib/recipes-data/src/lib/recipe-fixtures.ts
@@ -21,7 +21,7 @@ export const recipes = [
 		previewImage: {
 			url: 'https://media.guim.co.uk/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/2000.jpg',
 			mediaId: '87a7591d5260e962ad459d56771f50fc0ce05f14',
-			cropId: '0_257_5626_6188',
+			cropId: '360_1725_4754_4754',
 			source: 'The Observer',
 			photographer: 'Romas Foord',
 			caption: 'Hot honey and ricotta on toast.',
@@ -34,7 +34,7 @@ export const recipes = [
 		featuredImage: {
 			url: 'https://media.guim.co.uk/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/2000.jpg',
 			mediaId: '87a7591d5260e962ad459d56771f50fc0ce05f14',
-			cropId: '0_2412_5626_3375',
+			cropId: '360_1725_4754_4754',
 			source: 'The Observer',
 			photographer: 'Romas Foord',
 			caption: 'Hot honey and ricotta on toast.',

--- a/lib/recipes-data/src/lib/transform.test.ts
+++ b/lib/recipes-data/src/lib/transform.test.ts
@@ -86,8 +86,8 @@ describe('Recipe transforms', () => {
 			assertImageUrls(
 				recipes[0],
 				transformedRecipeReference,
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/0_2412_5626_3375/master/2000.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/0_257_5626_6188/master/2000.jpg?width=300&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
 			);
 		});
 
@@ -97,8 +97,8 @@ describe('Recipe transforms', () => {
 			assertImageUrls(
 				recipes[1],
 				transformedRecipeReference,
-				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/2000.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/2000.jpg?width=300&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=300&dpr=1&s=none',
 			);
 		});
 
@@ -116,12 +116,12 @@ describe('Recipe transforms', () => {
 			assertImageUrls(
 				recipes[0],
 				transformedRecipeReference,
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/0_2412_5626_3375/master/2000.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/0_257_5626_6188/master/2000.jpg?width=300&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
 			);
 		});
 
-    it('should failover if the mediaId is not present', () => {
+    it('should derive media ids from image URL, succeeding if the mediaId is not present', () => {
 			const { mediaId: _, ...featuredImage } = recipes[0].featuredImage;
 			const recipeWithFeaturedImageWithoutCropId = {
 				...recipes[0],
@@ -135,8 +135,8 @@ describe('Recipe transforms', () => {
 			assertImageUrls(
 				recipes[0],
 				transformedRecipeReference,
-				'https://media.guim.co.uk/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/2000.jpg',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/0_257_5626_6188/master/2000.jpg?width=300&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
 			);
 		});
 
@@ -149,27 +149,8 @@ describe('Recipe transforms', () => {
 			assertImageUrls(
 				recipeWithoutPreview,
 				transformedRecipeReference,
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/0_2412_5626_3375/master/2000.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/0_2412_5626_3375/master/2000.jpg?width=300&dpr=1&s=none',
-			);
-		});
-
-		it('should attempt to extract cropId from original URL if the featured image is missing a cropId', () => {
-			const { cropId: _, ...featuredImage } = recipes[0].featuredImage;
-			const recipeWithFeaturedImageWithoutCropId = {
-				...recipes[0],
-				featuredImage,
-			};
-
-			const transformedRecipeReference = replaceImageUrlsWithFastly(
-				recipeWithFeaturedImageWithoutCropId,
-			);
-
-			assertImageUrls(
-				recipeWithFeaturedImageWithoutCropId,
-				transformedRecipeReference,
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/2000.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/0_257_5626_6188/master/2000.jpg?width=300&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
 			);
 		});
 
@@ -187,9 +168,8 @@ describe('Recipe transforms', () => {
 			assertImageUrls(
 				recipeWithPreviewImageWithoutCropId,
 				transformedRecipeReference,
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/0_2412_5626_3375/master/2000.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/2000.jpg?width=300&dpr=1&s=none',
-			);
+        'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',			);
 		});
 
 		it('should not attempt to extract a crop from the original URL if the featured image URL is not a guim URL', () => {
@@ -209,7 +189,7 @@ describe('Recipe transforms', () => {
 			assertImageUrls(
 				recipeWithPreviewImageWithoutCropId,
 				transformedRecipeReference,
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/0_2412_5626_3375/master/2000.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
 				'https://cdn.road.cc/sites/default/files/styles/main_width/public/Wat-duck.png',
 			);
 		});

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -1,6 +1,6 @@
 import { FeaturedImageWidth, ImageDpr, PreviewImageWidth } from './config';
 import type { Contributor, RecipeImage } from './models';
-import { extractCropIdFromGuimUrl } from './utils';
+import { extractCropDataFromGuimUrl } from './utils';
 
 const getFastlyUrl = (
 	imageId: string,
@@ -32,7 +32,7 @@ export const replaceFastlyUrl = (
 	}
 
 	// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- we're testing for an empty string
-	const cropId = image.cropId || extractCropIdFromGuimUrl(image.url);
+	const cropId = image.cropId || extractCropDataFromGuimUrl(image.url);
 
 	if (!cropId) {
 		console.warn(

--- a/lib/recipes-data/src/lib/utils.test.ts
+++ b/lib/recipes-data/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import type { RecipeReferenceWithoutChecksum } from './models';
-import { calculateChecksum, extractCropIdFromGuimUrl } from './utils';
+import { calculateChecksum, extractCropDataFromGuimUrl } from './utils';
 
 jest.mock('./config', () => ({}));
 
@@ -19,69 +19,80 @@ describe('calculateChecksum', () => {
 });
 
 describe('extractCropIdFromGuimUrl', () => {
-	const assertCropId = (url: string, cropId: string) =>
-		expect(extractCropIdFromGuimUrl(url)).toBe(cropId);
+	const assertCropId = (url: string, cropId: string, width: number) =>
+		expect(extractCropDataFromGuimUrl(url)).toEqual({ cropId, width });
 
 	it('should find a crop id', () => {
-		const urlsToAssert = [
+		const cropDataToAssert = [
 			[
 				'https://media.guim.co.uk/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/2000.jpg',
 				'258_0_7328_4400',
+        7328,
 			],
 			[
 				'https://media.guim.co.uk/7f27c01fda5284d609a26ad4acb28443241ec6b3/5_2110_2299_1379/1000.jpg',
 				'5_2110_2299_1379',
+        2299
 			],
 			[
 				'https://media.guim.co.uk/13d94f7cf33f17a22da3d93a121623899e7da76e/0_0_3713_4378/1696.jpg',
 				'0_0_3713_4378',
+        3713
 			],
 			[
 				'https://media.guim.co.uk/affead41f14556fa03c18391aceae2ac8a5a9449/0_0_4000_5097/1570.jpg',
 				'0_0_4000_5097',
+        4000
 			],
 			[
 				'https://media.guim.co.uk/a1212c7bc9ddc45a79d274ee12b4fdc724c8a022/0_456_4000_5225/1531.jpg',
 				'0_456_4000_5225',
+        4000
 			],
 			[
 				'https://media.guim.co.uk/0204e0aa54caa8687a6627d6426fe06c38406f57/4002_593_3975_4970/1600.jpg',
 				'4002_593_3975_4970',
+        3975
 			],
 			[
 				'https://media.guim.co.uk/7ca187c030131b5db1c335688044f379210a78bc/0_0_6426_5086/2000.jpg',
 				'0_0_6426_5086',
+        6426
 			],
 			[
 				' https://media.guim.co.uk/945038b08cdf48ecc21de52d1c75a34c85bbfc92/37_54_5422_5419/5422.jpg',
 				'37_54_5422_5419',
+        5422
 			],
 			[
 				'https://media.guim.co.uk/7491ae2cb948d91ca71334cd6a9eeb83cbde6615/149_295_4923_4920/4923.jpg',
 				'149_295_4923_4920',
+        4923
 			],
 			[
 				'https://media.guim.co.uk/d7964a461c5ce4449395da3ee800965b4cb252b7/705_779_3876_3873/3876.jpg',
 				'705_779_3876_3873',
+        3876
 			],
       [
         'https://media.guim.co.uk/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/2000.jpg',
-        '258_0_7328_4400'
+        '258_0_7328_4400',
+        7328
       ]
-		];
+		] as const;
 
-		urlsToAssert.forEach(([url, cropId]) => assertCropId(url, cropId));
+		cropDataToAssert.forEach(([url, cropId, width]) => assertCropId(url, cropId, width));
 	});
 
 	it('should not give a crop id for a non-image URL with the same number of path segments', () => {
 		expect(
-			extractCropIdFromGuimUrl(
+			extractCropDataFromGuimUrl(
 				'https://another-url.co.uk/some-other-id/a-third-id/2000.jpg',
 			),
 		).toBe(undefined);
 	});
 
 	it('should not give a crop id for a non-image URL', () => {
-		expect(extractCropIdFromGuimUrl('https://google.com')).toBe(undefined);
+		expect(extractCropDataFromGuimUrl('https://google.com')).toBe(undefined);
 	});
 });

--- a/lib/recipes-data/src/lib/utils.test.ts
+++ b/lib/recipes-data/src/lib/utils.test.ts
@@ -19,69 +19,80 @@ describe('calculateChecksum', () => {
 });
 
 describe('extractCropIdFromGuimUrl', () => {
-	const assertCropId = (url: string, cropId: string, width: number) =>
-		expect(extractCropDataFromGuimUrl(url)).toEqual({ cropId, width });
+	const assertCropId = (url: string, mediaId: string, cropId: string, width: number) =>
+		expect(extractCropDataFromGuimUrl(url)).toEqual({ mediaId, cropId, width });
 
 	it('should find a crop id', () => {
 		const cropDataToAssert = [
 			[
 				'https://media.guim.co.uk/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/2000.jpg',
+        '902a2c387ba62c49ad7553c2712eb650e73eb5b2',
 				'258_0_7328_4400',
         7328,
 			],
 			[
 				'https://media.guim.co.uk/7f27c01fda5284d609a26ad4acb28443241ec6b3/5_2110_2299_1379/1000.jpg',
+        '7f27c01fda5284d609a26ad4acb28443241ec6b3',
 				'5_2110_2299_1379',
         2299
 			],
 			[
 				'https://media.guim.co.uk/13d94f7cf33f17a22da3d93a121623899e7da76e/0_0_3713_4378/1696.jpg',
+        '13d94f7cf33f17a22da3d93a121623899e7da76e',
 				'0_0_3713_4378',
         3713
 			],
 			[
 				'https://media.guim.co.uk/affead41f14556fa03c18391aceae2ac8a5a9449/0_0_4000_5097/1570.jpg',
+        'affead41f14556fa03c18391aceae2ac8a5a9449',
 				'0_0_4000_5097',
         4000
 			],
 			[
 				'https://media.guim.co.uk/a1212c7bc9ddc45a79d274ee12b4fdc724c8a022/0_456_4000_5225/1531.jpg',
+        'a1212c7bc9ddc45a79d274ee12b4fdc724c8a022',
 				'0_456_4000_5225',
         4000
 			],
 			[
 				'https://media.guim.co.uk/0204e0aa54caa8687a6627d6426fe06c38406f57/4002_593_3975_4970/1600.jpg',
+        '0204e0aa54caa8687a6627d6426fe06c38406f57',
 				'4002_593_3975_4970',
         3975
 			],
 			[
 				'https://media.guim.co.uk/7ca187c030131b5db1c335688044f379210a78bc/0_0_6426_5086/2000.jpg',
+        '7ca187c030131b5db1c335688044f379210a78bc',
 				'0_0_6426_5086',
         6426
 			],
 			[
 				' https://media.guim.co.uk/945038b08cdf48ecc21de52d1c75a34c85bbfc92/37_54_5422_5419/5422.jpg',
+        '945038b08cdf48ecc21de52d1c75a34c85bbfc92',
 				'37_54_5422_5419',
         5422
 			],
 			[
 				'https://media.guim.co.uk/7491ae2cb948d91ca71334cd6a9eeb83cbde6615/149_295_4923_4920/4923.jpg',
+        '7491ae2cb948d91ca71334cd6a9eeb83cbde6615',
 				'149_295_4923_4920',
         4923
 			],
 			[
 				'https://media.guim.co.uk/d7964a461c5ce4449395da3ee800965b4cb252b7/705_779_3876_3873/3876.jpg',
+        'd7964a461c5ce4449395da3ee800965b4cb252b7',
 				'705_779_3876_3873',
         3876
 			],
       [
         'https://media.guim.co.uk/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/2000.jpg',
+        '902a2c387ba62c49ad7553c2712eb650e73eb5b2',
         '258_0_7328_4400',
         7328
       ]
 		] as const;
 
-		cropDataToAssert.forEach(([url, cropId, width]) => assertCropId(url, cropId, width));
+		cropDataToAssert.forEach(([url, mediaId, cropId, width]) => assertCropId(url, mediaId, cropId, width));
 	});
 
 	it('should not give a crop id for a non-image URL with the same number of path segments', () => {

--- a/lib/recipes-data/src/lib/utils.test.ts
+++ b/lib/recipes-data/src/lib/utils.test.ts
@@ -19,80 +19,99 @@ describe('calculateChecksum', () => {
 });
 
 describe('extractCropIdFromGuimUrl', () => {
-	const assertCropId = (url: string, mediaId: string, cropId: string, width: number) =>
+	const assertCropId = (
+		url: string,
+		mediaId: string,
+		cropId: string,
+		width: number,
+	) =>
 		expect(extractCropDataFromGuimUrl(url)).toEqual({ mediaId, cropId, width });
 
 	it('should find a crop id', () => {
 		const cropDataToAssert = [
 			[
 				'https://media.guim.co.uk/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/2000.jpg',
-        '902a2c387ba62c49ad7553c2712eb650e73eb5b2',
+				'902a2c387ba62c49ad7553c2712eb650e73eb5b2',
 				'258_0_7328_4400',
-        7328,
+				7328,
 			],
 			[
 				'https://media.guim.co.uk/7f27c01fda5284d609a26ad4acb28443241ec6b3/5_2110_2299_1379/1000.jpg',
-        '7f27c01fda5284d609a26ad4acb28443241ec6b3',
+				'7f27c01fda5284d609a26ad4acb28443241ec6b3',
 				'5_2110_2299_1379',
-        2299
+				2299,
 			],
 			[
 				'https://media.guim.co.uk/13d94f7cf33f17a22da3d93a121623899e7da76e/0_0_3713_4378/1696.jpg',
-        '13d94f7cf33f17a22da3d93a121623899e7da76e',
+				'13d94f7cf33f17a22da3d93a121623899e7da76e',
 				'0_0_3713_4378',
-        3713
+				3713,
 			],
 			[
 				'https://media.guim.co.uk/affead41f14556fa03c18391aceae2ac8a5a9449/0_0_4000_5097/1570.jpg',
-        'affead41f14556fa03c18391aceae2ac8a5a9449',
+				'affead41f14556fa03c18391aceae2ac8a5a9449',
 				'0_0_4000_5097',
-        4000
+				4000,
 			],
 			[
 				'https://media.guim.co.uk/a1212c7bc9ddc45a79d274ee12b4fdc724c8a022/0_456_4000_5225/1531.jpg',
-        'a1212c7bc9ddc45a79d274ee12b4fdc724c8a022',
+				'a1212c7bc9ddc45a79d274ee12b4fdc724c8a022',
 				'0_456_4000_5225',
-        4000
+				4000,
 			],
 			[
 				'https://media.guim.co.uk/0204e0aa54caa8687a6627d6426fe06c38406f57/4002_593_3975_4970/1600.jpg',
-        '0204e0aa54caa8687a6627d6426fe06c38406f57',
+				'0204e0aa54caa8687a6627d6426fe06c38406f57',
 				'4002_593_3975_4970',
-        3975
+				3975,
 			],
 			[
 				'https://media.guim.co.uk/7ca187c030131b5db1c335688044f379210a78bc/0_0_6426_5086/2000.jpg',
-        '7ca187c030131b5db1c335688044f379210a78bc',
+				'7ca187c030131b5db1c335688044f379210a78bc',
 				'0_0_6426_5086',
-        6426
+				6426,
 			],
 			[
 				' https://media.guim.co.uk/945038b08cdf48ecc21de52d1c75a34c85bbfc92/37_54_5422_5419/5422.jpg',
-        '945038b08cdf48ecc21de52d1c75a34c85bbfc92',
+				'945038b08cdf48ecc21de52d1c75a34c85bbfc92',
 				'37_54_5422_5419',
-        5422
+				5422,
 			],
 			[
 				'https://media.guim.co.uk/7491ae2cb948d91ca71334cd6a9eeb83cbde6615/149_295_4923_4920/4923.jpg',
-        '7491ae2cb948d91ca71334cd6a9eeb83cbde6615',
+				'7491ae2cb948d91ca71334cd6a9eeb83cbde6615',
 				'149_295_4923_4920',
-        4923
+				4923,
 			],
 			[
 				'https://media.guim.co.uk/d7964a461c5ce4449395da3ee800965b4cb252b7/705_779_3876_3873/3876.jpg',
-        'd7964a461c5ce4449395da3ee800965b4cb252b7',
+				'd7964a461c5ce4449395da3ee800965b4cb252b7',
 				'705_779_3876_3873',
-        3876
+				3876,
+			],
+			[
+				'https://media.guim.co.uk/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/2000.jpg',
+				'902a2c387ba62c49ad7553c2712eb650e73eb5b2',
+				'258_0_7328_4400',
+				7328,
+			],
+			[
+				'https://media-origin.test.dev-guim.co.uk/db8f3a6b81112d50a37f7ea79259d3f0d97a0642/0_0_2448_3264/master/2448.jpg?width=1600&dpr=1&s=none',
+				'db8f3a6b81112d50a37f7ea79259d3f0d97a0642',
+				'0_0_2448_3264',
+				2448,
 			],
       [
-        'https://media.guim.co.uk/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/2000.jpg',
-        '902a2c387ba62c49ad7553c2712eb650e73eb5b2',
-        '258_0_7328_4400',
-        7328
+        'https://s3-eu-west-1.amazonaws.com/media-origin.test.dev-guim.co.uk/db8f3a6b81112d50a37f7ea79259d3f0d97a0642/0_0_2448_3264/2448.jpg',
+        'db8f3a6b81112d50a37f7ea79259d3f0d97a0642',
+				'0_0_2448_3264',
+				2448,
       ]
 		] as const;
 
-		cropDataToAssert.forEach(([url, mediaId, cropId, width]) => assertCropId(url, mediaId, cropId, width));
+		cropDataToAssert.forEach(([url, mediaId, cropId, width]) =>
+			assertCropId(url, mediaId, cropId, width),
+		);
 	});
 
 	it('should not give a crop id for a non-image URL with the same number of path segments', () => {

--- a/lib/recipes-data/src/lib/utils.ts
+++ b/lib/recipes-data/src/lib/utils.ts
@@ -41,7 +41,7 @@ export const extractCropDataFromGuimUrl = (
 	url: string,
 ): { mediaId: string; cropId: string; width: number } | undefined => {
 	const match = url.match(
-		/https:\/\/.*?\/(?<mediaId>.*?)\/(?<cropId>\d{1,4}_\d{1,4}_(?<width>\d{1,4})_\d{1,4})\/(?<fileName>.*?)$/,
+		/https:\/\/.*\/(?<mediaId>.*?)\/(?<cropId>\d{1,4}_\d{1,4}_(?<width>\d{1,4})_\d{1,4})\/(?<fileName>.*?)$/,
 	);
 
 	if (!match?.groups) {

--- a/lib/recipes-data/src/lib/utils.ts
+++ b/lib/recipes-data/src/lib/utils.ts
@@ -39,22 +39,23 @@ export function nowTime():Date {
 
 export const extractCropDataFromGuimUrl = (
 	url: string,
-): { cropId: string; width: number } | undefined => {
+): { mediaId: string; cropId: string; width: number } | undefined => {
 	const match = url.match(
-		/https:\/\/.*?\/(?<id>.*?)\/(?<cropId>\d{1,4}_\d{1,4}_(?<width>\d{1,4})_\d{1,4})\/(?<fileName>.*?)$/,
+		/https:\/\/.*?\/(?<mediaId>.*?)\/(?<cropId>\d{1,4}_\d{1,4}_(?<width>\d{1,4})_\d{1,4})\/(?<fileName>.*?)$/,
 	);
 
 	if (!match?.groups) {
 		return;
 	}
 
-	const { cropId, width } = match.groups;
+	const { mediaId, cropId, width } = match.groups;
 
-	if (!cropId || !width) {
+	if (!mediaId || !cropId || !width) {
 		return;
 	}
 
 	return {
+    mediaId,
 		cropId,
 		width: parseInt(width),
 	};

--- a/lib/recipes-data/src/lib/utils.ts
+++ b/lib/recipes-data/src/lib/utils.ts
@@ -37,7 +37,25 @@ export function nowTime():Date {
   return new Date();
 }
 
-export const extractCropIdFromGuimUrl = (url: string): string | undefined =>
-	url.match(
-		/https:\/\/.*?\/(?<id>.*?)\/(?<cropId>\d{1,4}_\d{1,4}_\d{1,4}_\d{1,4})\/(?<fileName>.*?)$/,
-	)?.groups?.cropId;
+export const extractCropDataFromGuimUrl = (
+	url: string,
+): { cropId: string; width: number } | undefined => {
+	const match = url.match(
+		/https:\/\/.*?\/(?<id>.*?)\/(?<cropId>\d{1,4}_\d{1,4}_(?<width>\d{1,4})_\d{1,4})\/(?<fileName>.*?)$/,
+	);
+
+	if (!match?.groups) {
+		return;
+	}
+
+	const { cropId, width } = match.groups;
+
+	if (!cropId || !width) {
+		return;
+	}
+
+	return {
+		cropId,
+		width: parseInt(width),
+	};
+};


### PR DESCRIPTION
## What does this change?

This PR corrects some faulty logic that means a few recipe image urls are giving 404s.

## Why?

At the moment, in our image resizer URLs transform (see #27), we're using the `/master` object path, which only contains the full-size image – but we're not using the master crop width to determine the URL. For example, at the moment we generate https://i.guim.co.uk/img/media/7f96c515c4e320b8ded848f23ffdef8bd311fcad/245_1381_2750_2751/master/2000.jpg?width=1600&dpr=1&s=none, because the `width` property of the image object is `2000`, but we should generate https://i.guim.co.uk/img/media/7f96c515c4e320b8ded848f23ffdef8bd311fcad/245_1381_2750_2751/master/2750.jpg?width=1600&dpr=1&s=none.

This mostly works, because VCL has a fallback when it can't find the master – it will try progressively smaller crop sizes, based on the aspect ratio it derives from the crop ID (format `x_y_width_height`, e.g. `245_1381_2750_2751` above) – [VCL here.](https://github.com/guardian/fastly-image-service/blob/34399e065bc85b8ca4d5adeeca02b4b6404eaa98/fastly-io_guim_co_uk/src/main/resources/varnish/main.vcl#L161) However, in the image URL above, the image is not quite square.

This means the fastly image resizer assumes an aspect ratio that is not _quite_ 1:1, and looks for an image in the crops bucket called `1999.jpg`, which doesn't exist.

To fix, we get the master width from the crop id in the URL, and use that, together with the `/master` object path, to look for the right master image every time.

This PR also avoids exercising failover logic when we are missing a `width` or `cropId` property in the image object – we do not use those properties any more, instead deriving everything from the image URL.

## How to test

- The automated tests should pass. I've adjusted the original transform tests to account for the new behaviour, and added new data to cover extracting the relevant params from the image url.
- Run a reindex (#30) in CODE. Image URLs should work as expected. Running the same code in PROD should correct a few recipes with known problems – e.g. at least one of the images in [1](https://recipes.guardianapis.com/api/content/by-uid/961c127e986b4a0e95aa358d3e62cf63), [2](https://recipes.guardianapis.com/api/content/by-uid/d577a532513aa0a6030b4e72dc03eb5b326b586d), [3](https://recipes.guardianapis.com/api/content/by-uid/838ccd441ce422c71a6169453180cea9aa0b6e97) are currently broken. (You'll need an API key for recipes-backend for these links, happy to pair to create one.)
- We can test images with https://github.com/guardian/recipe-tools/pull/5. The above pieces are now fixed!

```
Recipe 961c127e986b4a0e95aa358d3e62cf63
Featured image https://i.guim.co.uk/img/media/7f96c515c4e320b8ded848f23ffdef8bd311fcad/0_470_3761_4702/master/3761.jpg?width=1600&dpr=1&s=none: 200
Preview image https://i.guim.co.uk/img/media/7f96c515c4e320b8ded848f23ffdef8bd311fcad/245_1381_2750_2751/master/2750.jpg?width=1600&dpr=1&s=none: 200
Recipe d577a532513aa0a6030b4e72dc03eb5b326b586d
Featured image https://i.guim.co.uk/img/media/a51327900002017a5f09af4b0c711d164a655e4f/0_888_3731_3731/master/3731.jpg?width=1600&dpr=1&s=none: 200
Preview image https://i.guim.co.uk/img/media/a51327900002017a5f09af4b0c711d164a655e4f/0_888_3731_3731/master/3731.jpg?width=1600&dpr=1&s=none: 200
Recipe 838ccd441ce422c71a6169453180cea9aa0b6e97
Featured image https://i.guim.co.uk/img/media/652ac636ff7f245f37d135ccc68ead315e2a289b/0_854_3731_3731/master/3731.jpg?width=1600&dpr=1&s=none: 200
Preview image https://i.guim.co.uk/img/media/652ac636ff7f245f37d135ccc68ead315e2a289b/0_854_3731_3731/master/3731.jpg?width=1600&dpr=1&s=none: 200
```