### PR TITLE
Add alias for NX, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ npm run update-cdk
 
 Will update the CDK snapshot and allow the tests to pass again
 
+## Running projects
+
+Build, test and lint with `npm run build`, `npm run test`, and `npm run lint`. This will run the relevant command for every project.
+
+To run commands against individual projects, use NX. It's installed as a project dependency, and there's a handy alias to run it via NPM: `npm run nx`.
+
+For example, to run the tests in the `lib-recipes-data` project in watch mode, use `npm run nx -- run lib-recipes-data:test --watch`.
+
+See the [NX documentation](https://nx.dev/nx-api/nx/documents) for other commands.
+
 ## How does it work?
 
 ```mermaid

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "nx run-many --target=test",
     "lint": "nx run-many --target=lint",
     "manual-takedown": "nx run tools-manual-takedown:run",
-    "commandline-reindex": "nx run lambda-recipes-responder:commandline-reindex -- "
+    "commandline-reindex": "nx run lambda-recipes-responder:commandline-reindex -- ",
+    "nx": "nx"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## What does this change?

Adds an alias for using the npm-installed NX executable for ad-hoc nx commands, and instructions for use.

## How to test

Useful? Clear how to use?