### PR TITLE
Add templateUrl field so frontend can get needed image size

### DIFF
--- a/lib/recipes-data/src/lib/models.ts
+++ b/lib/recipes-data/src/lib/models.ts
@@ -121,6 +121,7 @@ export function recipeReferenceFromIndexEntry(entry: RecipeIndexEntry, jsonBlob:
 
 export type RecipeImage = {
 	url: string;
+  templateUrl?: string; // Contains #{width} so that device can request image at needed size
 	mediaId?: string;
 	cropId?: string;
 	source?: string;

--- a/lib/recipes-data/src/lib/transform.test.ts
+++ b/lib/recipes-data/src/lib/transform.test.ts
@@ -56,7 +56,9 @@ describe('Recipe transforms', () => {
 			originalRecipe: RecipeFixture,
 			newRecipe: RecipeFixture,
 			expectedFeaturedUrl: string,
+			expectedFeaturedTemplateUrl: string | undefined,
 			expectedPreviewUrl: string,
+			expectedPreviewTemplateUrl: string | undefined,
 		) => {
 			const {
 				featuredImage: originalFeaturedImage,
@@ -67,10 +69,20 @@ describe('Recipe transforms', () => {
 
 			// We should have transformed the relevant URLs
 			expect(featuredImage.url).toBe(expectedFeaturedUrl);
+			expect(featuredImage.templateUrl).toBe(expectedFeaturedTemplateUrl);
 			expect(previewImage?.url).toBe(expectedPreviewUrl);
+			expect(previewImage?.templateUrl).toBe(expectedPreviewTemplateUrl);
 
-			const { url: __, ...remainingFeaturedImage } = featuredImage;
-			const { url: ___, ...remainingPreviewImage } = previewImage ?? {};
+			const {
+				url: __,
+				templateUrl: ___,
+				...remainingFeaturedImage
+			} = featuredImage;
+			const {
+				url: ____,
+				templateUrl: _____,
+				...remainingPreviewImage
+			} = previewImage ?? {};
 
 			// Everything else should be the same
 			expect(originalFeaturedImage).toMatchObject(remainingFeaturedImage);
@@ -87,7 +99,9 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
@@ -98,7 +112,9 @@ describe('Recipe transforms', () => {
 				recipes[1],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=300&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
@@ -117,11 +133,13 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
-    it('should derive media ids from image URL, succeeding if the mediaId is not present', () => {
+		it('should derive media ids from image URL, succeeding if the mediaId is not present', () => {
 			const { mediaId: _, ...featuredImage } = recipes[0].featuredImage;
 			const recipeWithFeaturedImageWithoutCropId = {
 				...recipes[0],
@@ -136,18 +154,19 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
-    it('should respect image extensions', () => {
+		it('should respect image extensions', () => {
 			const recipeWithFeaturedImageWithoutCropId = {
 				...recipes[0],
 				featuredImage: {
-          ...recipes[0].featuredImage,
-          url: 'https://media.guim.co.uk/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/2000.png'
-        },
-
+					...recipes[0].featuredImage,
+					url: 'https://media.guim.co.uk/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/2000.png',
+				},
 			};
 
 			const transformedRecipeReference = replaceImageUrlsWithFastly(
@@ -158,10 +177,11 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.png?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.png?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
-
 
 		it("should backfill the preview image if there isn't one", () => {
 			const { previewImage: _, ...recipeWithoutPreview } = recipes[0];
@@ -173,7 +193,9 @@ describe('Recipe transforms', () => {
 				recipeWithoutPreview,
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
@@ -191,8 +213,11 @@ describe('Recipe transforms', () => {
 			assertImageUrls(
 				recipeWithPreviewImageWithoutCropId,
 				transformedRecipeReference,
-        'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',			);
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+			);
 		});
 
 		it('should not attempt to extract a crop from the original URL if the featured image URL is not a guim URL', () => {
@@ -213,7 +238,9 @@ describe('Recipe transforms', () => {
 				recipeWithPreviewImageWithoutCropId,
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://cdn.road.cc/sites/default/files/styles/main_width/public/Wat-duck.png',
+				undefined,
 			);
 		});
 	});

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -11,6 +11,14 @@ const getFastlyUrl = (
   extension: string
 ) => `https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.${extension}?width=${desiredWidth}&dpr=${dpr}&s=none`;
 
+const getFastlyTemplateUrl = (
+	imageId: string,
+	cropId: string,
+	dpr: number,
+	originalWidth: number,
+  extension: string
+) => `https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.${extension}?width=#{width}&dpr=${dpr}&s=none`;
+
 export const replaceFastlyUrl = (
 	recipeId: string,
 	image: RecipeImage,
@@ -31,6 +39,7 @@ export const replaceFastlyUrl = (
 	return {
 		...image,
 		url: getFastlyUrl(mediaId, cropId, dpr, desiredWidth, width, extension),
+		templateUrl: getFastlyTemplateUrl(mediaId, cropId, dpr, width, extension),
 	};
 };
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds a new field with a placeholder of #{width} so that the frontend can request the recipe image at the desired width needed based on the context.

## How to test

- [x] The automated tests should pass.
- [ ] Test in CODE with a consuming device. Images should appear as expected.

## How can we measure success?
Data usage for app users goes down by a factor of 10.

## Have we considered potential risks?

