### PR TITLE
Support timed "launch" of curation data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,5 @@ jobs:
               - dist/lambda/recipes-responder.zip
             recipes-backend-rest-endpoints:
               - dist/lambda/rest-endpoints.zip
+            recipes-publish-todays-curation:
+              - dist/lambda/publish-todays-curation.zip

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1053,6 +1053,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "Environment": {
           "Variables": {
             "APP": "recipes-publish-todays-curation",
+            "CONTENT_URL_BASE": "recipes.guardianapis.com",
             "FASTLY_API_KEY": {
               "Ref": "fastlyKey",
             },

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -352,7 +352,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         },
         "FunctionName": "recipes-backend-rest-endpoints-TEST",
         "Handler": "main.handler",
-        "MemorySize": 128,
+        "MemorySize": 256,
         "Role": {
           "Fn::GetAtt": [
             "LambdaServiceRoleA8ED4D3B",
@@ -1066,7 +1066,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         },
         "FunctionName": "PublishTodaysCuration-TEST",
         "Handler": "main.handler",
-        "MemorySize": 128,
+        "MemorySize": 256,
         "Role": {
           "Fn::GetAtt": [
             "PublishTodaysCurationServiceRoleBDC7AE8F",

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1048,11 +1048,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "content-api/TEST/recipies-publish-todays-curation/publish-todays-curation.zip",
+          "S3Key": "content-api/TEST/recipes-publish-todays-curation/publish-todays-curation.zip",
         },
         "Environment": {
           "Variables": {
-            "APP": "recipies-publish-todays-curation",
+            "APP": "recipes-publish-todays-curation",
             "FASTLY_API_KEY": {
               "Ref": "fastlyKey",
             },
@@ -1076,7 +1076,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "Tags": [
           {
             "Key": "App",
-            "Value": "recipies-publish-todays-curation",
+            "Value": "recipes-publish-todays-curation",
           },
           {
             "Key": "gu:cdk:version",
@@ -1168,7 +1168,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "Tags": [
           {
             "Key": "App",
-            "Value": "recipies-publish-todays-curation",
+            "Value": "recipes-publish-todays-curation",
           },
           {
             "Key": "gu:cdk:version",
@@ -1268,7 +1268,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/content-api/TEST/recipies-publish-todays-curation/publish-todays-curation.zip",
+                      "/content-api/TEST/recipes-publish-todays-curation/publish-todays-curation.zip",
                     ],
                   ],
                 },
@@ -1289,7 +1289,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/content-api/recipies-publish-todays-curation",
+                    ":parameter/TEST/content-api/recipes-publish-todays-curation",
                   ],
                 ],
               },
@@ -1312,7 +1312,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/content-api/recipies-publish-todays-curation/*",
+                    ":parameter/TEST/content-api/recipes-publish-todays-curation/*",
                   ],
                 ],
               },

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1235,6 +1235,16 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               },
             },
             {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "staticstaticServing53194089",
+                  "Arn",
+                ],
+              },
+            },
+            {
               "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -12,6 +12,7 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       "GuParameter",
       "GuKinesisLambdaExperimental",
       "GuApiLambda",
+      "GuScheduledLambda",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -77,6 +78,216 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "BucketNotificationsHandler050a0587b7544547bf325f094a3db8347ECC3691": {
+      "DependsOn": [
+        "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleDefaultPolicy2CF63D36",
+        "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleB6FB88EC",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "import boto3  # type: ignore
+import json
+import logging
+import urllib.request
+
+s3 = boto3.client("s3")
+
+EVENTBRIDGE_CONFIGURATION = 'EventBridgeConfiguration'
+
+CONFIGURATION_TYPES = ["TopicConfigurations", "QueueConfigurations", "LambdaFunctionConfigurations"]
+
+def handler(event: dict, context):
+  response_status = "SUCCESS"
+  error_message = ""
+  try:
+    props = event["ResourceProperties"]
+    bucket = props["BucketName"]
+    notification_configuration = props["NotificationConfiguration"]
+    request_type = event["RequestType"]
+    managed = props.get('Managed', 'true').lower() == 'true'
+    stack_id = event['StackId']
+
+    if managed:
+      config = handle_managed(request_type, notification_configuration)
+    else:
+      config = handle_unmanaged(bucket, stack_id, request_type, notification_configuration)
+
+    put_bucket_notification_configuration(bucket, config)
+  except Exception as e:
+    logging.exception("Failed to put bucket notification configuration")
+    response_status = "FAILED"
+    error_message = f"Error: {str(e)}. "
+  finally:
+    submit_response(event, context, response_status, error_message)
+
+def handle_managed(request_type, notification_configuration):
+  if request_type == 'Delete':
+    return {}
+  return notification_configuration
+
+def handle_unmanaged(bucket, stack_id, request_type, notification_configuration):
+  external_notifications = find_external_notifications(bucket, stack_id)
+
+  if request_type == 'Delete':
+    return external_notifications
+
+  def with_id(notification):
+    notification['Id'] = f"{stack_id}-{hash(json.dumps(notification, sort_keys=True))}"
+    return notification
+
+  notifications = {}
+  for t in CONFIGURATION_TYPES:
+    external = external_notifications.get(t, [])
+    incoming = [with_id(n) for n in notification_configuration.get(t, [])]
+    notifications[t] = external + incoming
+
+  if EVENTBRIDGE_CONFIGURATION in notification_configuration:
+    notifications[EVENTBRIDGE_CONFIGURATION] = notification_configuration[EVENTBRIDGE_CONFIGURATION]
+  elif EVENTBRIDGE_CONFIGURATION in external_notifications:
+    notifications[EVENTBRIDGE_CONFIGURATION] = external_notifications[EVENTBRIDGE_CONFIGURATION]
+
+  return notifications
+
+def find_external_notifications(bucket, stack_id):
+  existing_notifications = get_bucket_notification_configuration(bucket)
+  external_notifications = {}
+  for t in CONFIGURATION_TYPES:
+    external_notifications[t] = [n for n in existing_notifications.get(t, []) if not n['Id'].startswith(f"{stack_id}-")]
+
+  if EVENTBRIDGE_CONFIGURATION in existing_notifications:
+    external_notifications[EVENTBRIDGE_CONFIGURATION] = existing_notifications[EVENTBRIDGE_CONFIGURATION]
+
+  return external_notifications
+
+def get_bucket_notification_configuration(bucket):
+  return s3.get_bucket_notification_configuration(Bucket=bucket)
+
+def put_bucket_notification_configuration(bucket, notification_configuration):
+  s3.put_bucket_notification_configuration(Bucket=bucket, NotificationConfiguration=notification_configuration)
+
+def submit_response(event: dict, context, response_status: str, error_message: str):
+  response_body = json.dumps(
+    {
+      "Status": response_status,
+      "Reason": f"{error_message}See the details in CloudWatch Log Stream: {context.log_stream_name}",
+      "PhysicalResourceId": event.get("PhysicalResourceId") or event["LogicalResourceId"],
+      "StackId": event["StackId"],
+      "RequestId": event["RequestId"],
+      "LogicalResourceId": event["LogicalResourceId"],
+      "NoEcho": False,
+    }
+  ).encode("utf-8")
+  headers = {"content-type": "", "content-length": str(len(response_body))}
+  try:
+    req = urllib.request.Request(url=event["ResponseURL"], headers=headers, data=response_body, method="PUT")
+    with urllib.request.urlopen(req) as response:
+      print(response.read().decode("utf-8"))
+    print("Status code: " + response.reason)
+  except Exception as e:
+      print("send(..) failed executing request.urlopen(..): " + str(e))
+",
+        },
+        "Description": "AWS CloudFormation handler for "Custom::S3BucketNotifications" resources (@aws-cdk/aws-s3)",
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleB6FB88EC",
+            "Arn",
+          ],
+        },
+        "Runtime": "python3.9",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "content-api",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleB6FB88EC": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "content-api",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleDefaultPolicy2CF63D36": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:PutBucketNotification",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleDefaultPolicy2CF63D36",
+        "Roles": [
+          {
+            "Ref": "BucketNotificationsHandler050a0587b7544547bf325f094a3db834RoleB6FB88EC",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "DurationRuntimeAlarmC21C10E0": {
       "Properties": {
         "ActionsEnabled": true,
@@ -824,6 +1035,300 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
+    "PublishTodaysCuration6EFD9033": {
+      "DependsOn": [
+        "PublishTodaysCurationServiceRoleDefaultPolicy2854E18F",
+        "PublishTodaysCurationServiceRoleBDC7AE8F",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "content-api/TEST/recipies-publish-todays-curation/publish-todays-curation.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "recipies-publish-todays-curation",
+            "FASTLY_API_KEY": {
+              "Ref": "fastlyKey",
+            },
+            "STACK": "content-api",
+            "STAGE": "TEST",
+            "STATIC_BUCKET": {
+              "Ref": "staticstaticServing53194089",
+            },
+          },
+        },
+        "FunctionName": "PublishTodaysCuration-TEST",
+        "Handler": "main.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "PublishTodaysCurationServiceRoleBDC7AE8F",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "recipies-publish-todays-curation",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "content-api",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 10,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "PublishTodaysCurationPublishTodaysCurationcron10068F6AC9B": {
+      "Properties": {
+        "Description": "Update Feast app daily curation at midnight",
+        "ScheduleExpression": "cron(1 0 * * ? *)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "PublishTodaysCuration6EFD9033",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "PublishTodaysCurationPublishTodaysCurationcron100AllowEventRuleRecipesBackendPublishTodaysCuration6CDA0896A0786549": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "PublishTodaysCuration6EFD9033",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "PublishTodaysCurationPublishTodaysCurationcron10068F6AC9B",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "PublishTodaysCurationServiceRoleBDC7AE8F": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "recipies-publish-todays-curation",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "content-api",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "PublishTodaysCurationServiceRoleDefaultPolicy2854E18F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "*",
+              "Effect": "Deny",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "staticstaticServing53194089",
+                        "Arn",
+                      ],
+                    },
+                    "/content/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "staticstaticServing53194089",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/content-api/TEST/recipies-publish-todays-curation/publish-todays-curation.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/content-api/recipies-publish-todays-curation",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/content-api/recipies-publish-todays-curation/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PublishTodaysCurationServiceRoleDefaultPolicy2854E18F",
+        "Roles": [
+          {
+            "Ref": "PublishTodaysCurationServiceRoleBDC7AE8F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "staticcdnRead42C381A5": {
       "Properties": {
         "Tags": [
@@ -907,6 +1412,71 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
+    },
+    "staticstaticServingAllowBucketNotificationsToRecipesBackendPublishTodaysCuration6CDA0896F3EBC5C1": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "PublishTodaysCuration6EFD9033",
+            "Arn",
+          ],
+        },
+        "Principal": "s3.amazonaws.com",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId",
+        },
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "staticstaticServing53194089",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "staticstaticServingNotifications4994CB54": {
+      "DependsOn": [
+        "staticstaticServingAllowBucketNotificationsToRecipesBackendPublishTodaysCuration6CDA0896F3EBC5C1",
+      ],
+      "Properties": {
+        "BucketName": {
+          "Ref": "staticstaticServing53194089",
+        },
+        "Managed": true,
+        "NotificationConfiguration": {
+          "LambdaFunctionConfigurations": [
+            {
+              "Events": [
+                "s3:ObjectCreated:*",
+              ],
+              "Filter": {
+                "Key": {
+                  "FilterRules": [
+                    {
+                      "Name": "suffix",
+                      "Value": "curation.json",
+                    },
+                  ],
+                },
+              },
+              "LambdaFunctionArn": {
+                "Fn::GetAtt": [
+                  "PublishTodaysCuration6EFD9033",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "BucketNotificationsHandler050a0587b7544547bf325f094a3db8347ECC3691",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3BucketNotifications",
     },
     "staticstaticServingPolicyC6F5921B": {
       "Properties": {

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -174,6 +174,11 @@ export class RecipesBackend extends GuStack {
           effect: Effect.ALLOW,
           actions: ["s3:PutObject","s3:GetObject"],
           resources: [serving.staticBucket.bucketArn + "/*"]
+        }),
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["s3:ListBucket"],
+          resources: [serving.staticBucket.bucketArn]
         })
       ],
       memorySize: 128,

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -181,7 +181,7 @@ export class RecipesBackend extends GuStack {
           resources: [serving.staticBucket.bucketArn]
         })
       ],
-      memorySize: 128,
+      memorySize: 256,
       monitoringConfiguration: {
         noMonitoring: true,
       },

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -189,6 +189,7 @@ export class RecipesBackend extends GuStack {
       environment: {
         STATIC_BUCKET: serving.staticBucket.bucketName,
         FASTLY_API_KEY: fastlyKeyParam.valueAsString,
+        CONTENT_URL_BASE: contentUrlBase,
       }
     });
 

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -159,7 +159,7 @@ export class RecipesBackend extends GuStack {
     durationAlarm.addAlarmAction(new SnsAction(nonUrgentAlarmTopic));
 
     const publishTodaysCurationLambda = new GuScheduledLambda(this, "PublishTodaysCuration", {
-      app: "recipies-publish-todays-curation",
+      app: "recipes-publish-todays-curation",
       architecture: Architecture.ARM_64,
       fileName: "publish-todays-curation.zip",
       functionName: `PublishTodaysCuration-${props.stage}`,

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -1,3 +1,4 @@
+import {GuScheduledLambda} from "@guardian/cdk";
 import type {GuStackProps} from "@guardian/cdk/lib/constructs/core";
 import {GuParameter, GuStack} from "@guardian/cdk/lib/constructs/core";
 import {GuLambdaFunction} from "@guardian/cdk/lib/constructs/lambda";
@@ -6,8 +7,10 @@ import {StreamRetry} from "@guardian/cdk/lib/utils/lambda";
 import {type App, aws_sns, Duration} from "aws-cdk-lib";
 import {Alarm, ComparisonOperator, TreatMissingData, Unit} from "aws-cdk-lib/aws-cloudwatch";
 import {SnsAction} from "aws-cdk-lib/aws-cloudwatch-actions";
+import {Schedule} from "aws-cdk-lib/aws-events";
 import {Effect, PolicyStatement} from "aws-cdk-lib/aws-iam";
 import {Architecture, Runtime} from "aws-cdk-lib/aws-lambda";
+import {LambdaDestination} from "aws-cdk-lib/aws-s3-notifications";
 import {DataStore} from "./datastore";
 import {ExternalParameters} from "./external_parameters";
 import {RestEndpoints} from "./rest-endpoints";
@@ -47,6 +50,9 @@ export class RecipesBackend extends GuStack {
         })
       ]
     });
+    const externalParameters = new ExternalParameters(this, "externals");
+    //const urgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "urgent-alarm", externalParameters.urgentAlarmTopicArn.stringValue);
+    const nonUrgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "nonurgent-alarm", externalParameters.nonUrgentAlarmTopicArn.stringValue);
 
     //This is a nicer way to pick up the stream name - but CDK won't compile
     //when using the name token for the kinesis stream name below.
@@ -147,13 +153,49 @@ export class RecipesBackend extends GuStack {
         statistic: "Maximum",
         unit: Unit.MILLISECONDS
       }),
-      evaluationPeriods: 3,// when happens atleast 3 times
+      evaluationPeriods: 3,// when happens at least 3 times
     })
 
-    const externalParameters = new ExternalParameters(this, "externals");
-    //const urgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "urgent-alarm", externalParameters.urgentAlarmTopicArn.stringValue);
-    const nonUrgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "nonurgent-alarm", externalParameters.nonUrgentAlarmTopicArn.stringValue);
-    durationAlarm.addAlarmAction(new SnsAction(nonUrgentAlarmTopic))
+    durationAlarm.addAlarmAction(new SnsAction(nonUrgentAlarmTopic));
+
+    const publishTodaysCurationLambda = new GuScheduledLambda(this, "PublishTodaysCuration", {
+      app: "recipies-publish-todays-curation",
+      architecture: Architecture.ARM_64,
+      fileName: "publish-todays-curation.zip",
+      functionName: `PublishTodaysCuration-${props.stage}`,
+      handler: "main.handler",
+      initialPolicy: [
+        new PolicyStatement({
+          effect: Effect.DENY,
+          actions: ["*"],
+          resources: [serving.staticBucket.bucketArn + "/content/*"]
+        }),
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["s3:PutObject","s3:GetObject"],
+          resources: [serving.staticBucket.bucketArn + "/*"]
+        })
+      ],
+      memorySize: 128,
+      monitoringConfiguration: {
+        noMonitoring: true,
+      },
+      rules: [{
+        schedule: Schedule.cron({hour: "0", minute: "1"}),
+        description: "Update Feast app daily curation at midnight"
+      }],
+      runtime: Runtime.NODEJS_18_X,
+      timeout: Duration.seconds(10),
+      environment: {
+        STATIC_BUCKET: serving.staticBucket.bucketName,
+        FASTLY_API_KEY: fastlyKeyParam.valueAsString,
+      }
+    });
+
+    serving.staticBucket.addObjectCreatedNotification(
+      new LambdaDestination(publishTodaysCurationLambda),
+      { suffix: "curation.json", }
+    );
   }
 
 }

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -51,7 +51,6 @@ export class RecipesBackend extends GuStack {
       ]
     });
     const externalParameters = new ExternalParameters(this, "externals");
-    //const urgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "urgent-alarm", externalParameters.urgentAlarmTopicArn.stringValue);
     const nonUrgentAlarmTopic = aws_sns.Topic.fromTopicArn(this, "nonurgent-alarm", externalParameters.nonUrgentAlarmTopicArn.stringValue);
 
     //This is a nicer way to pick up the stream name - but CDK won't compile

--- a/cdk/lib/rest-endpoints.ts
+++ b/cdk/lib/rest-endpoints.ts
@@ -47,7 +47,7 @@ export class RestEndpoints extends Construct {
       fileName: "rest-endpoints.zip",
       functionName: `recipes-backend-rest-endpoints-${scope.stage}`,
       handler: "main.handler",
-      memorySize: 128,
+      memorySize: 256,
       monitoringConfiguration: {noMonitoring: true},  //for the time being
       runtime: Runtime.NODEJS_18_X,
       timeout: Duration.seconds(30),

--- a/lambda/publish-todays-curation/.eslintrc.json
+++ b/lambda/publish-todays-curation/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+	"extends": ["../../.eslintrc.json"],
+	"ignorePatterns": ["!**/*"],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}

--- a/lambda/publish-todays-curation/.eslintrc.json
+++ b/lambda/publish-todays-curation/.eslintrc.json
@@ -8,8 +8,25 @@
 		},
 		{
 			"files": ["*.ts", "*.tsx"],
-			"rules": {}
-		},
+			"rules": {},
+      "parserOptions": {
+        "project": [
+          "lambda/publish-todays-curation/tsconfig.app.json"
+        ]
+      }
+    },
+    {
+      "files": ["*.test.ts", "*.test.tsx"],
+      "parserOptions": {
+        "project": ["lambda/publish-todays-curation/tsconfig.spec.json"]
+      },
+      "rules": {
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/ban-ts-comment": "off",
+        "@typescript-eslint/prefer-ts-expect-error": "off",
+        "@typescript-eslint/no-unsafe-call": "off"
+      }
+    },
 		{
 			"files": ["*.js", "*.jsx"],
 			"rules": {}

--- a/lambda/publish-todays-curation/jest.config.ts
+++ b/lambda/publish-todays-curation/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+	displayName: 'lambda/publish-todays-curation',
+	preset: '../../jest.preset.js',
+	testEnvironment: 'node',
+	transform: {
+		'^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+	},
+	moduleFileExtensions: ['ts', 'js', 'html'],
+	coverageDirectory: '../../coverage/lambda/publish-todays-curation',
+};

--- a/lambda/publish-todays-curation/project.json
+++ b/lambda/publish-todays-curation/project.json
@@ -1,0 +1,77 @@
+{
+	"name": "lambda-publish-todays-curation",
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "lambda/publish-todays-curation/src",
+	"projectType": "application",
+	"targets": {
+		"build": {
+			"executor": "@nx/esbuild:esbuild",
+			"outputs": ["{options.outputPath}"],
+			"defaultConfiguration": "production",
+			"options": {
+				"platform": "node",
+				"outputPath": "dist/lambda/publish-todays-curation",
+				"format": ["cjs"],
+				"bundle": false,
+				"main": "lambda/publish-todays-curation/src/main.ts",
+				"tsConfig": "lambda/publish-todays-curation/tsconfig.app.json",
+				"assets": ["lambda/publish-todays-curation/src/assets"],
+				"generatePackageJson": true,
+				"esbuildOptions": {
+					"sourcemap": true,
+					"outExtension": {
+						".js": ".js"
+					}
+				}
+			},
+			"configurations": {
+				"development": {},
+				"production": {
+					"esbuildOptions": {
+						"sourcemap": false,
+						"outExtension": {
+							".js": ".js"
+						}
+					}
+				}
+			}
+		},
+		"serve": {
+			"executor": "@nx/js:node",
+			"defaultConfiguration": "development",
+			"options": {
+				"buildTarget": "lambda/publish-todays-curation:build"
+			},
+			"configurations": {
+				"development": {
+					"buildTarget": "lambda/publish-todays-curation:build:development"
+				},
+				"production": {
+					"buildTarget": "lambda/publish-todays-curation:build:production"
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": ["lambda/publish-todays-curation/**/*.ts"]
+			}
+		},
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "lambda/publish-todays-curation/jest.config.ts",
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		}
+	},
+	"tags": []
+}

--- a/lambda/publish-todays-curation/project.json
+++ b/lambda/publish-todays-curation/project.json
@@ -4,7 +4,20 @@
 	"sourceRoot": "lambda/publish-todays-curation/src",
 	"projectType": "application",
 	"targets": {
-		"build": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["zip -r ../publish-todays-curation.zip *"],
+        "cwd": "dist/lambda/publish-todays-curation"
+      },
+      "dependsOn": [
+        {
+          "projects": "self",
+          "target": "transpile"
+        }
+      ]
+    },
+		"transpile": {
 			"executor": "@nx/esbuild:esbuild",
 			"outputs": ["{options.outputPath}"],
 			"defaultConfiguration": "production",
@@ -12,11 +25,13 @@
 				"platform": "node",
 				"outputPath": "dist/lambda/publish-todays-curation",
 				"format": ["cjs"],
-				"bundle": false,
+        "external": ["@aws-sdk/*"],
+				"bundle": true,
 				"main": "lambda/publish-todays-curation/src/main.ts",
 				"tsConfig": "lambda/publish-todays-curation/tsconfig.app.json",
 				"assets": ["lambda/publish-todays-curation/src/assets"],
-				"generatePackageJson": true,
+        "generatePackageJson": true,
+        "thirdParty": true,
 				"esbuildOptions": {
 					"sourcemap": true,
 					"outExtension": {

--- a/lambda/publish-todays-curation/src/config.ts
+++ b/lambda/publish-todays-curation/src/config.ts
@@ -1,4 +1,5 @@
-export const Bucket = process.env["CONTENT_BUCKET"];
+export const Bucket = process.env["STATIC_BUCKET"];
 
 export const Today = new Date();
 
+export const FastlyApiKey = process.env["FASTLY_API_KEY"];

--- a/lambda/publish-todays-curation/src/config.ts
+++ b/lambda/publish-todays-curation/src/config.ts
@@ -1,0 +1,4 @@
+export const Bucket = process.env["CONTENT_BUCKET"];
+
+export const Today = new Date();
+

--- a/lambda/publish-todays-curation/src/curation.test.ts
+++ b/lambda/publish-todays-curation/src/curation.test.ts
@@ -123,7 +123,7 @@ describe("curation.validateCurationData", ()=> {
     expect(arg.input.Key).toEqual("some-region/some-variant/2024-03-03/curation.json");
   });
 
-  it("curation.should pass on any other error as an exception", async () => {
+  it("should pass on any other error as an exception", async () => {
     s3Mock.on(HeadObjectCommand).rejects(new S3ServiceException({
       $fault: "server",
       name: "",

--- a/lambda/publish-todays-curation/src/curation.test.ts
+++ b/lambda/publish-todays-curation/src/curation.test.ts
@@ -1,4 +1,27 @@
-import {checkCurationPath} from "./curation";
+import {
+  CopyObjectCommand,
+  HeadObjectCommand,
+  HeadObjectCommandInput,
+  NoSuchKey,
+  S3Client,
+  S3ServiceException
+} from "@aws-sdk/client-s3";
+import {mockClient} from "aws-sdk-client-mock";
+import {
+  activateCuration,
+  checkCurationPath,
+  doesCurationPathMatch,
+  generatePath,
+  generatePathFromCuration,
+  newCurationPath, validateCurationData
+} from "./curation";
+
+const s3Mock = mockClient(S3Client);
+
+jest.mock("./config", ()=>({
+  Bucket: "TestBucket",
+  Today: new Date(2024, 1,3,8,9,10)
+}));
 
 describe("curation.checkCurationPath", ()=>{
   it("should extract data from a proper path", ()=>{
@@ -14,4 +37,117 @@ describe("curation.checkCurationPath", ()=>{
     const result = checkCurationPath("content/jkhdfsdsfFfiodfsds");
     expect(result).toBeNull();
   })
+})
+
+describe("generatePathFromCuration", ()=>{
+  it("should generate CurationPath from the provided data", ()=>{
+    expect(generatePathFromCuration({
+      region: "region-one",
+      variant: "all-recipes",
+      year: 2024,
+      month: 3,
+      day: 2
+    })).toEqual("region-one/all-recipes/2024-03-02/curation.json")
+  })
+})
+
+describe("generatePath", ()=>{
+  it("should generate the curation path for the given date", ()=>{
+    expect(generatePath("region-one","all-recipes",new Date(2024,2,2)))
+      .toEqual("region-one/all-recipes/2024-03-02/curation.json")
+  })
+});
+
+describe("doesCurationPathMatch", ()=>{
+  it("should return truthy if the given date matches the CurationPath", ()=>{
+    expect(doesCurationPathMatch({region: "", variant:"", year:2024,month:3,day:2}, new Date(2024,2,2)))
+      .toBeTruthy();
+  });
+
+  it("should return falsy if the given date does not match the CurationPath", ()=>{
+    expect(doesCurationPathMatch({region: "", variant:"", year:2024,month:3,day:2}, new Date(2024,1,5)));
+  })
+})
+
+describe("newCurationPath", ()=>{
+  it("should return a CurationPath for the given data", ()=>{
+    expect(newCurationPath("region-one","all-recipes", new Date(2024,5,6)))
+      .toEqual({
+        region: "region-one",
+        variant: "all-recipes",
+        year: 2024,
+        month: 6,
+        day: 6
+      });
+  })
+});
+
+describe("validateCurationData", ()=> {
+  beforeEach(() => {
+    s3Mock.reset();
+  });
+
+  it("should return a CurationPath object if the file exists", async () => {
+    s3Mock.on(HeadObjectCommand).resolves({});
+
+    const response = await validateCurationData("some-region", "some-variant", new Date(2024, 2, 3));
+    expect(s3Mock.commandCalls(HeadObjectCommand).length).toEqual(1);
+    const c = s3Mock.commandCalls(HeadObjectCommand)[0];
+    const arg = c.firstArg as HeadObjectCommand;
+    expect(arg.input.Bucket).toEqual("TestBucket");
+    expect(arg.input.Key).toEqual("some-region/some-variant/2024-03-03/curation.json");
+
+    expect(response?.variant).toEqual("some-variant");
+    expect(response?.region).toEqual("some-region");
+    expect(response?.year).toEqual(2024);
+    expect(response?.month).toEqual(3);
+    expect(response?.day).toEqual(3);
+  });
+
+  it("should return null if the file does not exist", async () => {
+    s3Mock.on(HeadObjectCommand).rejects(new NoSuchKey({$metadata: {}, message: ""}))
+
+    const response = await validateCurationData("some-region", "some-variant", new Date(2024, 2, 3));
+    expect(response).toBeNull();
+
+    expect(s3Mock.commandCalls(HeadObjectCommand).length).toEqual(1);
+    const c = s3Mock.commandCalls(HeadObjectCommand)[0];
+    const arg = c.firstArg as HeadObjectCommand;
+    expect(arg.input.Bucket).toEqual("TestBucket");
+    expect(arg.input.Key).toEqual("some-region/some-variant/2024-03-03/curation.json");
+  });
+
+  it("should pass on any other error as an exception", async () => {
+    s3Mock.on(HeadObjectCommand).rejects(new S3ServiceException({
+      $fault: "server",
+      name: "",
+      $metadata: {},
+      message: "Test exception"
+    }))
+
+    await expect(validateCurationData("some-region", "some-variant", new Date(2024, 2, 3))).rejects.toBeInstanceOf(S3ServiceException);
+  });
+});
+
+describe("activateCuration", ()=>{
+  beforeEach(()=>{
+    s3Mock.reset();
+  });
+
+  it("should copy the given date to the default curation path", async ()=>{
+    s3Mock.on(CopyObjectCommand).resolves({CopyObjectResult: {ETag: "some-etag"}});
+    await activateCuration({
+      region: "some-region",
+      variant: "some-variant",
+      year: 2023,
+      month: 8,
+      day: 9
+    });
+
+    expect(s3Mock.commandCalls(CopyObjectCommand).length).toEqual(1);
+    const input = (s3Mock.commandCalls(CopyObjectCommand)[0].firstArg as CopyObjectCommand).input;
+    expect(input.Bucket).toEqual("TestBucket");
+    expect(input.CopySource).toEqual("some-region/some-variant/2023-08-09/curation.json");
+    expect(input.Key).toEqual("some-region/some-variant/curation.json");
+  });
 })

--- a/lambda/publish-todays-curation/src/curation.test.ts
+++ b/lambda/publish-todays-curation/src/curation.test.ts
@@ -32,8 +32,8 @@ jest.mock("./config", ()=>({
 describe("curation.checkCurationPath", ()=>{
   it("should extract data from a proper path", ()=>{
     const result = checkCurationPath("northern-area/all-recipes/2020-01-02/curation.json");
-    expect(result?.region).toEqual("northern-area");
-    expect(result?.variant).toEqual("all-recipes");
+    expect(result?.edition).toEqual("northern-area");
+    expect(result?.front).toEqual("all-recipes");
     expect(result?.year).toEqual(2020);
     expect(result?.month).toEqual(1);
     expect(result?.day).toEqual(2);
@@ -48,8 +48,8 @@ describe("curation.checkCurationPath", ()=>{
 describe("curation.generatePathFromCuration", ()=>{
   it("should generate CurationPath from the provided data", ()=>{
     expect(generatePathFromCuration({
-      region: "region-one",
-      variant: "all-recipes",
+      edition: "region-one",
+      front: "all-recipes",
       year: 2024,
       month: 3,
       day: 2
@@ -66,12 +66,12 @@ describe("curation.generatePath", ()=>{
 
 describe("curation.doesCurationPathMatch", ()=>{
   it("should return truthy if the given date matches the CurationPath", ()=>{
-    expect(doesCurationPathMatch({region: "", variant:"", year:2024,month:3,day:2}, new Date(2024,2,2)))
+    expect(doesCurationPathMatch({edition: "", front:"", year:2024,month:3,day:2}, new Date(2024,2,2)))
       .toBeTruthy();
   });
 
   it("curation.should return falsy if the given date does not match the CurationPath", ()=>{
-    expect(doesCurationPathMatch({region: "", variant:"", year:2024,month:3,day:2}, new Date(2024,1,5)));
+    expect(doesCurationPathMatch({edition: "", front:"", year:2024,month:3,day:2}, new Date(2024,1,5)));
   })
 })
 
@@ -79,8 +79,8 @@ describe("curation.newCurationPath", ()=>{
   it("should return a CurationPath for the given data", ()=>{
     expect(newCurationPath("region-one","all-recipes", new Date(2024,5,6)))
       .toEqual({
-        region: "region-one",
-        variant: "all-recipes",
+        edition: "region-one",
+        front: "all-recipes",
         year: 2024,
         month: 6,
         day: 6
@@ -103,8 +103,8 @@ describe("curation.validateCurationData", ()=> {
     expect(arg.input.Bucket).toEqual("TestBucket");
     expect(arg.input.Key).toEqual("some-region/some-variant/2024-03-03/curation.json");
 
-    expect(response?.variant).toEqual("some-variant");
-    expect(response?.region).toEqual("some-region");
+    expect(response?.front).toEqual("some-variant");
+    expect(response?.edition).toEqual("some-region");
     expect(response?.year).toEqual(2024);
     expect(response?.month).toEqual(3);
     expect(response?.day).toEqual(3);
@@ -171,15 +171,15 @@ describe("curation.validateAllCuration", ()=>{
 
     expect(result.length).toEqual(2);
     expect(result[0]).toEqual({
-      region: "northern",
-      variant: "meat-free",
+      edition: "northern",
+      front: "meat-free",
       year: 2024,
       month: 2,
       day: 3
     });
     expect(result[1]).toEqual({
-      region: "southern",
-      variant: "meat-free",
+      edition: "southern",
+      front: "meat-free",
       year: 2024,
       month: 2,
       day: 3
@@ -195,8 +195,8 @@ describe("curation.activateCuration", ()=>{
   it("should copy the given date to the default curation path", async ()=>{
     s3Mock.on(CopyObjectCommand).resolves({CopyObjectResult: {ETag: "some-etag"}});
     await activateCuration({
-      region: "some-region",
-      variant: "some-variant",
+      edition: "some-region",
+      front: "some-variant",
       year: 2023,
       month: 8,
       day: 9

--- a/lambda/publish-todays-curation/src/curation.test.ts
+++ b/lambda/publish-todays-curation/src/curation.test.ts
@@ -1,12 +1,12 @@
 import {
   CopyObjectCommand,
   HeadObjectCommand,
-  HeadObjectCommandInput,
   NoSuchKey,
   S3Client,
   S3ServiceException
 } from "@aws-sdk/client-s3";
 import {mockClient} from "aws-sdk-client-mock";
+import {sendFastlyPurgeRequestWithRetries} from "@recipes-api/lib/recipes-data";
 import {
   activateCuration,
   checkCurationPath,
@@ -17,6 +17,11 @@ import {
 } from "./curation";
 
 const s3Mock = mockClient(S3Client);
+
+jest.mock("@recipes-api/lib/recipes-data", ()=>({
+  sendFastlyPurgeRequestWithRetries: jest.fn(),
+}));
+
 
 jest.mock("./config", ()=>({
   Bucket: "TestBucket",
@@ -149,5 +154,8 @@ describe("activateCuration", ()=>{
     expect(input.Bucket).toEqual("TestBucket");
     expect(input.CopySource).toEqual("some-region/some-variant/2023-08-09/curation.json");
     expect(input.Key).toEqual("some-region/some-variant/curation.json");
+
+    const fastlyPurgeMocked = (sendFastlyPurgeRequestWithRetries as jest.Mock).mock.calls;
+    expect(fastlyPurgeMocked.length).toEqual(1);
   });
 })

--- a/lambda/publish-todays-curation/src/curation.test.ts
+++ b/lambda/publish-todays-curation/src/curation.test.ts
@@ -1,0 +1,17 @@
+import {checkCurationPath} from "./curation";
+
+describe("curation.checkCurationPath", ()=>{
+  it("should extract data from a proper path", ()=>{
+    const result = checkCurationPath("northern-area/all-recipes/2020-01-02/curation.json");
+    expect(result?.region).toEqual("northern-area");
+    expect(result?.variant).toEqual("all-recipes");
+    expect(result?.year).toEqual(2020);
+    expect(result?.month).toEqual(1);
+    expect(result?.day).toEqual(2);
+  });
+
+  it("should return null for an unrecognised path", ()=>{
+    const result = checkCurationPath("content/jkhdfsdsfFfiodfsds");
+    expect(result).toBeNull();
+  })
+})

--- a/lambda/publish-todays-curation/src/curation.ts
+++ b/lambda/publish-todays-curation/src/curation.ts
@@ -1,4 +1,4 @@
-import {CopyObjectCommand, HeadObjectCommand, NoSuchKey, S3Client, S3ServiceException} from "@aws-sdk/client-s3";
+import {CopyObjectCommand, HeadObjectCommand, NoSuchKey, S3Client} from "@aws-sdk/client-s3";
 import {format, formatISO} from "date-fns";
 import {Bucket} from "./config";
 
@@ -61,7 +61,7 @@ export function doesCurationPathMatch(p:CurationPath, d:Date):boolean {
   return (p.year==d.getFullYear()) && (p.month==d.getMonth()+1) && (p.day==d.getDate());
 }
 
-const PathMatcher = /^([^/]+)\/([^/]+)\/(\d{4})-(\d{2})-(\d{2})\/curation.json/;
+const PathMatcher = /^([^/]+)\/([^/]+)\/(\d{4})-(\d{2})-(\d{2})\/curation\.json/;
 export function checkCurationPath(key:string):CurationPath|null {
   const parts = PathMatcher.exec(key);
   if(parts) {
@@ -125,17 +125,4 @@ export async function activateCuration(info:CurationPath):Promise<void> {
 
   const response = await s3Client.send(req);
   console.log(`Done, new Etag is ${response.CopyObjectResult?.ETag ?? "(unknown)"}`);
-}
-
-export async function activateAllCurationForDate(date: Date): Promise<void> {
-  for (const region of KnownRegions) {
-    for (const variant of KnownVariants) {
-      try {
-        const p = newCurationPath(region, variant, date);
-        await activateCuration(p);
-      } catch(err) {
-        console.warn(`Unable to activate curation for ${region}/${variant} on ${formatISO(date)}: `, err);
-      }
-    }
-  }
 }

--- a/lambda/publish-todays-curation/src/curation.ts
+++ b/lambda/publish-todays-curation/src/curation.ts
@@ -1,0 +1,112 @@
+import {CopyObjectCommand, HeadObjectCommand, NoSuchKey, S3Client, S3ServiceException} from "@aws-sdk/client-s3";
+import {format} from "date-fns";
+import {Bucket} from "./config";
+
+const s3Client = new S3Client({region: process.env["AWS_REGION"]});
+
+const KnownRegions = [
+  "northern-hemisphere",
+  "southern-hemisphere"
+];
+
+const KnownVariants = [
+  "meat-free",
+  "all-recipes"
+];
+
+const DateFormat = "yyyy-MM-dd";
+
+export async function validateAllCuration(date:Date, throwOnAbsent:boolean) {
+  for(const region in KnownRegions) {
+    for(const variant in KnownVariants) {
+      const present = await validateCurationData(region, variant, date);
+      if(!present) {
+        console.warn(`No curation was present for region ${region} variant ${variant} on date ${format(date, DateFormat)}`);
+        if(throwOnAbsent) throw new Error(`Missing some curation for ${format(date, DateFormat)}. Consult the logs for more detail.`)
+      }
+    }
+  }
+}
+
+export function generatePath(region:string, variant:string, date:Date) {
+  return `${region}/${variant}/${format(date, DateFormat)}/curation.json`;
+}
+
+export function generateActivePath(region:string, variant: string) {
+  return `${region}/${variant}/curation.json`;
+}
+
+interface CurationPath {
+  region: string;
+  variant: string;
+  year: number;
+  month: number;
+  day: number;
+}
+
+export function doesCurationPathMatch(p:CurationPath, d:Date):boolean {
+  //Remember that Javascript dates have Jan=month 0, Feb=month 1 etc.! Hence the +1.
+  return (p.year==d.getFullYear()) && (p.month==d.getMonth()+1) && (p.day==d.getDate());
+}
+
+const PathMatcher = /^([^\/]+)\/([^\/]+)\/(\d{4})-(\d{2})-(\d{2})\/curation.json/;
+export function checkCurationPath(key:string):CurationPath|null {
+  const parts = PathMatcher.exec(key);
+  if(parts) {
+    return {
+      region: parts[1],
+      variant: parts[2],
+      year: parseInt(parts[3]),
+      month: parseInt(parts[4]),
+      day: parseInt(parts[5])
+    }
+  } else {
+    return null;
+  }
+}
+
+export async function validateCurationData(region:string, variant:string, date:Date):Promise<boolean> {
+  const req = new HeadObjectCommand({
+    Bucket,
+    Key: generatePath(region, variant, date),
+  });
+
+  try {
+    await s3Client.send(req); //this should throw an exception if the file does not exist
+    console.debug(`Found curation data for ${region}/${variant} on ${date}`);
+    return true;
+  } catch(err) {
+    if(err instanceof NoSuchKey) {
+      console.debug(`Did not find curation data for ${region}/${variant} on ${date}`);
+      return false;
+    } else {
+      console.error(err);
+      throw err;
+    }
+  }
+}
+
+export async function activateCurationForDate(region: string, variant: string, date:Date):Promise<void> {
+  console.log(`Deploying config ${generatePath(region, variant, date)} to ${generateActivePath(region, variant)}`);
+
+  const req = new CopyObjectCommand({
+    Bucket,
+    CopySource: generatePath(region, variant, date),
+    Key: generateActivePath(region, variant)
+  });
+
+  const response = await s3Client.send(req);
+  console.log(`Done, new Etag is ${response.CopyObjectResult?.ETag}`);
+}
+
+export async function activateAllCurationForDate(date: Date): Promise<void> {
+  for (const region in KnownRegions) {
+    for (const variant in KnownVariants) {
+      try {
+        await activateCurationForDate(region, variant, date);
+      } catch(err) {
+        console.warn(`Unable to activate curation for ${region}/${variant} on ${date}: `, err);
+      }
+    }
+  }
+}

--- a/lambda/publish-todays-curation/src/main.test.ts
+++ b/lambda/publish-todays-curation/src/main.test.ts
@@ -35,9 +35,9 @@ describe("main.handler", ()=>{
 
   it("should launch all present curations for today's date, if they are available", async ()=>{
     const availableFronts:CurationPath[] = [
-      {variant: "some-variant",region:"region-one",year: 2024, month: 2, day:3},
-      {variant: "another-variant", region: "region-one", year: 2024, month: 2, day: 3},
-      {variant: "some-variant",region:"region-two",year: 2024, month: 2, day:3},
+      {front: "some-variant",edition:"region-one",year: 2024, month: 2, day:3},
+      {front: "another-variant", edition: "region-one", year: 2024, month: 2, day: 3},
+      {front: "some-variant",edition:"region-two",year: 2024, month: 2, day:3},
     ];
 
     (validateAllCuration as jest.Mock).mockReturnValue(Promise.resolve<CurationPath[]>(availableFronts));
@@ -102,8 +102,8 @@ describe("main.handler", ()=>{
     const activateCalls = (activateCuration as jest.Mock).mock.calls;
     expect(activateCalls.length).toEqual(1);
     expect(activateCalls[0][0]).toEqual({
-      variant: "variant-two",
-      region: "region-one",
+      front: "variant-two",
+      edition: "region-one",
       year: 2024,
       month: 2,
       day: 3

--- a/lambda/publish-todays-curation/src/main.test.ts
+++ b/lambda/publish-todays-curation/src/main.test.ts
@@ -24,6 +24,10 @@ jest.mock('./curation', ()=>{
   }
 });
 
+jest.mock("@recipes-api/lib/recipes-data", ()=>({
+  sendFastlyPurgeRequestWithRetries: jest.fn(),
+}));
+
 describe("main.handler", ()=>{
   beforeEach(()=>{
     jest.resetAllMocks();

--- a/lambda/publish-todays-curation/src/main.test.ts
+++ b/lambda/publish-todays-curation/src/main.test.ts
@@ -1,0 +1,204 @@
+import {S3Client} from "@aws-sdk/client-s3";
+import {mockClient} from "aws-sdk-client-mock";
+import {Today} from "./config";
+import type { CurationPath} from "./curation";
+import { activateCuration, validateAllCuration} from "./curation";
+import {handler} from "./main";
+
+mockClient(S3Client);
+
+jest.mock("./config", ()=>({
+  Bucket: "TestBucket",
+  Today: new Date(2024,1,3,11,26,19)
+}));
+
+jest.mock('./curation', ()=>{
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- recommended way to partial-mock
+  const original = jest.requireActual("./curation");
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- recommended way to partial-mock
+  return {
+    ...original,
+    activateAllCurationForDate: jest.fn(),
+    activateCuration: jest.fn(),
+    validateAllCuration: jest.fn()
+  }
+});
+
+describe("main.handler", ()=>{
+  beforeEach(()=>{
+    jest.resetAllMocks();
+  });
+
+  it("should launch all present curations for today's date, if they are available", async ()=>{
+    const availableFronts:CurationPath[] = [
+      {variant: "some-variant",region:"region-one",year: 2024, month: 2, day:3},
+      {variant: "another-variant", region: "region-one", year: 2024, month: 2, day: 3},
+      {variant: "some-variant",region:"region-two",year: 2024, month: 2, day:3},
+    ];
+
+    (validateAllCuration as jest.Mock).mockReturnValue(Promise.resolve<CurationPath[]>(availableFronts));
+    (activateCuration as jest.Mock).mockReturnValue(Promise.resolve());
+
+    await handler({});
+    const validateCalls  = (validateAllCuration as jest.Mock).mock.calls;
+    expect(validateCalls.length).toEqual(1);
+    expect(validateCalls[0][0]).toEqual(Today);
+    expect(validateCalls[0][1]).toBeFalsy();
+    const activateCalls = (activateCuration as jest.Mock).mock.calls;
+    expect(activateCalls.length).toEqual(3);
+    expect(activateCalls[0][0]).toEqual(availableFronts[0]);
+    expect(activateCalls[1][0]).toEqual(availableFronts[1]);
+    expect(activateCalls[2][0]).toEqual(availableFronts[2]);
+  });
+
+  it("should relaunch a specific curation page if it's been updated in the S3 bucket", async ()=>{
+    const sampleS3Msg = {
+      "Records": [
+        {
+          "eventVersion": "2.0",
+          "eventSource": "aws:s3",
+          "awsRegion": "us-east-1",
+          "eventTime": "1970-01-01T00:00:00.000Z",
+          "eventName": "ObjectCreated:Put",
+          "userIdentity": {
+            "principalId": "EXAMPLE"
+          },
+          "requestParameters": {
+            "sourceIPAddress": "127.0.0.1"
+          },
+          "responseElements": {
+            "x-amz-request-id": "EXAMPLE123456789",
+            "x-amz-id-2": "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH"
+          },
+          "s3": {
+            "s3SchemaVersion": "1.0",
+            "configurationId": "testConfigRule",
+            "bucket": {
+              "name": "TestBucket",
+              "ownerIdentity": {
+                "principalId": "EXAMPLE"
+              },
+              "arn": "arn:aws:s3:::TestBucket"
+            },
+            "object": {
+              "key": "region-one%2Fvariant-two%2F2024-02-03%2Fcuration.json",
+              "size": 1024,
+              "eTag": "0123456789abcdef0123456789abcdef",
+              "sequencer": "0A1B2C3D4E5F678901"
+            }
+          }
+        }
+      ]
+    };
+
+    (activateCuration as jest.Mock).mockReturnValue(Promise.resolve());
+    await handler(sampleS3Msg);
+
+    expect((validateAllCuration as jest.Mock).mock.calls.length).toEqual(0);
+    const activateCalls = (activateCuration as jest.Mock).mock.calls;
+    expect(activateCalls.length).toEqual(1);
+    expect(activateCalls[0][0]).toEqual({
+      variant: "variant-two",
+      region: "region-one",
+      year: 2024,
+      month: 2,
+      day: 3
+    });
+  });
+
+  it("should ignore Delete messages", async ()=>{
+    const sampleS3Msg = {
+      "Records": [
+        {
+          "eventVersion": "2.0",
+          "eventSource": "aws:s3",
+          "awsRegion": "us-east-1",
+          "eventTime": "1970-01-01T00:00:00.000Z",
+          "eventName": "ObjectRemoved:Delete",
+          "userIdentity": {
+            "principalId": "EXAMPLE"
+          },
+          "requestParameters": {
+            "sourceIPAddress": "127.0.0.1"
+          },
+          "responseElements": {
+            "x-amz-request-id": "EXAMPLE123456789",
+            "x-amz-id-2": "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH"
+          },
+          "s3": {
+            "s3SchemaVersion": "1.0",
+            "configurationId": "testConfigRule",
+            "bucket": {
+              "name": "TestBucket",
+              "ownerIdentity": {
+                "principalId": "EXAMPLE"
+              },
+              "arn": "arn:aws:s3:::TestBucket"
+            },
+            "object": {
+              "key": "region-one%2Fvariant-two%2F2024-02-03%2Fcuration.json",
+              "size": 1024,
+              "eTag": "0123456789abcdef0123456789abcdef",
+              "sequencer": "0A1B2C3D4E5F678901"
+            }
+          }
+        }
+      ]
+    };
+
+    (activateCuration as jest.Mock).mockReturnValue(Promise.resolve());
+    await handler(sampleS3Msg);
+
+    expect((validateAllCuration as jest.Mock).mock.calls.length).toEqual(0);
+    const activateCalls = (activateCuration as jest.Mock).mock.calls;
+    expect(activateCalls.length).toEqual(0);
+  });
+
+  it("should ignore unknown paths", async ()=>{
+    const sampleS3Msg = {
+      "Records": [
+        {
+          "eventVersion": "2.0",
+          "eventSource": "aws:s3",
+          "awsRegion": "us-east-1",
+          "eventTime": "1970-01-01T00:00:00.000Z",
+          "eventName": "ObjectCreated:Put",
+          "userIdentity": {
+            "principalId": "EXAMPLE"
+          },
+          "requestParameters": {
+            "sourceIPAddress": "127.0.0.1"
+          },
+          "responseElements": {
+            "x-amz-request-id": "EXAMPLE123456789",
+            "x-amz-id-2": "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH"
+          },
+          "s3": {
+            "s3SchemaVersion": "1.0",
+            "configurationId": "testConfigRule",
+            "bucket": {
+              "name": "TestBucket",
+              "ownerIdentity": {
+                "principalId": "EXAMPLE"
+              },
+              "arn": "arn:aws:s3:::TestBucket"
+            },
+            "object": {
+              "key": "content%2Fsadfadfsjklbbncvxbxdftur",
+              "size": 1024,
+              "eTag": "0123456789abcdef0123456789abcdef",
+              "sequencer": "0A1B2C3D4E5F678901"
+            }
+          }
+        }
+      ]
+    };
+
+    (activateCuration as jest.Mock).mockReturnValue(Promise.resolve());
+    await handler(sampleS3Msg);
+
+    expect((validateAllCuration as jest.Mock).mock.calls.length).toEqual(0);
+    const activateCalls = (activateCuration as jest.Mock).mock.calls;
+    expect(activateCalls.length).toEqual(0);
+  });
+});

--- a/lambda/publish-todays-curation/src/main.ts
+++ b/lambda/publish-todays-curation/src/main.ts
@@ -1,0 +1,1 @@
+console.log('Hello World');

--- a/lambda/publish-todays-curation/src/main.ts
+++ b/lambda/publish-todays-curation/src/main.ts
@@ -1,1 +1,59 @@
-console.log('Hello World');
+import {Context, S3Event} from "aws-lambda";
+import {
+  activateAllCurationForDate, activateCurationForDate, checkCurationPath, doesCurationPathMatch,
+  validateAllCuration,
+} from "./curation";
+import {Bucket, Today} from "./config";
+
+/**
+ * Check if an upload consists of an update for today's curation data. If so, then activate it
+ * immediately.
+ * @param event
+ */
+async function handleS3Event(event:S3Event):Promise<void> {
+  const toWaitFor = event.Records.map((rec)=>{
+    if(rec.s3.bucket.name != Bucket) {
+      console.log(`Event was for bucket ${rec.s3.bucket.name}, ignoring`);
+      return;
+    }
+
+    const info = checkCurationPath(rec.s3.object.key);
+    if(info) {
+      if(doesCurationPathMatch(info, Today)) {
+        console.log(`Detected an update of today's curation data for ${info.region}/${info.variant}, redeploying`);
+        return activateCurationForDate(info.region, info.variant, Today);
+      } else {
+        console.log(`Detected an update of curation data for ${info.region}/${info.variant} on ${info.year}-${info.month}-${info.day}`);
+      }
+    } else {
+      console.log(`Event was for unrecognised path ${rec.s3.object.key}`);
+    }
+  });
+
+  await Promise.all(toWaitFor.filter((maybePromise)=>!!maybePromise));
+}
+
+/**
+ * Activate the fronts for a given date
+ * @param date Date to activate
+ */
+async function handleTimerEvent(date: Date):Promise<void> {
+  console.log(`Checking we have curation for ${date}...`)
+  //Check if we have curation available for the new date
+  await validateAllCuration(date, false);
+  console.log(`Activating...`);
+  await activateAllCurationForDate(date);
+  console.log("Done.");
+}
+
+
+
+async function handler(event: S3Event|unknown, context: Context) {
+  if((event as {}).hasOwnProperty("Records")) {
+    console.log("Invoked from S3");
+    return handleS3Event(event as S3Event)
+  } else {
+    console.log("Did not receive an S3 record, assuming invoked from timer");
+    return handleTimerEvent(new Date());
+  }
+}

--- a/lambda/publish-todays-curation/src/main.ts
+++ b/lambda/publish-todays-curation/src/main.ts
@@ -27,10 +27,10 @@ async function handleS3Event(event:S3Event):Promise<void> {
     const info = checkCurationPath(targetPath);
     if(info) {
       if(doesCurationPathMatch(info, Today)) {
-        console.log(`Detected an update of today's curation data for ${info.region}/${info.variant}, redeploying`);
+        console.log(`Detected an update of today's curation data for ${info.edition}/${info.front}, redeploying`);
         return activateCuration(info);
       } else {
-        console.log(`Detected an update of curation data for ${info.region}/${info.variant} on ${info.year}-${info.month}-${info.day}`);
+        console.log(`Detected an update of curation data for ${info.edition}/${info.front} on ${info.year}-${info.month}-${info.day}`);
       }
     } else {
       console.log(`Event was for unrecognised path ${targetPath}`);

--- a/lambda/publish-todays-curation/tsconfig.app.json
+++ b/lambda/publish-todays-curation/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"module": "commonjs",
+		"types": ["node"]
+	},
+	"exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+	"include": ["src/**/*.ts"]
+}

--- a/lambda/publish-todays-curation/tsconfig.json
+++ b/lambda/publish-todays-curation/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"files": [],
+	"include": [],
+	"references": [
+		{
+			"path": "./tsconfig.app.json"
+		},
+		{
+			"path": "./tsconfig.spec.json"
+		}
+	],
+	"compilerOptions": {
+		"esModuleInterop": true
+	}
+}

--- a/lambda/publish-todays-curation/tsconfig.spec.json
+++ b/lambda/publish-todays-curation/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"module": "commonjs",
+		"types": ["jest", "node"]
+	},
+	"include": [
+		"jest.config.ts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.ts",
+		"src/**/*.d.ts"
+	]
+}

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -14,8 +14,8 @@ const router = express.Router();
 router.use(bodyParser.json());
 
 interface CurationParams {
-  region: string;
-  variant: string;
+  edition: string;
+  front: string;
 }
 
 /**
@@ -25,12 +25,12 @@ interface CurationParams {
 function validateCurationParams(params: CurationParams) {
   const checker = /[^\\w]+/;
 
-  if(!params.region.match(checker) || !params.variant.match(checker)) {
+  if(!params.edition.match(checker) || !params.front.match(checker)) {
     throw new Error("Invalid region parameter");
   }
 }
 
-router.post('/api/curation/:region/:variant', (req: Request<CurationParams>, resp)=>{
+router.post('/api/curation/:edition/:front', (req: Request<CurationParams>, resp)=>{
   if(req.header("Content-Type") != "application/json") {
     resp.status(405).json({status: "error", detail: "wrong content type"});
     return;
@@ -61,7 +61,7 @@ router.post('/api/curation/:region/:variant', (req: Request<CurationParams>, res
       return;
     }
 
-    importNewData(textContent, req.params.region, req.params.variant, dateval)
+    importNewData(textContent, req.params.edition, req.params.front, dateval)
       .then(() => {
         return resp.status(200).json({status: "ok"})
       })
@@ -105,6 +105,9 @@ router.get('/api/content/by-uid/:recipeUID', (req: Request<RecipeIdParams>, resp
       resp.status(404).json({status: "not found", detail: "No recipe found with that UID"});
       return;
     }
+  }).catch((err)=>{
+    console.error(err);
+    resp.status(500).json({status: "error", detail: "there was an internal error fetching the recipe. See server-side logs."})
   });
 });
 

--- a/lambda/rest-endpoints/src/helpers.test.ts
+++ b/lambda/rest-endpoints/src/helpers.test.ts
@@ -1,4 +1,4 @@
-import {getBodyContentAsJson} from "./helpers";
+import {getBodyContentAsJson, validateDateParam} from "./helpers";
 
 describe("app.getBodyContentAsJson", ()=>{
   it("should pass back a string as-is", ()=>{
@@ -15,4 +15,30 @@ describe("app.getBodyContentAsJson", ()=>{
   it("should convert an array into json string", ()=>{
     expect(getBodyContentAsJson([1,2,3])).toEqual("[1,2,3]");
   })
+})
+
+describe("app.validateDateParam", ()=>{
+  it("should convert a valid date string into a Date object", ()=>{
+    const result = validateDateParam("2024-06-05");
+    expect(result?.getFullYear()).toEqual(2024);
+    expect(result?.getMonth()).toEqual(5);  //note - JS Date() object month index is Jan=>0, Feb=1
+    expect(result?.getDate()).toEqual(5);
+  });
+
+  it("should reject a malformed string", ()=>{
+    expect(()=>
+      validateDateParam("2014-06-05somethingmalicious")
+    ).toThrow("Provided date was not valid");
+  });
+
+  it("should reject an out-of-range string", ()=>{
+   expect(()=>
+     validateDateParam("2024-96-05")
+   ).toThrow("Invalid number of months");
+
+    expect(()=>
+      validateDateParam("1902-96-05")
+    ).toThrow("Invalid year");
+  });
+
 })

--- a/lambda/rest-endpoints/src/helpers.ts
+++ b/lambda/rest-endpoints/src/helpers.ts
@@ -10,3 +10,22 @@ export function getBodyContentAsJson(body:unknown): string {
     throw new Error("Did not recognise the body content as json or json-like");
   }
 }
+
+export function validateDateParam(dateParam:string):Date|null {
+  const checker = /^(\d{4})-(\d{2})-(\d{2})$/;
+  const parts = checker.exec(dateParam);
+
+  if(!parts) {
+    console.warn(`Provided date argument ${dateParam} is not valid `);
+    throw new Error("Provided date was not valid");
+  } else {
+    const year = parseInt(parts[1]);
+    if(year<2024) throw new Error("Invalid year");
+    const month = parseInt(parts[2]);
+    if(month<1 || month>12) throw new Error("Invalid number of months");
+    const day = parseInt(parts[3]);
+    if(day<1 || day>31) throw new Error("Invalid number of days");
+
+    return new Date(year,month-1,day);
+  }
+}

--- a/lambda/rest-endpoints/src/main.ts
+++ b/lambda/rest-endpoints/src/main.ts
@@ -1,4 +1,13 @@
-import serverlessExpress from '@vendia/serverless-express';
+import serverlessExpress from '@codegenie/serverless-express';
+import type {Logger} from "@codegenie/serverless-express/src/logger";
 import {app} from './app';
 
-export const handler = serverlessExpress({ app });
+const consoleLogger:Logger = ({
+  debug: console.debug,
+  error: console.error,
+  info: console.info,
+  verbose: console.debug,
+  warn: console.warn
+});
+
+export const handler = serverlessExpress({ app, log: consoleLogger });

--- a/lambda/rest-endpoints/src/submit-data.test.ts
+++ b/lambda/rest-endpoints/src/submit-data.test.ts
@@ -1,0 +1,68 @@
+import {PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
+import {mockClient} from "aws-sdk-client-mock";
+import {importNewData} from "./submit-data";
+import {sendFastlyPurgeRequestWithRetries} from "@recipes-api/lib/recipes-data";
+import MockedFn = jest.MockedFn;
+import Mock = jest.Mock;
+
+const s3Mock = mockClient(S3Client);
+//const dynamoMock = mockClient(DynamoDBClient);
+
+jest.mock("process", ()=>{
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- typescript doesn't like 'any' value
+  const originalModule = jest.requireActual("process");
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- doesn't like 'any' value
+  return {
+    ...originalModule,
+    env: {
+      CONTENT_URL_BASE: "not-used",
+      STATIC_BUCKET: "static-content-bucket",
+      AWS_REGION: "some-aws-region",
+      FASTLY_API_KEY: "blahblahblah"
+    }
+  }
+});
+
+jest.mock("@recipes-api/lib/recipes-data", ()=>({
+  sendFastlyPurgeRequestWithRetries: jest.fn(),
+}));
+
+describe("importNewData", ()=>{
+  beforeEach(()=>{
+    s3Mock.reset();
+    jest.resetAllMocks();
+  });
+
+  it("should upload the data to the right place and flush the CDN cache", async ()=>{
+    await importNewData("test-content", "some-region", "some-variant", null);
+
+    expect(s3Mock.calls().length).toEqual(1);
+    const uploadArgs = s3Mock.call(0).firstArg as PutObjectCommand;
+    expect(uploadArgs.input.Body).toEqual("test-content");
+    expect(uploadArgs.input.Key).toEqual(`some-region/some-variant/curation.json`);
+    expect(uploadArgs.input.Bucket).toEqual("static-content-bucket");
+
+    const fastlyPurgeMock = sendFastlyPurgeRequestWithRetries as MockedFn<typeof sendFastlyPurgeRequestWithRetries>;
+    expect(fastlyPurgeMock.mock.calls[0][0]).toEqual(`some-region/some-variant/curation.json`);
+    expect(fastlyPurgeMock.mock.calls[0][1]).toEqual("blahblahblah");
+    expect(fastlyPurgeMock.mock.calls[0][2]).toEqual("hard");
+  });
+
+  it("should respect the date parameter if given", async ()=>{
+    const d = new Date(2021, 5, 5); //Note - actually 5th Jun - due to Date() constructor weirdness
+
+    await importNewData("test-content", "some-region", "some-variant", d);
+
+    expect(s3Mock.calls().length).toEqual(1);
+    const uploadArgs = s3Mock.call(0).firstArg as PutObjectCommand;
+    expect(uploadArgs.input.Body).toEqual("test-content");
+    expect(uploadArgs.input.Key).toEqual(`some-region/some-variant/2021-06-05/curation.json`);
+    expect(uploadArgs.input.Bucket).toEqual("static-content-bucket");
+
+    const fastlyPurgeMock = sendFastlyPurgeRequestWithRetries as MockedFn<typeof sendFastlyPurgeRequestWithRetries>;
+    expect(fastlyPurgeMock.mock.calls[0][0]).toEqual(`some-region/some-variant/2021-06-05/curation.json`);
+    expect(fastlyPurgeMock.mock.calls[0][1]).toEqual("blahblahblah");
+    expect(fastlyPurgeMock.mock.calls[0][2]).toEqual("hard");
+  });
+})

--- a/lambda/rest-endpoints/src/submit-data.test.ts
+++ b/lambda/rest-endpoints/src/submit-data.test.ts
@@ -1,12 +1,11 @@
-import {PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
+import type {PutObjectCommand} from "@aws-sdk/client-s3";
+import { S3Client} from "@aws-sdk/client-s3";
 import {mockClient} from "aws-sdk-client-mock";
-import {importNewData} from "./submit-data";
 import {sendFastlyPurgeRequestWithRetries} from "@recipes-api/lib/recipes-data";
+import {importNewData} from "./submit-data";
 import MockedFn = jest.MockedFn;
-import Mock = jest.Mock;
 
 const s3Mock = mockClient(S3Client);
-//const dynamoMock = mockClient(DynamoDBClient);
 
 jest.mock("process", ()=>{
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- typescript doesn't like 'any' value

--- a/lambda/rest-endpoints/src/submit-data.ts
+++ b/lambda/rest-endpoints/src/submit-data.ts
@@ -1,12 +1,13 @@
 import {PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
+import format from "date-fns/format";
 import {sendFastlyPurgeRequestWithRetries} from "@recipes-api/lib/recipes-data";
 import {StaticBucketName as Bucket, FastlyApiKey} from "./config";
 
 const s3client = new S3Client({region: process.env["AWS_REGION"]});
 
-export async function importNewData(content:string|Buffer, region: string, variant: string):Promise<void>
+export async function importNewData(content:string|Buffer, region: string, variant: string, maybeDate: Date|null):Promise<void>
 {
-  const Key = `${region}/${variant}/curation.json`;
+  const Key = maybeDate ? `${region}/${variant}/${format(maybeDate, "yyyy-MM-dd")}/curation.json`: `${region}/${variant}/curation.json`;
 
   const req = new PutObjectCommand({
     Bucket,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "@aws-sdk/client-s3": "^3.458.0",
         "@aws-sdk/client-sns": "^3.529.1",
         "@aws-sdk/client-sts": "^3.529.1",
+        "@codegenie/serverless-express": "^4.14.0",
         "@guardian/content-api-models": "^17.8.0",
-        "@vendia/serverless-express": "^4.10.4",
         "aws-lambda": "^1.0.7",
         "axios": "^1.6.4",
         "body-parser": "^1.20.2",
@@ -23,8 +23,7 @@
         "express": "^4.18.2",
         "express-async-handler": "^1.2.0",
         "tslib": "^2.3.0",
-        "uuid": "^9.0.1",
-        "winston": "^3.13.0"
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@guardian/cdk": "52.0.0",
@@ -5394,12 +5393,12 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/@colors/colors": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+    "node_modules/@codegenie/serverless-express": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@codegenie/serverless-express/-/serverless-express-4.14.0.tgz",
+      "integrity": "sha512-74hOQzHz+rEhDtTKIdAZ/Gks/PGc9JHxKULBrVl5WBComGv6ceJHewdEKNfDtwPo7d1LKidNFJ2QXGO5pZr2tQ==",
       "engines": {
-        "node": ">=0.1.90"
+        "node": ">=12"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -5422,16 +5421,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@dabh/diagnostics": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-      "dependencies": {
-        "colorspace": "1.1.x",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
@@ -8020,11 +8009,6 @@
         "@types/q": "*"
       }
     },
-    "node_modules/@types/triple-beam": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
-      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
-    },
     "node_modules/@types/yargs": {
       "version": "17.0.29",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.29.tgz",
@@ -8233,14 +8217,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
-    },
-    "node_modules/@vendia/serverless-express": {
-      "version": "4.10.4",
-      "resolved": "https://registry.npmjs.org/@vendia/serverless-express/-/serverless-express-4.10.4.tgz",
-      "integrity": "sha512-OH2cX+LqtrayCIkHAkShiLnvrgqGDvwIQEex5dHc/uJitBQjIz3q7dZtfU7cZ5vcR9Vkide5xJQDBEMbXoWLeA==",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -8551,7 +8527,8 @@
     "node_modules/async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "dev": true
     },
     "node_modules/async-limiter": {
       "version": "1.0.1",
@@ -9801,15 +9778,6 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
-    "node_modules/color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "dependencies": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -9825,44 +9793,14 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/color/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
-    },
-    "node_modules/colorspace": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-      "dependencies": {
-        "color": "^3.1.3",
-        "text-hex": "1.0.x"
-      }
     },
     "node_modules/columnify": {
       "version": "1.6.0",
@@ -10528,11 +10466,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "node_modules/enabled": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -11901,11 +11834,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fecha": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -12056,11 +11984,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
-    },
-    "node_modules/fn.name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.4",
@@ -13065,6 +12988,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -14039,11 +13963,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/kuler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -14173,22 +14092,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/logform": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
-      "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
-      "dependencies": {
-        "@colors/colors": "1.6.0",
-        "@types/triple-beam": "^1.3.2",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "safe-stable-stringify": "^2.3.1",
-        "triple-beam": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "node_modules/lru-cache": {
@@ -14453,7 +14356,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -14777,14 +14681,6 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/one-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "dependencies": {
-        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -15476,6 +15372,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -15792,14 +15689,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-stable-stringify": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -15976,19 +15865,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/sinon": {
       "version": "14.0.2",
@@ -16298,14 +16174,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -16348,6 +16216,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -16604,11 +16473,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/text-hex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -16702,14 +16566,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/triple-beam": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/ts-jest": {
@@ -17149,7 +17005,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -17335,40 +17192,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/winston": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
-      "integrity": "sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==",
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.4.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/winston-transport": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
-      "integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
-      "dependencies": {
-        "logform": "^2.3.2",
-        "readable-stream": "^3.6.0",
-        "triple-beam": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "node_modules/wordwrap": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@aws-sdk/client-sns": "^3.529.1",
     "@aws-sdk/client-sts": "^3.529.1",
     "@guardian/content-api-models": "^17.8.0",
-    "@vendia/serverless-express": "^4.10.4",
+    "@codegenie/serverless-express": "^4.14.0",
     "aws-lambda": "^1.0.7",
     "axios": "^1.6.4",
     "body-parser": "^1.20.2",


### PR DESCRIPTION
## What does this change?

- Updates the recipe backend API to support dated curation delivery.
- Adds a lambda function to "launch" todays curation by copying it over the default path
  - Also detects when an update is made to todays curation and "re-launches" it

### New endpoints/arguments:

**POST** https://recipes.code.dev-guardianapis.com/api/curation/{region}/{variant}?date={YYYY-MM-DD} [authenticated]
**GET** https://recipes.code.dev-guardianapis/{region}/{variant}/{YYYY-MM-DD}/curation.json [open]

## How to test

1. POST some JSON to a 'test' region/variant combination, e.g. `region-andy-test`/`variant-one` using TOMORROW'S date.  Use a name that nobody else will use as you'll need to go back tomorrow.
2. Test that you can access it with the GET request above
3. Test that **GET** https://recipes.code.dev-guardianapis/{region}/{variant}/curation.json returns you 403
4. **POST** some _different_ JSON to the same region/variant combination, using TODAY'S date
5. **GET** https://recipes.code.dev-guardianapis/{region}/{variant}/curation.json should now return you this JSON (you might need to try a couple of times to allow for CDN lag)
6. Test the same GET tomorrow.  It should now return you the JSON you originally uploaded with tomorrow's date.

## How can we measure success?

Able to support future-launching of fronts

## Have we considered potential risks?

There is currently no protection against one user over-writing another's changes.  This will come with the Fronts Tool work.