### PR TITLE
Connect to eventbridge

### DIFF
--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -318,7 +318,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
     "CrierConnectionE7D24320": {
       "Properties": {
         "Description": "Connect recipe responder TEST to Crier",
-        "EventBusName": "content-api-crier-v2-TEST",
+        "EventBusName": "crier-eventbus-content-api-crier-v2-TEST",
         "EventPattern": {
           "detail": {
             "channels": [

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -11,7 +11,7 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       "GuParameter",
       "GuParameter",
       "GuParameter",
-      "GuKinesisLambdaExperimental",
+      "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaErrorPercentageAlarm",
       "GuApiLambda",
@@ -295,6 +295,66 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "CrierConnectionAllowEventRuleRecipesBackendupdaterLambda0796CBC53405D228": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "updaterLambdaE2EB52D9",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "CrierConnectionE7D24320",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "CrierConnectionE7D24320": {
+      "Properties": {
+        "Description": "Connect recipe responder TEST to Crier",
+        "EventBusName": "content-api-crier-v2-TEST",
+        "EventPattern": {
+          "detail": {
+            "channels": [
+              "feast",
+            ],
+          },
+          "source": [
+            "crier",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "updaterLambdaE2EB52D9",
+                "Arn",
+              ],
+            },
+            "DeadLetterConfig": {
+              "Arn": {
+                "Fn::GetAtt": [
+                  "RecipeResponcerDLQF19E09A3",
+                  "Arn",
+                ],
+              },
+            },
+            "Id": "Target0",
+            "RetryPolicy": {
+              "MaximumEventAgeInSeconds": 1800,
+              "MaximumRetryAttempts": 5,
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
     },
     "DurationRuntimeAlarmC21C10E0": {
       "Properties": {
@@ -1347,6 +1407,71 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "RecipeResponcerDLQF19E09A3": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "QueueName": "recipe-responder-TEST-DLQ",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "content-api",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RecipeResponcerDLQPolicyB88FED23": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "CrierConnectionE7D24320",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "RecipeResponcerDLQF19E09A3",
+                  "Arn",
+                ],
+              },
+              "Sid": "AllowEventRuleRecipesBackendCrierConnection45DBF5AE",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Queues": [
+          {
+            "Ref": "RecipeResponcerDLQF19E09A3",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::QueuePolicy",
     },
     "RecipesFaciaConnection04952500": {
       "DeletionPolicy": "Delete",
@@ -2505,6 +2630,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
             },
           },
         },
+        "FunctionName": "recipe-responder-content-api-TEST",
         "Handler": "main.handler",
         "MemorySize": 512,
         "Role": {
@@ -2539,34 +2665,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "Timeout": 30,
       },
       "Type": "AWS::Lambda::Function",
-    },
-    "updaterLambdaKinesisEventSourceRecipesBackendcontentapifirehosev2TEST610C4BA2C96AE54F": {
-      "Properties": {
-        "BatchSize": 100,
-        "BisectBatchOnFunctionError": true,
-        "EventSourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:aws:kinesis:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":stream/content-api-firehose-v2-TEST",
-            ],
-          ],
-        },
-        "FunctionName": {
-          "Ref": "updaterLambdaE2EB52D9",
-        },
-        "MaximumRetryAttempts": 5,
-        "StartingPosition": "LATEST",
-      },
-      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "updaterLambdaServiceRole83C687C0": {
       "Properties": {
@@ -2770,55 +2868,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Ref": "AWS::AccountId",
                     },
                     ":parameter/TEST/content-api/recipes-responder/*",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "kinesis:DescribeStreamSummary",
-                "kinesis:GetRecords",
-                "kinesis:GetShardIterator",
-                "kinesis:ListShards",
-                "kinesis:SubscribeToShard",
-                "kinesis:DescribeStream",
-                "kinesis:ListStreams",
-                "kinesis:DescribeStreamConsumer",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:kinesis:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":stream/content-api-firehose-v2-TEST",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": "kinesis:DescribeStream",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:kinesis:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":stream/content-api-firehose-v2-TEST",
                   ],
                 ],
               },

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -9,12 +9,12 @@ import {EventBus, Rule, Schedule} from "aws-cdk-lib/aws-events";
 import {Effect, PolicyStatement} from "aws-cdk-lib/aws-iam";
 import {Architecture, Runtime} from "aws-cdk-lib/aws-lambda";
 import {LambdaDestination} from "aws-cdk-lib/aws-s3-notifications";
