### PR TITLE
Respect image extension when generating fastly URLs

### DIFF
--- a/lib/recipes-data/src/lib/transform.test.ts
+++ b/lib/recipes-data/src/lib/transform.test.ts
@@ -140,6 +140,29 @@ describe('Recipe transforms', () => {
 			);
 		});
 
+    it('should respect image extensions', () => {
+			const recipeWithFeaturedImageWithoutCropId = {
+				...recipes[0],
+				featuredImage: {
+          ...recipes[0].featuredImage,
+          url: 'https://media.guim.co.uk/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/2000.png'
+        },
+
+			};
+
+			const transformedRecipeReference = replaceImageUrlsWithFastly(
+				recipeWithFeaturedImageWithoutCropId,
+			);
+
+			assertImageUrls(
+				recipes[0],
+				transformedRecipeReference,
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.png?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
+			);
+		});
+
+
 		it("should backfill the preview image if there isn't one", () => {
 			const { previewImage: _, ...recipeWithoutPreview } = recipes[0];
 

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -8,7 +8,8 @@ const getFastlyUrl = (
 	dpr: number,
 	desiredWidth: number,
 	originalWidth: number,
-) => `https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.jpg?width=${desiredWidth}&dpr=${dpr}&s=none`;
+  extension: string
+) => `https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.${extension}?width=${desiredWidth}&dpr=${dpr}&s=none`;
 
 export const replaceFastlyUrl = (
 	recipeId: string,
@@ -25,11 +26,11 @@ export const replaceFastlyUrl = (
 		return image;
 	}
 
-	const { mediaId, cropId, width } = cropData;
+	const { mediaId, cropId, width, extension } = cropData;
 
 	return {
 		...image,
-		url: getFastlyUrl(mediaId, cropId, dpr, desiredWidth, width),
+		url: getFastlyUrl(mediaId, cropId, dpr, desiredWidth, width, extension),
 	};
 };
 

--- a/lib/recipes-data/src/lib/utils.test.ts
+++ b/lib/recipes-data/src/lib/utils.test.ts
@@ -24,94 +24,120 @@ describe('extractCropIdFromGuimUrl', () => {
 		mediaId: string,
 		cropId: string,
 		width: number,
+		extension: string,
 	) =>
-		expect(extractCropDataFromGuimUrl(url)).toEqual({ mediaId, cropId, width });
+		expect(extractCropDataFromGuimUrl(url)).toEqual({
+			mediaId,
+			cropId,
+			width,
+			extension,
+		});
 
-	it('should find a crop id', () => {
-		const cropDataToAssert = [
-			[
-				'https://media.guim.co.uk/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/2000.jpg',
-				'902a2c387ba62c49ad7553c2712eb650e73eb5b2',
-				'258_0_7328_4400',
-				7328,
-			],
-			[
-				'https://media.guim.co.uk/7f27c01fda5284d609a26ad4acb28443241ec6b3/5_2110_2299_1379/1000.jpg',
-				'7f27c01fda5284d609a26ad4acb28443241ec6b3',
-				'5_2110_2299_1379',
-				2299,
-			],
-			[
-				'https://media.guim.co.uk/13d94f7cf33f17a22da3d93a121623899e7da76e/0_0_3713_4378/1696.jpg',
-				'13d94f7cf33f17a22da3d93a121623899e7da76e',
-				'0_0_3713_4378',
-				3713,
-			],
-			[
-				'https://media.guim.co.uk/affead41f14556fa03c18391aceae2ac8a5a9449/0_0_4000_5097/1570.jpg',
-				'affead41f14556fa03c18391aceae2ac8a5a9449',
-				'0_0_4000_5097',
-				4000,
-			],
-			[
-				'https://media.guim.co.uk/a1212c7bc9ddc45a79d274ee12b4fdc724c8a022/0_456_4000_5225/1531.jpg',
-				'a1212c7bc9ddc45a79d274ee12b4fdc724c8a022',
-				'0_456_4000_5225',
-				4000,
-			],
-			[
-				'https://media.guim.co.uk/0204e0aa54caa8687a6627d6426fe06c38406f57/4002_593_3975_4970/1600.jpg',
-				'0204e0aa54caa8687a6627d6426fe06c38406f57',
-				'4002_593_3975_4970',
-				3975,
-			],
-			[
-				'https://media.guim.co.uk/7ca187c030131b5db1c335688044f379210a78bc/0_0_6426_5086/2000.jpg',
-				'7ca187c030131b5db1c335688044f379210a78bc',
-				'0_0_6426_5086',
-				6426,
-			],
-			[
-				' https://media.guim.co.uk/945038b08cdf48ecc21de52d1c75a34c85bbfc92/37_54_5422_5419/5422.jpg',
-				'945038b08cdf48ecc21de52d1c75a34c85bbfc92',
-				'37_54_5422_5419',
-				5422,
-			],
-			[
-				'https://media.guim.co.uk/7491ae2cb948d91ca71334cd6a9eeb83cbde6615/149_295_4923_4920/4923.jpg',
-				'7491ae2cb948d91ca71334cd6a9eeb83cbde6615',
-				'149_295_4923_4920',
-				4923,
-			],
-			[
-				'https://media.guim.co.uk/d7964a461c5ce4449395da3ee800965b4cb252b7/705_779_3876_3873/3876.jpg',
-				'd7964a461c5ce4449395da3ee800965b4cb252b7',
-				'705_779_3876_3873',
-				3876,
-			],
-			[
-				'https://media.guim.co.uk/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/2000.jpg',
-				'902a2c387ba62c49ad7553c2712eb650e73eb5b2',
-				'258_0_7328_4400',
-				7328,
-			],
-			[
-				'https://media-origin.test.dev-guim.co.uk/db8f3a6b81112d50a37f7ea79259d3f0d97a0642/0_0_2448_3264/master/2448.jpg?width=1600&dpr=1&s=none',
-				'db8f3a6b81112d50a37f7ea79259d3f0d97a0642',
-				'0_0_2448_3264',
-				2448,
-			],
-      [
-        'https://s3-eu-west-1.amazonaws.com/media-origin.test.dev-guim.co.uk/db8f3a6b81112d50a37f7ea79259d3f0d97a0642/0_0_2448_3264/2448.jpg',
-        'db8f3a6b81112d50a37f7ea79259d3f0d97a0642',
-				'0_0_2448_3264',
-				2448,
-      ]
-		] as const;
+	const cropDataToAssert = [
+		[
+			'https://media.guim.co.uk/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/2000.jpg',
+			'902a2c387ba62c49ad7553c2712eb650e73eb5b2',
+			'258_0_7328_4400',
+			7328,
+			'jpg',
+		],
+		[
+			'https://media.guim.co.uk/7f27c01fda5284d609a26ad4acb28443241ec6b3/5_2110_2299_1379/1000.jpg',
+			'7f27c01fda5284d609a26ad4acb28443241ec6b3',
+			'5_2110_2299_1379',
+			2299,
+			'jpg',
+		],
+		[
+			'https://media.guim.co.uk/13d94f7cf33f17a22da3d93a121623899e7da76e/0_0_3713_4378/1696.jpg',
+			'13d94f7cf33f17a22da3d93a121623899e7da76e',
+			'0_0_3713_4378',
+			3713,
+			'jpg',
+		],
+		[
+			'https://media.guim.co.uk/affead41f14556fa03c18391aceae2ac8a5a9449/0_0_4000_5097/1570.jpg',
+			'affead41f14556fa03c18391aceae2ac8a5a9449',
+			'0_0_4000_5097',
+			4000,
+			'jpg',
+		],
+		[
+			'https://media.guim.co.uk/a1212c7bc9ddc45a79d274ee12b4fdc724c8a022/0_456_4000_5225/1531.jpg',
+			'a1212c7bc9ddc45a79d274ee12b4fdc724c8a022',
+			'0_456_4000_5225',
+			4000,
+			'jpg',
+		],
+		[
+			'https://media.guim.co.uk/0204e0aa54caa8687a6627d6426fe06c38406f57/4002_593_3975_4970/1600.jpg',
+			'0204e0aa54caa8687a6627d6426fe06c38406f57',
+			'4002_593_3975_4970',
+			3975,
+			'jpg',
+		],
+		[
+			'https://media.guim.co.uk/7ca187c030131b5db1c335688044f379210a78bc/0_0_6426_5086/2000.jpg',
+			'7ca187c030131b5db1c335688044f379210a78bc',
+			'0_0_6426_5086',
+			6426,
+			'jpg',
+		],
+		[
+			' https://media.guim.co.uk/945038b08cdf48ecc21de52d1c75a34c85bbfc92/37_54_5422_5419/5422.jpg',
+			'945038b08cdf48ecc21de52d1c75a34c85bbfc92',
+			'37_54_5422_5419',
+			5422,
+			'jpg',
+		],
+		[
+			'https://media.guim.co.uk/7491ae2cb948d91ca71334cd6a9eeb83cbde6615/149_295_4923_4920/4923.jpg',
+			'7491ae2cb948d91ca71334cd6a9eeb83cbde6615',
+			'149_295_4923_4920',
+			4923,
+			'jpg',
+		],
+		[
+			'https://media.guim.co.uk/d7964a461c5ce4449395da3ee800965b4cb252b7/705_779_3876_3873/3876.jpg',
+			'd7964a461c5ce4449395da3ee800965b4cb252b7',
+			'705_779_3876_3873',
+			3876,
+			'jpg',
+		],
+		[
+			'https://media.guim.co.uk/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/2000.jpg',
+			'902a2c387ba62c49ad7553c2712eb650e73eb5b2',
+			'258_0_7328_4400',
+			7328,
+			'jpg',
+		],
+		[
+			'https://media-origin.test.dev-guim.co.uk/db8f3a6b81112d50a37f7ea79259d3f0d97a0642/0_0_2448_3264/master/2448.jpg?width=1600&dpr=1&s=none',
+			'db8f3a6b81112d50a37f7ea79259d3f0d97a0642',
+			'0_0_2448_3264',
+			2448,
+			'jpg',
+		],
+		[
+			'https://s3-eu-west-1.amazonaws.com/media-origin.test.dev-guim.co.uk/db8f3a6b81112d50a37f7ea79259d3f0d97a0642/0_0_2448_3264/2448.jpg',
+			'db8f3a6b81112d50a37f7ea79259d3f0d97a0642',
+			'0_0_2448_3264',
+			2448,
+			'jpg',
+		],
+		[
+			'https://media.guim.co.uk/310f1bd9bf1cc8d30afaca212e77aec07bf7e753/0_406_4259_4701/1812.png',
+			'310f1bd9bf1cc8d30afaca212e77aec07bf7e753',
+			'0_406_4259_4701',
+			4259,
+			'png',
+		],
+	] as const;
 
-		cropDataToAssert.forEach(([url, mediaId, cropId, width]) =>
-			assertCropId(url, mediaId, cropId, width),
-		);
+	cropDataToAssert.forEach(([url, mediaId, cropId, width, extension]) => {
+		it(`should find a crop id for ${url}`, () => {
+			assertCropId(url, mediaId, cropId, width, extension);
+		});
 	});
 
 	it('should not give a crop id for a non-image URL with the same number of path segments', () => {

--- a/lib/recipes-data/src/lib/utils.ts
+++ b/lib/recipes-data/src/lib/utils.ts
@@ -39,18 +39,19 @@ export function nowTime():Date {
 
 export const extractCropDataFromGuimUrl = (
 	url: string,
-): { mediaId: string; cropId: string; width: number } | undefined => {
+): { mediaId: string; cropId: string; width: number; extension: string } | undefined => {
+  // Some capturing groups here are not needed – they're added to make the regex a bit more comprehensible.
 	const match = url.match(
-		/https:\/\/.*\/(?<mediaId>.*?)\/(?<cropId>\d{1,4}_\d{1,4}_(?<width>\d{1,4})_\d{1,4})\/(?<fileName>.*?)$/,
+		/https:\/\/.*\/(?<mediaId>.*?)\/(?<cropId>\d{1,4}_\d{1,4}_(?<width>\d{1,4})_\d{1,4})\/(?<fileName>.*?)\.(?<extension>.*?)(?<queryParams>\?.*)?$/,
 	);
 
 	if (!match?.groups) {
 		return;
 	}
 
-	const { mediaId, cropId, width } = match.groups;
+	const { mediaId, cropId, width, extension } = match.groups;
 
-	if (!mediaId || !cropId || !width) {
+	if (!mediaId || !cropId || !width || !extension) {
 		return;
 	}
 
@@ -58,5 +59,6 @@ export const extractCropDataFromGuimUrl = (
     mediaId,
 		cropId,
 		width: parseInt(width),
+    extension
 	};
 };


### PR DESCRIPTION
## What does this change?

Respects the image extension when generating Fastly URLs.

Only spotted by scraping all our image links with https://github.com/guardian/recipe-tools/pull/5 and finding the one image in ~2000 that was a `.png` 🤦 

## How to test

- The automated tests should pass. I've added two to cover this case.
- Once merged, reindex recipe `6f8d1bcb6fab4d98ab138e35ca542478` in PROD. Both its featured and preview image should no longer 404.