### PR TITLE
Revert template URL work

### DIFF
--- a/lib/recipes-data/src/lib/models.ts
+++ b/lib/recipes-data/src/lib/models.ts
@@ -121,7 +121,6 @@ export function recipeReferenceFromIndexEntry(entry: RecipeIndexEntry, jsonBlob:
 
 export type RecipeImage = {
 	url: string;
-  templateUrl?: string; // Contains #{width} so that device can request image at needed size
 	mediaId?: string;
 	cropId?: string;
 	source?: string;

--- a/lib/recipes-data/src/lib/models.ts
+++ b/lib/recipes-data/src/lib/models.ts
@@ -121,7 +121,7 @@ export function recipeReferenceFromIndexEntry(entry: RecipeIndexEntry, jsonBlob:
 
 export type RecipeImage = {
 	url: string;
-  templateURL?: string; // Contains #{width} so that device can request image at needed size
+  templateUrl?: string; // Contains #{width} so that device can request image at needed size
 	mediaId?: string;
 	cropId?: string;
 	source?: string;

--- a/lib/recipes-data/src/lib/transform.test.ts
+++ b/lib/recipes-data/src/lib/transform.test.ts
@@ -56,9 +56,7 @@ describe('Recipe transforms', () => {
 			originalRecipe: RecipeFixture,
 			newRecipe: RecipeFixture,
 			expectedFeaturedUrl: string,
-			expectedFeaturedTemplateUrl: string | undefined,
 			expectedPreviewUrl: string,
-			expectedPreviewTemplateUrl: string | undefined,
 		) => {
 			const {
 				featuredImage: originalFeaturedImage,
@@ -69,20 +67,10 @@ describe('Recipe transforms', () => {
 
 			// We should have transformed the relevant URLs
 			expect(featuredImage.url).toBe(expectedFeaturedUrl);
-			expect(featuredImage.templateUrl).toBe(expectedFeaturedTemplateUrl);
 			expect(previewImage?.url).toBe(expectedPreviewUrl);
-			expect(previewImage?.templateUrl).toBe(expectedPreviewTemplateUrl);
 
-			const {
-				url: __,
-				templateUrl: ___,
-				...remainingFeaturedImage
-			} = featuredImage;
-			const {
-				url: ____,
-				templateUrl: _____,
-				...remainingPreviewImage
-			} = previewImage ?? {};
+			const { url: __, ...remainingFeaturedImage } = featuredImage;
+			const { url: ___, ...remainingPreviewImage } = previewImage ?? {};
 
 			// Everything else should be the same
 			expect(originalFeaturedImage).toMatchObject(remainingFeaturedImage);
@@ -99,9 +87,7 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
@@ -112,9 +98,7 @@ describe('Recipe transforms', () => {
 				recipes[1],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
@@ -133,13 +117,11 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
-		it('should derive media ids from image URL, succeeding if the mediaId is not present', () => {
+    it('should derive media ids from image URL, succeeding if the mediaId is not present', () => {
 			const { mediaId: _, ...featuredImage } = recipes[0].featuredImage;
 			const recipeWithFeaturedImageWithoutCropId = {
 				...recipes[0],
@@ -154,19 +136,18 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
-		it('should respect image extensions', () => {
+    it('should respect image extensions', () => {
 			const recipeWithFeaturedImageWithoutCropId = {
 				...recipes[0],
 				featuredImage: {
-					...recipes[0].featuredImage,
-					url: 'https://media.guim.co.uk/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/2000.png',
-				},
+          ...recipes[0].featuredImage,
+          url: 'https://media.guim.co.uk/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/2000.png'
+        },
+
 			};
 
 			const transformedRecipeReference = replaceImageUrlsWithFastly(
@@ -177,11 +158,10 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.png?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.png?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
+
 
 		it("should backfill the preview image if there isn't one", () => {
 			const { previewImage: _, ...recipeWithoutPreview } = recipes[0];
@@ -193,9 +173,7 @@ describe('Recipe transforms', () => {
 				recipeWithoutPreview,
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
@@ -213,11 +191,8 @@ describe('Recipe transforms', () => {
 			assertImageUrls(
 				recipeWithPreviewImageWithoutCropId,
 				transformedRecipeReference,
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
-			);
+        'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',			);
 		});
 
 		it('should not attempt to extract a crop from the original URL if the featured image URL is not a guim URL', () => {
@@ -238,9 +213,7 @@ describe('Recipe transforms', () => {
 				recipeWithPreviewImageWithoutCropId,
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://cdn.road.cc/sites/default/files/styles/main_width/public/Wat-duck.png',
-				undefined,
 			);
 		});
 	});

--- a/lib/recipes-data/src/lib/transform.test.ts
+++ b/lib/recipes-data/src/lib/transform.test.ts
@@ -69,18 +69,18 @@ describe('Recipe transforms', () => {
 
 			// We should have transformed the relevant URLs
 			expect(featuredImage.url).toBe(expectedFeaturedUrl);
-			expect(featuredImage.templateURL).toBe(expectedFeaturedTemplateUrl);
+			expect(featuredImage.templateUrl).toBe(expectedFeaturedTemplateUrl);
 			expect(previewImage?.url).toBe(expectedPreviewUrl);
-			expect(previewImage?.templateURL).toBe(expectedPreviewTemplateUrl);
+			expect(previewImage?.templateUrl).toBe(expectedPreviewTemplateUrl);
 
 			const {
 				url: __,
-				templateURL: ___,
+				templateUrl: ___,
 				...remainingFeaturedImage
 			} = featuredImage;
 			const {
 				url: ____,
-				templateURL: _____,
+				templateUrl: _____,
 				...remainingPreviewImage
 			} = previewImage ?? {};
 
@@ -99,9 +99,9 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
@@ -112,9 +112,9 @@ describe('Recipe transforms', () => {
 				recipes[1],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/902a2c387ba62c49ad7553c2712eb650e73eb5b2/258_0_7328_4400/master/7328.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
@@ -133,9 +133,9 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
@@ -154,9 +154,9 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
@@ -177,9 +177,9 @@ describe('Recipe transforms', () => {
 				recipes[0],
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.png?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.png?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.png?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
@@ -193,9 +193,9 @@ describe('Recipe transforms', () => {
 				recipeWithoutPreview,
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
@@ -214,9 +214,9 @@ describe('Recipe transforms', () => {
 				recipeWithPreviewImageWithoutCropId,
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=300&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 			);
 		});
 
@@ -238,7 +238,7 @@ describe('Recipe transforms', () => {
 				recipeWithPreviewImageWithoutCropId,
 				transformedRecipeReference,
 				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=700&dpr=1&s=none',
-				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&quality=#{quality}&dpr=1&s=none',
+				'https://i.guim.co.uk/img/media/87a7591d5260e962ad459d56771f50fc0ce05f14/360_1725_4754_4754/master/4754.jpg?width=#{width}&dpr=1&s=none',
 				'https://cdn.road.cc/sites/default/files/styles/main_width/public/Wat-duck.png',
 				undefined,
 			);

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -11,14 +11,6 @@ const getFastlyUrl = (
   extension: string
 ) => `https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.${extension}?width=${desiredWidth}&dpr=${dpr}&s=none`;
 
-const getFastlyTemplateUrl = (
-	imageId: string,
-	cropId: string,
-	dpr: number,
-	originalWidth: number,
-  extension: string
-) => `https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.${extension}?width=#{width}&dpr=${dpr}&s=none`;
-
 export const replaceFastlyUrl = (
 	recipeId: string,
 	image: RecipeImage,
@@ -39,7 +31,6 @@ export const replaceFastlyUrl = (
 	return {
 		...image,
 		url: getFastlyUrl(mediaId, cropId, dpr, desiredWidth, width, extension),
-		templateUrl: getFastlyTemplateUrl(mediaId, cropId, dpr, width, extension),
 	};
 };
 

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -2,50 +2,30 @@ import { FeaturedImageWidth, ImageDpr, PreviewImageWidth } from './config';
 import type { Contributor, RecipeImage } from './models';
 import { extractCropDataFromGuimUrl } from './utils';
 
-const getFastlyUrl = ({
-	imageId,
-	cropId,
-	dpr,
-	desiredWidth,
-	originalWidth,
-	extension,
-}: {
-	imageId: string;
-	cropId: string;
-	dpr: number;
-	desiredWidth: number;
-	originalWidth: number;
-	extension: string;
-}) =>
-	`https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.${extension}?width=${desiredWidth}&dpr=${dpr}&s=none`;
+const getFastlyUrl = (
+	imageId: string,
+	cropId: string,
+	dpr: number,
+	desiredWidth: number,
+	originalWidth: number,
+  extension: string
+) => `https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.${extension}?width=${desiredWidth}&dpr=${dpr}&s=none`;
 
-const getFastlyTemplateUrl = ({
-	imageId,
-	cropId,
-	dpr,
-	originalWidth,
-	extension,
-}: {
-	imageId: string;
-	cropId: string;
-	dpr: number;
-	originalWidth: number;
-	extension: string;
-}) =>
-	`https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.${extension}?width=#{width}&quality=#{quality}&dpr=${dpr}&s=none`;
+const getFastlyTemplateUrl = (
+	imageId: string,
+	cropId: string,
+	dpr: number,
+	originalWidth: number,
+  extension: string
+) => `https://i.guim.co.uk/img/media/${imageId}/${cropId}/master/${originalWidth}.${extension}?width=#{width}&dpr=${dpr}&s=none`;
 
-export const replaceFastlyUrl = ({
-	recipeId,
-	image,
-	desiredWidth,
-	dpr,
-}: {
-	recipeId: string;
-	image: RecipeImage;
-	desiredWidth: number;
-	dpr: number;
-}): RecipeImage => {
-	const cropData = extractCropDataFromGuimUrl(image.url);
+export const replaceFastlyUrl = (
+	recipeId: string,
+	image: RecipeImage,
+	desiredWidth: number,
+	dpr: number,
+): RecipeImage => {
+  const cropData = extractCropDataFromGuimUrl(image.url);
 
 	if (!cropData) {
 		console.warn(
@@ -58,21 +38,8 @@ export const replaceFastlyUrl = ({
 
 	return {
 		...image,
-		url: getFastlyUrl({
-			imageId: mediaId,
-			cropId,
-			dpr,
-			desiredWidth,
-			originalWidth: width,
-			extension,
-		}),
-		templateURL: getFastlyTemplateUrl({
-			imageId: mediaId,
-			cropId,
-			dpr,
-			originalWidth: width,
-			extension,
-		}),
+		url: getFastlyUrl(mediaId, cropId, dpr, desiredWidth, width, extension),
+		templateUrl: getFastlyTemplateUrl(mediaId, cropId, dpr, width, extension),
 	};
 };
 
@@ -99,18 +66,18 @@ export const replaceImageUrlsWithFastly = <R extends RecipeWithImageData>(
 	try {
 		return {
 			...recipe,
-			previewImage: replaceFastlyUrl({
-				recipeId: recipe.id,
-				image: recipe.previewImage ?? recipe.featuredImage,
-				desiredWidth: PreviewImageWidth,
-				dpr: ImageDpr,
-    }),
-			featuredImage: replaceFastlyUrl({
-				recipeId: recipe.id,
-				image: recipe.featuredImage,
-				desiredWidth: FeaturedImageWidth,
-				dpr: ImageDpr,
-    }),
+			previewImage: replaceFastlyUrl(
+				recipe.id,
+				recipe.previewImage ?? recipe.featuredImage,
+				PreviewImageWidth,
+				ImageDpr,
+			),
+			featuredImage: replaceFastlyUrl(
+				recipe.id,
+				recipe.featuredImage,
+				FeaturedImageWidth,
+				ImageDpr,
+			),
 		};
 	} catch (err) {
 		if (err instanceof Error) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Reverts #38 and #43 to remove the `templateURL` field, which requires additional work in iOS. 

## How to test

Deploy and reindex CODE. You should see images in recipes no longer contain a `templateURL` property.