### PR TITLE
Replace canonical article with CAPI ID

### DIFF
--- a/lib/recipes-data/src/lib/extract-recipes.test.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.test.ts
@@ -5,6 +5,7 @@ import type {Sponsorship} from "@guardian/content-api-models/v1/sponsorship";
 import {SponsorshipType} from "@guardian/content-api-models/v1/sponsorshipType";
 import {extractRecipeData} from "./extract-recipes";
 import {makeCapiDateTime} from './utils';
+import { RecipeWithImageData } from "./transform";
 
 jest.mock('./config', () => ({
   FeaturedImageWidth: 700,
@@ -594,4 +595,93 @@ describe("extractRecipeData", () => {
   })
 
 
+  it("should update the canonicalArticle with the content ID", () => {
+    const canonicalId = "a-new-path"
+    const block: Block = {
+      id: "5a4b754ce4b0e33567c465c7",
+      bodyHtml: "<figure class=\"element element-image\" data-media-id=\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\"> <img src=\"https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg\" alt=\"Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.\" width=\"1000\" height=\"600\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class=\"element-image__credit\">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>",
+      bodyTextSummary: "",
+      attributes: {},
+      published: true,
+      contributors: [],
+      createdBy: {
+        email: "stephanie.fincham@guardian.co.uk",
+        firstName: "Stephanie",
+        lastName: "Fincham"
+      },
+      lastModifiedBy: {
+        email: "stephanie.fincham@guardian.co.uk",
+        firstName: "Stephanie",
+        lastName: "Fincham"
+      },
+      elements: [
+        {
+          type: ElementType.TEXT,
+          assets: [],
+          textTypeData: {
+            html: "<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>"
+          }
+        },
+        {
+          type: ElementType.RECIPE,
+          assets: [],
+          recipeTypeData: {
+            recipeJson: "{\"id\":\"1\",\"canonicalArticle\":\"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers\",\"title\":\"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing\",\"featuredImage\":\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\",\"contributors\":[{\"type\":\"contributor\",\"tagId\":\"profile/thomasina-miers\"}],\"ingredients\":[{\"recipeSection\":\"For the dressing\",\"ingredientsList\":[{\"item\":\"soba\",\"unit\":\"g\",\"comment\":\"or glass noodles\",\"text\":\"200g soba or glass noodles\"},{\"item\":\"frozen soya beans\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g frozen soya beans\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp sesame oil\"},{\"item\":\"carrots\",\"unit\":\"\",\"comment\":\"peeled then grated or cut into thin ribbons\",\"text\":\"2 carrots, peeled, then grated or cut into thin ribbons\"},{\"item\":\"red cabbage\",\"unit\":\"g\",\"comment\":\"finely shredded\",\"text\":\"150g red cabbage, finely shredded\"},{\"item\":\"mooli\",\"unit\":\"g\",\"comment\":\"or radishes cut into matchsticks or thin slivers\",\"text\":\"100g mooli or radishes, cut into matchsticks or thin slivers\"},{\"item\":\"green apple\",\"unit\":\"\",\"comment\":\"\",\"text\":\"1 green apple\"},{\"item\":\"spring onions\",\"unit\":\"\",\"comment\":\"finely sliced\",\"text\":\"3 spring onions, finely sliced\"},{\"item\":\"coriander\",\"unit\":\"small bunch\",\"comment\":\"roughly chopped\",\"text\":\"1 small bunch coriander, roughly chopped\"},{\"item\":\"mint leaves\",\"unit\":\"handful\",\"comment\":\"roughly torn\",\"text\":\"1 handful mint leaves, roughly torn\"},{\"item\":\"basil leaves\",\"unit\":\"handful\",\"comment\":\"or more coriander roughly chopped\",\"text\":\"1 handful basil leaves (or more coriander), roughly chopped\"},{\"item\":\"toasted sunflower seeds\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"40g toasted sunflower seeds\"},{\"item\":\"toasted sesame seeds\",\"unit\":\"g\",\"comment\":\"a mixture of black and white looks good to serve\",\"text\":\"25g toasted sesame seeds (a mixture of black and white looks good), to serve\"}]},{\"recipeSection\":\"And for the rest of the week…\",\"ingredientsList\":[{\"item\":\"fresh ginger\",\"unit\":\"thumb\",\"comment\":\"sized chunk  peeled\",\"text\":\"1 thumb-sized chunk fresh ginger, peeled\"},{\"item\":\"garlic\",\"unit\":\"clove\",\"comment\":\"\",\"text\":\"½ garlic clove\"},{\"item\":\"tahini\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g tahini\"},{\"item\":\"lime\",\"unit\":\"\",\"comment\":\"Juice of\",\"text\":\"Juice of 1 lime\"},{\"item\":\"sriracha\",\"unit\":\"tbsp\",\"comment\":\"or your favourite style of chilli sauce\",\"text\":\"1 tbsp sriracha (or your favourite style of chilli sauce)\"},{\"item\":\"bird’s\",\"unit\":\"\",\"comment\":\"eye chilli stalked removed optional\",\"text\":\"1 bird’s-eye chilli, stalked removed (optional)\"},{\"item\":\"soy sauce\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp soy sauce\"},{\"item\":\"demerara sugar\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp demerara sugar\"},{\"item\":\"\",\"unit\":\"\",\"comment\":\"or honey\",\"text\":\"(or honey)\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"3 tbsp sesame oil\"},{\"item\":\"water\",\"unit\":\"ml\",\"comment\":\"\",\"text\":\"25ml water\"}]}],\"suitableForDietIds\":[],\"cuisineIds\":[],\"mealTypeIds\":[],\"celebrationsIds\":[\"summer-food-and-drink\"],\"utensilsAndApplianceIds\":[],\"techniquesUsedIds\":[],\"timings\":[],\"instructions\":[{\"stepNumber\":0,\"description\":\"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.\",\"images\":[]},{\"stepNumber\":1,\"description\":\"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).\",\"images\":[]},{\"stepNumber\":2,\"description\":\"Add the carrots, red cabbage and mooli or radishes to the bowl.\",\"images\":[]},{\"stepNumber\":3,\"description\":\"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.\",\"images\":[]},{\"stepNumber\":4,\"description\":\"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).\",\"images\":[]},{\"stepNumber\":5,\"description\":\"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.\",\"images\":[]},{\"stepNumber\":6,\"description\":\"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.\",\"images\":[]},{\"stepNumber\":7,\"description\":\"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.\",\"images\":[]},{\"stepNumber\":8,\"description\":\"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.\",\"images\":[]},{\"stepNumber\":9,\"description\":\"Toss the dressing through the salad and season to taste; it may need more lime juice.\",\"images\":[]},{\"stepNumber\":10,\"description\":\"Scatter the sesame seeds on top and serve.\",\"images\":[]},{\"stepNumber\":11,\"description\":\"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.\",\"images\":[]}]}"
+          }
+        },
+        {
+          type: ElementType.IMAGE,
+          assets: [
+            {
+              type: AssetType.IMAGE,
+              mimeType: "image/jpeg",
+              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg",
+              typeData: {
+                aspectRatio: "5:3",
+                width: 1000,
+                height: 600
+              }
+            },
+            {
+              type: AssetType.IMAGE,
+              mimeType: "image/jpeg",
+              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg",
+              typeData: {
+                aspectRatio: "5:3",
+                width: 500,
+                height: 300
+              }
+            },
+            {
+              type: AssetType.IMAGE,
+              mimeType: "image/jpeg",
+              file: "http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg",
+              typeData: {
+                aspectRatio: "5:3",
+                width: 5512,
+                height: 3308,
+                isMaster: true
+              }
+            }
+          ],
+          imageTypeData: {
+            caption: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
+            copyright: "LOUISE HAGGER",
+            displayCredit: true,
+            credit: "Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
+            source: "Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
+            alt: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
+            mediaId: "58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
+            mediaApiUri: "https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
+            suppliersReference: "Soba noodles with crisp rainbow vegetables and a spicy sesame se",
+            imageType: "Photograph"
+          }
+        }
+      ]
+    }
+    const result = extractRecipeData(canonicalId, block, []);
+    expect(result.length).toEqual(1);
+    const data = JSON.parse(result[0]?.jsonBlob as string) as RecipeWithImageData;
+    expect(data.canonicalArticle).toBe(canonicalId);
+  })
 });

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -10,6 +10,7 @@ import type {Contributor, RecipeReferenceWithoutChecksum} from './models';
 import {
   addSponsorsTransform,
   handleFreeTextContribs,
+  replaceCanonicalArticle,
   replaceImageUrlsWithFastly
 } from "./transform";
 import type {
@@ -75,6 +76,7 @@ function parseJsonBlob(canonicalId: string, recipeJson: string, sponsorship: Spo
       handleFreeTextContribs,
       replaceImageUrlsWithFastly,
       addSponsorsTransform(sponsorship),
+      replaceCanonicalArticle(canonicalId)
     ];
 
     const updatedRecipe = transforms.reduce((acc, transform) => transform(acc), recipeData);

--- a/lib/recipes-data/src/lib/recipe-fixtures.ts
+++ b/lib/recipes-data/src/lib/recipe-fixtures.ts
@@ -2,6 +2,7 @@ import type { RecipeImage } from "./models";
 
 export type RecipeFixture = Record<string, unknown> & {
 	id: string;
+	canonicalArticle: string;
 	featuredImage: RecipeImage;
 	previewImage?: RecipeImage;
 };

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -40,6 +40,7 @@ export const replaceFastlyUrl = (
 
 export type RecipeWithImageData = {
   id: string;
+  canonicalArticle: string;
   featuredImage: RecipeImage | string; // the latter is an old image format that appears in our test fixtures
   previewImage?: RecipeImage | string;
 };

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -68,6 +68,13 @@ export const addSponsorsTransform: (sponsors: Sponsorship[]) => RecipeTransforma
   })
 }
 