+import {Queue} from "aws-cdk-lib/aws-sqs";
 import {DataStore} from "./datastore";
 import {ExternalParameters} from "./external_parameters";
 import {FaciaConnection} from "./facia-connection";
 import {RestEndpoints} from "./rest-endpoints";
 import {StaticServing} from "./static-serving";
-import {Queue} from "aws-cdk-lib/aws-sqs";
 
 export class RecipesBackend extends GuStack {
   constructor(scope: App, id: string, props: GuStackProps) {
@@ -134,7 +134,7 @@ export class RecipesBackend extends GuStack {
       timeout: lambdaTimeout
     });
 
-    const eventBus = EventBus.fromEventBusName(this, "CrierEventBus", `content-api-crier-v2-${this.stage}`);
+    const eventBus = EventBus.fromEventBusName(this, "CrierEventBus", `crier-eventbus-content-api-crier-v2-${this.stage}`);
     const responderDLQ = new Queue(this, "RecipeResponcerDLQ", {
       queueName: `recipe-responder-${this.stage}-DLQ`
     });
@@ -202,7 +202,7 @@ export class RecipesBackend extends GuStack {
         }),
         new PolicyStatement({
           effect: Effect.ALLOW,
-          actions: ["s3:PutObject","s3:GetObject"],
+          actions: ["s3:PutObject", "s3:GetObject"],
           resources: [serving.staticBucket.bucketArn + "/*"]
         }),
         new PolicyStatement({
@@ -230,7 +230,7 @@ export class RecipesBackend extends GuStack {
 
     serving.staticBucket.addObjectCreatedNotification(
       new LambdaDestination(publishTodaysCurationLambda),
-      { suffix: "curation.json", }
+      {suffix: "curation.json",}
     );
   }
 

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -2,12 +2,10 @@ import {GuScheduledLambda} from "@guardian/cdk";
 import type {GuStackProps} from "@guardian/cdk/lib/constructs/core";
 import {GuParameter, GuStack} from "@guardian/cdk/lib/constructs/core";
 import {GuLambdaFunction} from "@guardian/cdk/lib/constructs/lambda";
-import {GuKinesisLambdaExperimental} from "@guardian/cdk/lib/experimental/patterns";
-import {StreamRetry} from "@guardian/cdk/lib/utils/lambda";
-import {type App, aws_sns, Duration} from "aws-cdk-lib";
+import {type App, aws_events_targets, aws_sns, Duration} from "aws-cdk-lib";
 import {Alarm, ComparisonOperator, TreatMissingData, Unit} from "aws-cdk-lib/aws-cloudwatch";
 import {SnsAction} from "aws-cdk-lib/aws-cloudwatch-actions";
-import {Schedule} from "aws-cdk-lib/aws-events";
+import {EventBus, Rule, Schedule} from "aws-cdk-lib/aws-events";
 import {Effect, PolicyStatement} from "aws-cdk-lib/aws-iam";
 import {Architecture, Runtime} from "aws-cdk-lib/aws-lambda";
 import {LambdaDestination} from "aws-cdk-lib/aws-s3-notifications";
@@ -16,6 +14,7 @@ import {ExternalParameters} from "./external_parameters";
 import {FaciaConnection} from "./facia-connection";
 import {RestEndpoints} from "./rest-endpoints";
 import {StaticServing} from "./static-serving";
+import {Queue} from "aws-cdk-lib/aws-sqs";
 
 export class RecipesBackend extends GuStack {
   constructor(scope: App, id: string, props: GuStackProps) {
@@ -93,15 +92,8 @@ export class RecipesBackend extends GuStack {
 
     const contentUrlBase = this.stage === "CODE" ? "recipes.code.dev-guardianapis.com" : "recipes.guardianapis.com";
 
-    const updaterLambda = new GuKinesisLambdaExperimental(this, "updaterLambda", {
-      monitoringConfiguration: {noMonitoring: true},
-      existingKinesisStream: {
-        externalKinesisStreamName: `content-api-firehose-v2-${this.stage}`,
-      },
-      errorHandlingConfiguration: {
-        retryBehaviour: StreamRetry.maxAttempts(5),
-        bisectBatchOnError: true,
-      },
+    const updaterLambda = new GuLambdaFunction(this, "updaterLambda", {
+      functionName: `recipe-responder-${this.stack}-${this.stage}`,
       environment: {
         CAPI_KEY: capiKeyParam.valueAsString,
         INDEX_TABLE: store.table.tableName,
@@ -140,6 +132,29 @@ export class RecipesBackend extends GuStack {
       handler: "main.handler",
       fileName: `${app}.zip`,
       timeout: lambdaTimeout
+    });
+
+    const eventBus = EventBus.fromEventBusName(this, "CrierEventBus", `content-api-crier-v2-${this.stage}`);
+    const responderDLQ = new Queue(this, "RecipeResponcerDLQ", {
+      queueName: `recipe-responder-${this.stage}-DLQ`
+    });
+
+    new Rule(this, "CrierConnection", {
+      eventBus,
+      description: `Connect recipe responder ${this.stage} to Crier`,
+      eventPattern: {
+        "source": ["crier"],
+        "detail": {
+          "channels": ["feast"]
+        }
+      },
+      targets: [
+        new aws_events_targets.LambdaFunction(updaterLambda, {
+          deadLetterQueue: responderDLQ,
+          maxEventAge: Duration.minutes(30),
+          retryAttempts: 5,
+        }),
+      ]
     });
 
     new FaciaConnection(this, "RecipesFacia", {

--- a/lambda/recipes-responder/src/eventbridge_models.ts
+++ b/lambda/recipes-responder/src/eventbridge_models.ts
@@ -1,0 +1,5 @@
+export interface CrierEvent {
+  "capi-models"?: string;
+  channels?: string[];
+  event: string;  //Base64-encoded Thrift event
+}

--- a/lambda/recipes-responder/src/main.test.ts
+++ b/lambda/recipes-responder/src/main.test.ts
@@ -282,7 +282,7 @@ describe("main.handler", () => {
 
     const eventMock:EventBridgeEvent<string, CrierEvent> =
     {
-      "account": "308506855511",
+      "account": "234786246782",
       "detail": testReq,
       "detail-type": "content-update",
       "id": "d8acb3c0-2426-43f3-beb5-bdf2f2c973b5",

--- a/lambda/recipes-responder/src/main.test.ts
+++ b/lambda/recipes-responder/src/main.test.ts
@@ -3,7 +3,13 @@ import {EventType} from "@guardian/content-api-models/crier/event/v1/eventType";
 import {ItemType} from "@guardian/content-api-models/crier/event/v1/itemType";
 import type {Content} from "@guardian/content-api-models/v1/content";
 import {ContentType} from "@guardian/content-api-models/v1/contentType";
-import type {Callback, KinesisStreamBatchResponse, KinesisStreamEvent, KinesisStreamRecord} from "aws-lambda";
+import type {
+  Callback,
+  EventBridgeEvent,
+  KinesisStreamBatchResponse,
+  KinesisStreamEvent,
+  KinesisStreamRecord
+} from "aws-lambda";
 import formatISO from "date-fns/formatISO";
 import {registerMetric} from "@recipes-api/cwmetrics";
 import {deserializeEvent} from "@recipes-api/lib/capi";
@@ -11,6 +17,7 @@ import {handler, processRecord} from "./main";
 import {handleDeletedContent, handleTakedown} from "./takedown_processor";
 import {handleContentUpdate} from "./update_processor";
 import {handleContentUpdateRetrievable} from "./update_retrievable_processor";
+import {CrierEvent} from "./eventbridge_models";
 
 jest.mock("@recipes-api/lib/capi", () => ({
   deserializeEvent: jest.fn(),
@@ -262,19 +269,29 @@ describe("main.processRecord", () => {
 describe("main.handler", () => {
 
   it("should call registerMetric", async () => {
-    //@ts-ignore
-    const testReq: KinesisStreamRecord = {
-      //@ts-ignore
-      kinesis: {
-        data: "base64-would-be-here"
+    const testReq:CrierEvent = {
+        "capi-models": "25.0.0",
+        "channels": [
+          "open",
+          "feast",
+          "editions",
+          "newsletters"
+        ],
+        "event": "GFR1ay1uZXdzL2FydGljbGUvMjAyNC9qdWwv… (73324 chars)"
       }
-    }
 
-    const eventMock: KinesisStreamEvent = {
-      Records: [
-        testReq
-      ],
-    };
+    const eventMock:EventBridgeEvent<string, CrierEvent> =
+    {
+      "account": "308506855511",
+      "detail": testReq,
+      "detail-type": "content-update",
+      "id": "d8acb3c0-2426-43f3-beb5-bdf2f2c973b5",
+      "region": "eu-west-1",
+      "resources": [],
+      "source": "crier",
+      "time": "2024-07-10T13:10:44Z",
+      "version": "0"
+    }
 
     const contextMock = {
       awsRequestId: "",


### PR DESCRIPTION
## What does this change?

- Removes the connection to Kinesis and replaces with a channel-specific EventBridge connection
- Changes the Responder lambda function name to something a bit easier to read!

## How to test

- Deploy this to CODE
- Make sure `main` branch Composer is deployed to CODE
- Make sure `main` branch Crier is deployed to CODE
- Open the responder logs in a tab: https://logs.gutools.co.uk/s/content-platforms/app/discover#/view/07684cb0-8893-11ee-a54f-21683a02b3a0?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(stage,level,message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:b0be43a0-59d7-11e8-a75a-b7af20e8f748,key:app.keyword,negate:!f,params:(query:recipes-responder),type:phrase),query:(match_phrase:(app.keyword:recipes-responder))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:b0be43a0-59d7-11e8-a75a-b7af20e8f748,key:stage,negate:!t,params:(query:PROD),type:phrase),query:(match_phrase:(stage:PROD)))),grid:(),hideChart:!f,index:b0be43a0-59d7-11e8-a75a-b7af20e8f748,interval:auto,query:(language:lucene,query:'app:*recipe*'),sort:!(!('@timestamp',desc)))

### Scenario 1: Channel-only
- In Composer CODE, create a new article
- Add a recipe element to it (put in some dummy data)
- Add furniture for publication. DON'T publish.
- In the `Advanced` panel, click `Launch` next to `Feast App`. The indicator should change from red to green
- Within 10s, you should see some activity from the lambda in ELK.  You can find the published recipe ID by l;ooking for the `Purge of content` lines
- In another new tab, go to `https://recipes.code.dev-guardianapis.com/content/{content-id}`. You should see information there.
- Back in Composer, make some changes to the recipe element
- Relaunch them using the `Update content` button under the Channels in `Advanced`
- You should again see some activity from the lambda function
- Refresh the JSON information that you obtained earlier. You should get a "permission denied" error (this is S3 masking content-does-not-exist)
- Back in the lambda logs, find the new SHA for the changed recipe
- Update your recipes.code.dev-guardianapis.com URI for the new SHA. You should see your updated content.
- Take the recipe down from the channel. It should be removed from recipes.code.dev-guardianapis.com.

### Scenario 2: Global launch
- In Composer CODE, create a new article
- Add a recipe element to it (put in some dummy data)
- Add furniture for publication. Hit the `Publish` button.
- Within 10s, you should see some activity from the lambda in ELK.  You can find the published recipe ID by l;ooking for the `Purge of content` lines
- In another new tab, go to `https://recipes.code.dev-guardianapis.com/content/{content-id}`. You should see information there.
- Back in Composer, make some changes to the recipe element
- Relaunch them using the `Update content` button under the Channels in `Advanced`
- You should again see some activity from the lambda function
- Refresh the JSON information that you obtained earlier. You should get a "permission denied" error (this is S3 masking content-does-not-exist)
- Back in the lambda logs, find the new SHA for the changed recipe
- Update your recipes.code.dev-guardianapis.com URI for the new SHA. You should see your updated content.
- Take the recipe down from the channel. It should be removed from recipes.code.dev-guardianapis.com.

_Note that due to a bug in Composer, once a page is taken down it will not automatically relaunch to Channels. You need to explicity launch it as in the first scenario_

### Scenario 3: Embargo to Feast
Follow the steps for "Global Launch" above, but before you `Publish` go to `Channels` under `Advanced` and click `Embargo` next to `Feast App`
- Now when you launch globally, you should not see any activity from the lambda function at all.

## How can we measure success?

The Feast app respects the channelling flags for Feast app in Composer
