### PR TITLE
Replace CAPI URL passed from Crier with channels-specific URL

### DIFF
--- a/lambda/recipes-responder/src/update_retrievable_processor.test.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.test.ts
@@ -18,7 +18,7 @@ jest.mock("./config", ()=>({
 }));
 
 const fakeUpdate:RetrievableContent = {
-  capiUrl: "api:///path/to/article",
+  capiUrl: "https://api.com/path/to/article",
   id: "path/to/article",
   contentType: ContentType.ARTICLE,
 }
@@ -49,7 +49,13 @@ describe('handleContentUpdateRetrievable',  ()=> {
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(callCAPI.mock.calls.length).toEqual(1);
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(callCAPI.mock.calls[0][0]).toEqual(fakeUpdate.capiUrl + "?show-fields=internalRevision&show-blocks=all&show-channels=all&api-key=fake-api-key&format=thrift");
+    expect(callCAPI.mock.calls[0][0]).toEqual(
+			fakeUpdate.capiUrl.replace(
+				'/path/to/article',
+				'/channel/feast/item/path/to/article',
+			) +
+				'?show-fields=internalRevision&show-blocks=all&show-channels=all&api-key=fake-api-key&format=thrift',
+		);
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(handleContentUpdate.mock.calls.length).toEqual(1);
     // @ts-ignore -- Typescript doesn't know that this is a mock

--- a/lambda/recipes-responder/src/update_retrievable_processor.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.ts
@@ -40,7 +40,12 @@ export async function handleContentUpdateRetrievable(retrievable:RetrievableCont
 {
   if(retrievable.contentType!=ContentType.ARTICLE) return 0;  //no point processing live-blogs etc.
 
-  const capiResponse = await retrieveContent(retrievable.capiUrl);
+  // TO FIX UPSTREAM – Crier returns a path that does not include channelled content, giving a 404
+  // if the content is not on open. We modify the path manually here to fix. Crier should return a path
+  // that is scoped to the appropriate channel if the content is not on open.
+  const capiUrl = new URL(retrievable.capiUrl);
+  const capiResponse = await retrieveContent(`${capiUrl.protocol}//${capiUrl.hostname}/channel/feast/item${capiUrl.pathname}`);
+
   switch(capiResponse.action) {
     case PollingAction.CONTENT_EXISTS:
       //Great, we have it - but should check if this has now been superceded


### PR DESCRIPTION
... so content solely launched to Feast can be retrieved.

## How to test

- The automated tests should pass. They've been adjusted for the new CAPI url.
- Modify [this article](https://composer.code.dev-gutools.co.uk/content/668503618f08a83a9aecabb3) and launch. You should see the change in the related recipe in the recipe backend content, e.g. [this recipe](https://recipes.code.dev-guardianapis.com/api/content/by-uid/3b3ba7fb30b24e83a6caef20eea83c91) (requires auth.) This would not occur prior to this PR.

## How can we measure success?

Feast can publish recipes from articles that are large enough to trigger a RetrievableUpdate.