+export const replaceCanonicalArticle: (
+	canonicalArticle: string,
+) => RecipeTransformationFunction = (canonicalArticle) => (recipeData) => ({
+	...recipeData,
+	canonicalArticle,
+});
+
 /**
  * Replace the featured and preview image URLs, which are by convention full-resolution crops,
  * with Fastly resizer urls. Allows us to serve lower resolution assets to the app.


### PR DESCRIPTION
## What does this change?

Adds a transformer to ensure that a recipe's `canonicalArticle` property always reflects the latest value from CAPI.

This property was previously added upstream in Composer – but it's not kept in sync, and there's no guarantee that the article path will not change after the element is added.

Better to derive it from fresh data.

## How to test

The automated test should pass, and it should be clear what it tests.

On `main`:

- Add a headline to a new article
- Add a recipe to an article (via the structuriser – manually adding is broken at the moment)
- Change the headline
- Note that in the recipe-backend API, the `canonicalArticle` property of the recipe has not updated.

Repeat on this branch. The `canonicalArticle` property should update.

- [x] Tested in CODE with this [article](https://composer.code.dev-gutools.co.uk/content/6697c1728f084da525701e30) – note that the recipe element has an incorrect path, but the recipe in [the CODE API](recipes.code.dev-guardianapis.com/content/FOJGV3iFruAHqxhq7jx-oRDkvYAzTP0lTEoiokB0yR0) has the correct path.