### PR TITLE
Allow larger request body size

### DIFF
--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -11,7 +11,9 @@ app.set('view engine', 'ejs');
 app.engine('.ejs', ejs);
 
 const router = express.Router();
-router.use(bodyParser.json());
+router.use(bodyParser.json({
+  limit: '1mb'
+}));
 
 interface CurationParams {
   edition: string;


### PR DESCRIPTION
## What does this change?

Increases serverless-express body parser size limit from the default 100kb to 1mb.

This is because we have had user reports of upload failures for curation data from Mise En Place which turned out to be because the express framework was rejecting any json body over 100kb.  1mb should be sufficient for them.

## How to test

Deploy to CODE and send a 256kb blob of junk json data - it should respond 200 not request body too large (413).

This curl command sends data, assuming that the `smalldata.txt` file is your junk data file:

```bash
curl https://recipes.code.dev-guardianapis.com/api/curation/test-edition/test-front -X POST -d@smalldata.txt --header 'X-Api-Key: {valid-api-key}' --header 'Content-Type: application/json' -D-
```

Don't use a real edition or front name or you may break the app! (in CODE at least)

## How can we measure success?

Less user failures

## Have we considered potential risks?

We don't anticipate any problems going from 100kb to 1Mb, the lambda function has a 256Mb limit and isn't so marginal on RAM that we are at risk of OOM
