### PR TITLE
Minor template URL changes after feedback from iOS

### DIFF
--- a/lib/recipes-data/src/lib/models.ts
+++ b/lib/recipes-data/src/lib/models.ts
@@ -121,7 +121,7 @@ export function recipeReferenceFromIndexEntry(entry: RecipeIndexEntry, jsonBlob:
 
 export type RecipeImage = {
 	url: string;
-  templateUrl?: string; // Contains #{width} so that device can request image at needed size
+  templateURL?: string; // Contains #{width} so that device can request image at needed size
 	mediaId?: string;
 	cropId?: string;
 	source?: string;

--- a/lib/recipes-data/src/lib/transform.test.ts
+++ b/lib/recipes-data/src/lib/transform.test.ts
@@ -69,18 +69,18 @@ describe('Recipe transforms', () => {
 
 			// We should have transformed the relevant URLs
 			expect(featuredImage.url).toBe(expectedFeaturedUrl);
-			expect(featuredImage.templateUrl).toBe(expectedFeaturedTemplateUrl);
+			expect(featuredImage.templateURL).toBe(expectedFeaturedTemplateUrl);
 			expect(previewImage?.url).toBe(expectedPreviewUrl);
-			expect(previewImage?.templateUrl).toBe(expectedPreviewTemplateUrl);
+			expect(previewImage?.templateURL).toBe(expectedPreviewTemplateUrl);
 
 			const {
 				url: __,
-				templateUrl: ___,
+				templateURL: ___,
 				...remainingFeaturedImage
 			} = featuredImage;
 			const {
 				url: ____,
-				templateUrl: _____,
+				templateURL: _____,
 				...remainingPreviewImage
 			} = previewImage ?? {};
 

--- a/lib/recipes-data/src/lib/transform.test.ts
+++ b/lib/recipes-data/src/lib/transform.test.ts
@@ -99,9 +99,9 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 			);
 		});
 
@@ -112,9 +112,9 @@ describe('Recipe transforms', () => {
 				recipes[1],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 			);
 		});
 
@@ -133,9 +133,9 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 			);
 		});
 
@@ -154,9 +154,9 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 			);
 		});
 
@@ -177,9 +177,9 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.png?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.png?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.png?width=#{width}&quality=#{quality}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 			);
 		});
 
@@ -193,9 +193,9 @@ describe('Recipe transforms', () => {
 				recipeWithoutPreview,
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 			);
 		});
 
@@ -214,9 +214,9 @@ describe('Recipe transforms', () => {
 				recipeWithPreviewImageWithoutCropId,
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 			);
 		});
 
@@ -238,7 +238,7 @@ describe('Recipe transforms', () => {
 				recipeWithPreviewImageWithoutCropId,
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
 				'https://cdn.road.cc/sites/default/files/styles/main_width/public/Wat-duck.png',
 				undefined,
 			);

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -2,30 +2,50 @@ import { FeaturedImageWidth, ImageDpr, PreviewImageWidth } from './config';
 import type { Contributor, RecipeImage } from './models';
 import { extractCropDataFromGuimUrl } from './utils';
 
-const getFastlyUrl = (
-	imageId: string,
-	cropId: string,
-	dpr: number,
-	desiredWidth: number,
-	originalWidth: number,
-  extension: string
-) => `https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.${extension}?width=${desiredWidth}&dpr=${dpr}&s=none`;
+const getFastlyUrl = ({
+	imageId,
+	cropId,
+	dpr,
+	desiredWidth,
+	originalWidth,
+	extension,
+}: {
+	imageId: string;
+	cropId: string;
+	dpr: number;
+	desiredWidth: number;
+	originalWidth: number;
+	extension: string;
+}) =>
+	`https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.${extension}?width=${desiredWidth}&dpr=${dpr}&s=none`;
 
-const getFastlyTemplateUrl = (
-	imageId: string,
-	cropId: string,
-	dpr: number,
-	originalWidth: number,
-  extension: string
-) => `https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.${extension}?width=#{width}&dpr=${dpr}&s=none`;
+const getFastlyTemplateUrl = ({
+	imageId,
+	cropId,
+	dpr,
+	originalWidth,
+	extension,
+}: {
+	imageId: string;
+	cropId: string;
+	dpr: number;
+	originalWidth: number;
+	extension: string;
+}) =>
+	`https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.${extension}?width=#{width}&quality=#{quality}&dpr=${dpr}&s=none`;
 
-export const replaceFastlyUrl = (
-	recipeId: string,
-	image: RecipeImage,
-	desiredWidth: number,
-	dpr: number,
-): RecipeImage => {
-  const cropData = extractCropDataFromGuimUrl(image.url);
+export const replaceFastlyUrl = ({
+	recipeId,
+	image,
+	desiredWidth,
+	dpr,
+}: {
+	recipeId: string;
+	image: RecipeImage;
+	desiredWidth: number;
+	dpr: number;
+}): RecipeImage => {
+	const cropData = extractCropDataFromGuimUrl(image.url);
 
 	if (!cropData) {
 		console.warn(
@@ -38,8 +58,21 @@ export const replaceFastlyUrl = (
 
 	return {
 		...image,
-		url: getFastlyUrl(mediaId, cropId, dpr, desiredWidth, width, extension),
-		templateUrl: getFastlyTemplateUrl(mediaId, cropId, dpr, width, extension),
+		url: getFastlyUrl({
+			imageId: mediaId,
+			cropId,
+			dpr,
+			desiredWidth,
+			originalWidth: width,
+			extension,
+		}),
+		templateUrl: getFastlyTemplateUrl({
+			imageId: mediaId,
+			cropId,
+			dpr,
+			originalWidth: width,
+			extension,
+		}),
 	};
 };
 
@@ -66,18 +99,18 @@ export const replaceImageUrlsWithFastly = <R extends RecipeWithImageData>(
 	try {
 		return {
 			...recipe,
-			previewImage: replaceFastlyUrl(
-				recipe.id,
-				recipe.previewImage ?? recipe.featuredImage,
-				PreviewImageWidth,
-				ImageDpr,
-			),
-			featuredImage: replaceFastlyUrl(
-				recipe.id,
-				recipe.featuredImage,
-				FeaturedImageWidth,
-				ImageDpr,
-			),
+			previewImage: replaceFastlyUrl({
+				recipeId: recipe.id,
+				image: recipe.previewImage ?? recipe.featuredImage,
+				desiredWidth: PreviewImageWidth,
+				dpr: ImageDpr,
+    }),
+			featuredImage: replaceFastlyUrl({
+				recipeId: recipe.id,
+				image: recipe.featuredImage,
+				desiredWidth: FeaturedImageWidth,
+				dpr: ImageDpr,
+    }),
 		};
 	} catch (err) {
 		if (err instanceof Error) {

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -66,7 +66,7 @@ export const replaceFastlyUrl = ({
 			originalWidth: width,
 			extension,
 		}),
-		templateUrl: getFastlyTemplateUrl({
+		templateURL: getFastlyTemplateUrl({
 			imageId: mediaId,
 			cropId,
 			dpr,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

A few minor changes re: feedback –
- `templateUrl` -> `templateURL`, as this is what the (in production) iOS app already uses
- added a `quality` template param

Also a minor refactor as the arity of some functions was quite large, which merited a conversion to an options object.

## How to test

- [x] The automated tests should pass.
- [ ] Deploy to CODE, reindex content, and verify that things are as expected with the Feast team.