### PR TITLE
Announce new recipes to EventBridge

### DIFF
--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1423,7 +1423,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
     "RecipeResponderDLQ4E2B8219": {
       "DeletionPolicy": "Delete",
       "Properties": {
-        "QueueName": "recipe-responder-TEST-DLQ",
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1423,6 +1423,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
     "RecipeResponderDLQ4E2B8219": {
       "DeletionPolicy": "Delete",
       "Properties": {
+        "QueueName": "recipe-responder-TEST-DLQ",
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -2639,6 +2639,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               "Ref": "storeRecipeTableC3AD84B7",
             },
             "LAST_UPDATED_INDEX": "idxArticleLastUpdated",
+            "OUTGOING_EVENT_BUS": "crier-eventbus-content-api-crier-v2-TEST",
             "STACK": "content-api",
             "STAGE": "TEST",
             "STATIC_BUCKET": {
@@ -2808,6 +2809,30 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               "Effect": "Allow",
               "Resource": {
                 "Ref": "TelemetryCrossAcctRole",
+              },
+            },
+            {
+              "Action": "events:PutEvents",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":events:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":event-bus/crier-eventbus-content-api-crier-v2-TEST",
+                  ],
+                ],
               },
             },
             {

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -165,7 +165,7 @@ export class RecipesBackend extends GuStack {
     });
 
     const responderDLQ = new Queue(this, "RecipeResponderDLQ", {
-      queueName: `recipe-responder-${this.stage}-DLQ`
+      //queueName: `recipe-responder-${this.stage}-DLQ`
     });
 
     new Rule(this, "CrierConnection", {

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -165,7 +165,7 @@ export class RecipesBackend extends GuStack {
     });
 
     const responderDLQ = new Queue(this, "RecipeResponderDLQ", {
-      //queueName: `recipe-responder-${this.stage}-DLQ`
+      queueName: `recipe-responder-${this.stage}-DLQ`
     });
 
     new Rule(this, "CrierConnection", {

--- a/lambda/recipes-responder/src/config.ts
+++ b/lambda/recipes-responder/src/config.ts
@@ -1,1 +1,2 @@
-export const CapiKey = process.env["CAPI_KEY"]
+export const CapiKey = process.env["CAPI_KEY"];
+export const OutgoingEventBus = process.env["OUTGOING_EVENT_BUS"];

--- a/lambda/recipes-responder/src/config.ts
+++ b/lambda/recipes-responder/src/config.ts
@@ -1,2 +1,1 @@
 export const CapiKey = process.env["CAPI_KEY"];
-export const OutgoingEventBus = process.env["OUTGOING_EVENT_BUS"];

--- a/lambda/recipes-responder/src/eventbus.ts
+++ b/lambda/recipes-responder/src/eventbus.ts
@@ -1,0 +1,65 @@
+import * as process from "process";
+import {EventBridgeClient,PutEventsCommand} from "@aws-sdk/client-eventbridge";
+import {registerMetric} from "@recipes-api/cwmetrics";
+import type {RecipeIndexEntry, RecipeReference} from "@recipes-api/lib/recipes-data";
+import {OutgoingEventBus} from "./config";
+
+const ebClient = new EventBridgeClient({region: process.env["AWS_REGION"]});
+
+export async function announce_new_recipe(updated:RecipeReference[], removedList:RecipeIndexEntry[]) {
+  if(!OutgoingEventBus || OutgoingEventBus =="") {
+    throw new Error("Could not announce to EventBridge - please set OUTGOING_EVENT_BUS to an event bus name in the config");
+  }
+
+  const updates = updated.map(recep=>(      {
+      Time: new Date(),             //Timestamp
+      Source: "recipe-responder",   //Identity of sender
+      Resources: [],                //Affected AWS resources
+      DetailType: "recipe-update",   //What happened
+      Detail: JSON.stringify({
+        "blob": recep.jsonBlob,
+        "uid": recep.recipeUID,
+        "checksum": recep.checksum,
+      }),
+      EventBusName: OutgoingEventBus,
+    }));
+
+  const removals = removedList.map(ent=>({
+    Time: new Date(),             //Timestamp
+    Source: "recipe-responder",   //Identity of sender
+    Resources: [],                //Affected AWS resources
+    DetailType: "recipe-update",   //What happened
+    Detail: JSON.stringify({
+      "checksum": ent.checksum,
+      "uid": ent.recipeUID,
+    }),
+    EventBusName: OutgoingEventBus,
+  }));
+
+  const req= new PutEventsCommand({
+    Entries: updates.concat(removals)
+  });
+
+  const response = await ebClient.send(req);
+
+  if(response.FailedEntryCount && response.FailedEntryCount > 0) {
+    const failedEntries = response.Entries ? response.Entries.filter((_)=>!_.EventId) : [];
+    failedEntries.forEach((e, n)=>{
+      console.warn(`${n}: Event failed to send: ${e.ErrorCode ?? "(unknown code)"} ${e.ErrorMessage ?? "(message not provided)"}`)
+    });
+
+    try {
+      await registerMetric("FailedAnnouncements", response.FailedEntryCount)
+    } catch(e) {
+      console.error(`Unable to register FailedAnnouncements metric: `, e);
+    }
+    throw new Error(`${response.FailedEntryCount} messages failed to send, failures are logged out`);
+  } else {
+    try {
+      await registerMetric("FailedAnnouncements", 0);
+    } catch(e) {
+      console.error(`Unable to register FailedAnnouncements metric: `, e);
+    }
+    return response.Entries ? response.Entries.length : 0;
+  }
+}

--- a/lambda/recipes-responder/src/eventbus.ts
+++ b/lambda/recipes-responder/src/eventbus.ts
@@ -24,7 +24,15 @@ export async function announce_new_recipe(updated:RecipeReference[], removedList
       EventBusName: OutgoingEventBus,
     }));
 
-  const removals = removedList.map(ent=>({
+  const updatedUIDs = updated.map((_)=>_.recipeUID);
+
+  //OK this would be more efficient with sets or a map, but the numbers are going to be so small
+  //it's not worth worrying about here.
+  const actualRemovals = removedList.filter((removedEntry)=>
+    !updatedUIDs.includes(removedEntry.recipeUID)
+  );
+
+  const removals = actualRemovals.map(ent=>({
     Time: new Date(),             //Timestamp
     Source: "recipe-responder",   //Identity of sender
     Resources: [],                //Affected AWS resources

--- a/lambda/recipes-responder/src/takedown_processor.test.ts
+++ b/lambda/recipes-responder/src/takedown_processor.test.ts
@@ -3,6 +3,7 @@ import {EventType} from "@guardian/content-api-models/crier/event/v1/eventType";
 import {ItemType} from "@guardian/content-api-models/crier/event/v1/itemType";
 import Int64 from "node-int64";
 import {awaitableDelay, removeAllRecipesForArticle} from "@recipes-api/lib/recipes-data";
+import {announce_new_recipe} from "../../../lib/recipes-data/src/lib/eventbus";
 import {handleTakedown} from "./takedown_processor";
 
 jest.mock("@recipes-api/lib/recipes-data", ()=>({
@@ -10,6 +11,10 @@ jest.mock("@recipes-api/lib/recipes-data", ()=>({
   removeAllRecipesForArticle: jest.fn(),
 }));
 
+
+jest.mock("../../../lib/recipes-data/src/lib/eventbus", ()=>({
+  announce_new_recipe: jest.fn(),
+}));
 
 describe("takedown_processor.handleTakedown", ()=>{
   beforeEach(()=>{

--- a/lambda/recipes-responder/src/takedown_processor.test.ts
+++ b/lambda/recipes-responder/src/takedown_processor.test.ts
@@ -3,7 +3,7 @@ import {EventType} from "@guardian/content-api-models/crier/event/v1/eventType";
 import {ItemType} from "@guardian/content-api-models/crier/event/v1/itemType";
 import Int64 from "node-int64";
 import {awaitableDelay, removeAllRecipesForArticle} from "@recipes-api/lib/recipes-data";
-import {announce_new_recipe} from "../../../lib/recipes-data/src/lib/eventbus";
+import {announceNewRecipe} from "../../../lib/recipes-data/src/lib/eventbus";
 import {handleTakedown} from "./takedown_processor";
 
 jest.mock("@recipes-api/lib/recipes-data", ()=>({

--- a/lambda/recipes-responder/src/takedown_processor.ts
+++ b/lambda/recipes-responder/src/takedown_processor.ts
@@ -1,7 +1,7 @@
 import type {DeletedContent} from "@guardian/content-api-models/crier/event/v1/deletedContent";
 import type {Event} from "@guardian/content-api-models/crier/event/v1/event"
-import {removeAllRecipesForArticle} from "@recipes-api/lib/recipes-data";
 import {ItemType} from "@guardian/content-api-models/crier/event/v1/itemType";
+import {removeAllRecipesForArticle} from "@recipes-api/lib/recipes-data";
 
 export async function handleTakedown(evt:Event):Promise<number> {
   console.log("takedown payload: ", JSON.stringify(evt));

--- a/lambda/recipes-responder/src/update_processor.test.ts
+++ b/lambda/recipes-responder/src/update_processor.test.ts
@@ -5,7 +5,7 @@ import type {
   RecipeReferenceWithoutChecksum
 } from "@recipes-api/lib/recipes-data";
 import {
-  announce_new_recipe,
+  announceNewRecipe,
   calculateChecksum,
   extractAllRecipesFromArticle,
   insertNewRecipe,
@@ -25,7 +25,7 @@ jest.mock("@recipes-api/lib/recipes-data", () => ({
   recipesToTakeDown: jest.fn(),
   removeRecipeVersion: jest.fn(),
   sendTelemetryEvent: jest.fn(),
-  announce_new_recipe: jest.fn(),
+  announceNewRecipe: jest.fn(),
 }));
 
 const fakeContent: Content = {
@@ -157,7 +157,7 @@ describe("update_processor.handleContentUpdate", () => {
     expect((sendTelemetryEvent as Mock).mock.calls[0][0]).toEqual("PublishedData");
 
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(announce_new_recipe.mock.calls.length).toEqual(1);
+    expect(announceNewRecipe.mock.calls.length).toEqual(1);
   });
 
   it("should ignore a piece of content that is not an article", async () => {
@@ -204,7 +204,7 @@ describe("update_processor.handleContentUpdate", () => {
     expect((sendTelemetryEvent as Mock).mock.calls.length).toEqual(0);
 
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(announce_new_recipe.mock.calls.length).toEqual(0);
+    expect(announceNewRecipe.mock.calls.length).toEqual(0);
   });
 
   it("should be fine if there is no recipe content", async () => {
@@ -236,7 +236,7 @@ describe("update_processor.handleContentUpdate", () => {
     expect((sendTelemetryEvent as Mock).mock.calls.length).toEqual(0);
 
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(announce_new_recipe.mock.calls.length).toEqual(0);
+    expect(announceNewRecipe.mock.calls.length).toEqual(0);
   });
 
   it("should publish as normal if the telemetry fails", async () => {
@@ -353,7 +353,7 @@ describe("update_processor.handleContentUpdate", () => {
     expect((sendTelemetryEvent as Mock).mock.calls[0][0]).toEqual("PublishedData");
 
     // @ts-ignore -- Typescript doesn't know that this is a mock
-    expect(announce_new_recipe.mock.calls.length).toEqual(1);
+    expect(announceNewRecipe.mock.calls.length).toEqual(1);
   });
 
 });

--- a/lambda/recipes-responder/src/update_processor.test.ts
+++ b/lambda/recipes-responder/src/update_processor.test.ts
@@ -5,6 +5,7 @@ import type {
   RecipeReferenceWithoutChecksum
 } from "@recipes-api/lib/recipes-data";
 import {
+  announce_new_recipe,
   calculateChecksum,
   extractAllRecipesFromArticle,
   insertNewRecipe,
@@ -24,6 +25,7 @@ jest.mock("@recipes-api/lib/recipes-data", () => ({
   recipesToTakeDown: jest.fn(),
   removeRecipeVersion: jest.fn(),
   sendTelemetryEvent: jest.fn(),
+  announce_new_recipe: jest.fn(),
 }));
 
 const fakeContent: Content = {
@@ -153,6 +155,9 @@ describe("update_processor.handleContentUpdate", () => {
 
     expect((sendTelemetryEvent as Mock).mock.calls.length).toEqual(3);
     expect((sendTelemetryEvent as Mock).mock.calls[0][0]).toEqual("PublishedData");
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(announce_new_recipe.mock.calls.length).toEqual(1);
   });
 
   it("should ignore a piece of content that is not an article", async () => {
@@ -197,6 +202,9 @@ describe("update_processor.handleContentUpdate", () => {
     expect(removeRecipeVersion.mock.calls.length).toEqual(0);
 
     expect((sendTelemetryEvent as Mock).mock.calls.length).toEqual(0);
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(announce_new_recipe.mock.calls.length).toEqual(0);
   });
 
   it("should be fine if there is no recipe content", async () => {
@@ -226,6 +234,9 @@ describe("update_processor.handleContentUpdate", () => {
     expect(removeRecipeVersion.mock.calls.length).toEqual(0);
 
     expect((sendTelemetryEvent as Mock).mock.calls.length).toEqual(0);
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(announce_new_recipe.mock.calls.length).toEqual(0);
   });
 
   it("should publish as normal if the telemetry fails", async () => {
@@ -340,6 +351,9 @@ describe("update_processor.handleContentUpdate", () => {
 
     expect((sendTelemetryEvent as Mock).mock.calls.length).toEqual(3);
     expect((sendTelemetryEvent as Mock).mock.calls[0][0]).toEqual("PublishedData");
+
+    // @ts-ignore -- Typescript doesn't know that this is a mock
+    expect(announce_new_recipe.mock.calls.length).toEqual(1);
   });
 
 });

--- a/lambda/recipes-responder/src/update_processor.ts
+++ b/lambda/recipes-responder/src/update_processor.ts
@@ -10,6 +10,7 @@ import {
   removeRecipeVersion,
   sendTelemetryEvent
 } from "@recipes-api/lib/recipes-data";
+import {announce_new_recipe} from "./eventbus";
 
 /**
  * Pushes new content into the service
@@ -56,6 +57,13 @@ export async function handleContentUpdate(content: Content): Promise<number> {
     console.log(`INFO [${content.id}] - publishing ${allRecipes.length} new/updated recipes to the service`)
     await Promise.all(allRecipes.map(recep => publishRecipe(content.id, recep)))
 
+    console.log(`INFO [${content.id}] - sending notification of new/updated recipes`);
+
+    try {
+      await announce_new_recipe(allRecipes, entriesToRemove);
+    } catch(e) {
+      console.error("Unable to announce updates");
+    }
     console.log(`INFO [${content.id}] - Done`);
     return allRecipes.length + entriesToRemove.length;
   } catch (err) {

--- a/lambda/recipes-responder/src/update_processor.ts
+++ b/lambda/recipes-responder/src/update_processor.ts
@@ -2,7 +2,7 @@ import type {Content} from "@guardian/content-api-models/v1/content";
 import {ContentType} from "@guardian/content-api-models/v1/contentType";
 import type {RecipeReference} from "@recipes-api/lib/recipes-data";
 import {
-  announce_new_recipe,
+  announceNewRecipe,
   calculateChecksum,
   extractAllRecipesFromArticle,
   insertNewRecipe,
@@ -59,9 +59,10 @@ export async function handleContentUpdate(content: Content): Promise<number> {
     console.log(`INFO [${content.id}] - sending notification of new/updated recipes`);
 
     try {
-      await announce_new_recipe(allRecipes, entriesToRemove);
+      await announceNewRecipe(allRecipes, entriesToRemove);
     } catch(e) {
-      console.error("Unable to announce updates");
+      const err = e as Error;
+      console.error(`Unable to announce updates: ${err.toString()}`);
     }
     console.log(`INFO [${content.id}] - Done`);
     return allRecipes.length + entriesToRemove.length;

--- a/lambda/recipes-responder/src/update_processor.ts
+++ b/lambda/recipes-responder/src/update_processor.ts
@@ -2,15 +2,14 @@ import type {Content} from "@guardian/content-api-models/v1/content";
 import {ContentType} from "@guardian/content-api-models/v1/contentType";
 import type {RecipeReference} from "@recipes-api/lib/recipes-data";
 import {
+  announce_new_recipe,
   calculateChecksum,
   extractAllRecipesFromArticle,
   insertNewRecipe,
   publishRecipeContent,
   recipesToTakeDown,
-  removeRecipeVersion,
-  sendTelemetryEvent
-} from "@recipes-api/lib/recipes-data";
-import {announce_new_recipe} from "./eventbus";
+  removeRecipeVersion
+, sendTelemetryEvent } from "@recipes-api/lib/recipes-data";
 
 /**
  * Pushes new content into the service

--- a/lib/cwmetrics/src/lib/cloudwatch.ts
+++ b/lib/cwmetrics/src/lib/cloudwatch.ts
@@ -3,7 +3,7 @@ import {CloudWatchClient, PutMetricDataCommand, StandardUnit} from "@aws-sdk/cli
 
 const cwClient = new CloudWatchClient({region: process.env["AWS_REGION"]});
 
-export type KnownMetric = "FailedRecipes" | "SuccessfulRecipes" | "UpdatesTotalOfArticle";
+export type KnownMetric = "FailedRecipes" | "SuccessfulRecipes" | "UpdatesTotalOfArticle" | "FailedAnnouncements";
 
 
 export async function registerMetric(metricName: KnownMetric, value: number) {

--- a/lib/recipes-data/src/index.ts
+++ b/lib/recipes-data/src/index.ts
@@ -6,6 +6,7 @@ export * from './lib/extract-recipes';
 export * from './lib/telemetry';
 export * from './lib/curation';
 export * from './lib/constants';
+export * from './lib/eventbus';
 
 export {sendFastlyPurgeRequestWithRetries} from './lib/fastly';
 export {awaitableDelay, calculateChecksum, makeCapiDateTime} from './lib/utils';

--- a/lib/recipes-data/src/lib/config.ts
+++ b/lib/recipes-data/src/lib/config.ts
@@ -32,3 +32,6 @@ export const TelemetryTopic = process.env["TELEMETRY_TOPIC"]
 export const PreviewImageWidth = process.env["PREVIEW_IMAGE_WIDTH"] ? parseInt(process.env["PREVIEW_IMAGE_WIDTH"]) : 1600;
 export const FeaturedImageWidth = process.env["FEATURED_IMAGE_WIDTH"] ? parseInt(process.env["FEATURED_IMAGE_WIDTH"]) : 1600;
 export const ImageDpr = process.env["IMAGE_DPR"] ? parseInt(process.env["IMAGE_DPR"]) : 1;
+
+//Used by eventbus
+export const OutgoingEventBus = process.env["OUTGOING_EVENT_BUS"];

--- a/lib/recipes-data/src/lib/dynamo.test.ts
+++ b/lib/recipes-data/src/lib/dynamo.test.ts
@@ -14,7 +14,6 @@ jest.mock("./config", () => ({
 }));
 
 const mockDynamoClient = mockClient(DynamoDBClient);
-const ddbClient = new DynamoDBClient(); //this is actually a mock now
 
 function makeRecptBatch(length: number): RecipeDatabaseKey[] {
   const results: RecipeDatabaseKey[] = [];

--- a/lib/recipes-data/src/lib/eventbus.test.ts
+++ b/lib/recipes-data/src/lib/eventbus.test.ts
@@ -1,7 +1,7 @@
 import {EventBridgeClient, PutEventsCommand} from "@aws-sdk/client-eventbridge";
 import {mockClient} from "aws-sdk-client-mock";
 import {registerMetric} from "@recipes-api/cwmetrics";
-import {announce_new_recipe} from "./eventbus";
+import {announceNewRecipe} from "./eventbus";
 import type { RecipeIndexEntry, RecipeReference} from "./models";
 import Mock = jest.Mock;
 
@@ -65,7 +65,7 @@ describe("announce_new_recipe", ()=>{
         }
       ]
     })
-    const result = await announce_new_recipe(updates,removals);
+    const result = await announceNewRecipe(updates,removals);
     expect(result).toEqual(3);
 
     expect(mockEbClient.commandCalls(PutEventsCommand).length).toEqual(1);

--- a/lib/recipes-data/src/lib/eventbus.test.ts
+++ b/lib/recipes-data/src/lib/eventbus.test.ts
@@ -1,0 +1,88 @@
+import {EventBridgeClient, PutEventsCommand} from "@aws-sdk/client-eventbridge";
+import {mockClient} from "aws-sdk-client-mock";
+import {registerMetric} from "@recipes-api/cwmetrics";
+import {announce_new_recipe} from "./eventbus";
+import type { RecipeIndexEntry, RecipeReference} from "./models";
+import Mock = jest.Mock;
+
+const mockEbClient = mockClient(EventBridgeClient);
+
+jest.mock("./config", ()=>({
+  OutgoingEventBus: "test-event-bus"
+}));
+
+jest.mock("@recipes-api/cwmetrics", ()=>({
+  registerMetric: jest.fn()
+}));
+
+describe("announce_new_recipe", ()=>{
+  beforeEach(()=>{
+    mockEbClient.reset();
+    jest.resetAllMocks();
+  });
+
+  it("should send a combined stack of messages for updates and takedowns, not double-announcing updates", async ()=>{
+    const updates:RecipeReference[] = [
+      {
+        checksum: "recep-1-cs",
+        recipeUID: "recep-1-uid",
+        jsonBlob: "recep-1-content"
+      },
+      {
+        checksum: "recep-2-cs-updated",
+        recipeUID: "recep-2-uid",
+        jsonBlob: "recep-2-content"
+      },
+    ];
+    const removals:RecipeIndexEntry[] = [
+      {
+        checksum: "recep-2-cs-old", //"recep-2" is updated, so been taken down and replaced with a new checksum
+        recipeUID: "recep-2-uid",
+        capiArticleId: "xxxxxxxxxx"
+      },
+      {
+        checksum: "recep-3-cs",
+        recipeUID: "recep-3-uid",
+        capiArticleId: "yyyyyyyyy"
+      }
+    ];
+
+    mockEbClient.on(PutEventsCommand).resolves({
+      FailedEntryCount: 0,
+      Entries: [
+        {
+          EventId: "event-1"
+        },
+        {
+          EventId: "event-2"
+        },
+        {
+          EventId: "event-3"
+        }
+      ]
+    })
+    const result = await announce_new_recipe(updates,removals);
+    expect(result).toEqual(3);
+
+    expect(mockEbClient.commandCalls(PutEventsCommand).length).toEqual(1);
+    const putCmd = mockEbClient.commandCalls(PutEventsCommand)[0].firstArg as PutEventsCommand;
+
+    expect(putCmd.input.Entries?.length).toEqual(3);
+
+    const firstEntry = putCmd.input.Entries ? putCmd.input.Entries[0] : {};
+    expect(firstEntry.DetailType).toEqual("recipe-update");
+    expect(firstEntry.Detail).toEqual(`{"blob":"recep-1-content","uid":"recep-1-uid","checksum":"recep-1-cs"}`);
+
+    const secondEntry = putCmd.input.Entries ? putCmd.input.Entries[1] : {};
+    expect(secondEntry.DetailType).toEqual("recipe-update");
+    expect(secondEntry.Detail).toEqual(`{"blob":"recep-2-content","uid":"recep-2-uid","checksum":"recep-2-cs-updated"}`);
+
+    const thirdEntry = putCmd.input.Entries ? putCmd.input.Entries[2] : {};
+    expect(thirdEntry.DetailType).toEqual("recipe-delete");
+    expect(thirdEntry.Detail).toEqual(`{"checksum":"recep-3-cs","uid":"recep-3-uid"}`);
+
+    expect((registerMetric as Mock).mock.calls.length).toEqual(1);
+    expect((registerMetric as Mock).mock.calls[0][0]).toEqual("FailedAnnouncements");
+    expect((registerMetric as Mock).mock.calls[0][1]).toEqual(0);
+  })
+})

--- a/lib/recipes-data/src/lib/eventbus.test.ts
+++ b/lib/recipes-data/src/lib/eventbus.test.ts
@@ -26,24 +26,28 @@ describe("announce_new_recipe", ()=>{
       {
         checksum: "recep-1-cs",
         recipeUID: "recep-1-uid",
-        jsonBlob: "recep-1-content"
+        jsonBlob: "recep-1-content",
+        sponsorshipCount: 0,
       },
       {
         checksum: "recep-2-cs-updated",
         recipeUID: "recep-2-uid",
-        jsonBlob: "recep-2-content"
+        jsonBlob: "recep-2-content",
+        sponsorshipCount: 0,
       },
     ];
     const removals:RecipeIndexEntry[] = [
       {
         checksum: "recep-2-cs-old", //"recep-2" is updated, so been taken down and replaced with a new checksum
         recipeUID: "recep-2-uid",
-        capiArticleId: "xxxxxxxxxx"
+        capiArticleId: "xxxxxxxxxx",
+        sponsorshipCount: 0,
       },
       {
         checksum: "recep-3-cs",
         recipeUID: "recep-3-uid",
-        capiArticleId: "yyyyyyyyy"
+        capiArticleId: "yyyyyyyyy",
+        sponsorshipCount: 0,
       }
     ];
 

--- a/lib/recipes-data/src/lib/eventbus.ts
+++ b/lib/recipes-data/src/lib/eventbus.ts
@@ -6,7 +6,7 @@ import type { RecipeIndexEntry, RecipeReference } from './models';
 
 const ebClient = new EventBridgeClient({region: process.env["AWS_REGION"]});
 
-export async function announce_new_recipe(updated:RecipeReference[], removedList:RecipeIndexEntry[]) {
+export async function announceNewRecipe(updated:RecipeReference[], removedList:RecipeIndexEntry[]) {
   if(!OutgoingEventBus || OutgoingEventBus =="") {
     throw new Error("Could not announce to EventBridge - please set OUTGOING_EVENT_BUS to an event bus name in the config");
   }

--- a/lib/recipes-data/src/lib/eventbus.ts
+++ b/lib/recipes-data/src/lib/eventbus.ts
@@ -1,8 +1,8 @@
 import * as process from "process";
 import {EventBridgeClient,PutEventsCommand} from "@aws-sdk/client-eventbridge";
 import {registerMetric} from "@recipes-api/cwmetrics";
-import type {RecipeIndexEntry, RecipeReference} from "@recipes-api/lib/recipes-data";
 import {OutgoingEventBus} from "./config";
+import type { RecipeIndexEntry, RecipeReference } from './models';
 
 const ebClient = new EventBridgeClient({region: process.env["AWS_REGION"]});
 
@@ -36,7 +36,7 @@ export async function announce_new_recipe(updated:RecipeReference[], removedList
     Time: new Date(),             //Timestamp
     Source: "recipe-responder",   //Identity of sender
     Resources: [],                //Affected AWS resources
-    DetailType: "recipe-update",   //What happened
+    DetailType: "recipe-delete",   //What happened
     Detail: JSON.stringify({
       "checksum": ent.checksum,
       "uid": ent.recipeUID,

--- a/lib/recipes-data/src/lib/takedown.ts
+++ b/lib/recipes-data/src/lib/takedown.ts
@@ -2,6 +2,7 @@ import {recipesforArticle, removeAllRecipeIndexEntriesForArticle, removeRecipe} 
 import type { RecipeIndexEntry } from './models';
 import {removeRecipeContent} from "./s3";
 import {sendTelemetryEvent} from "./telemetry";
+import {announce_new_recipe} from "./eventbus";
 
 enum TakedownMode {
   AllVersions,
@@ -61,6 +62,13 @@ export async function removeAllRecipesForArticle(canonicalArticleId: string): Pr
   const removedEntries = await removeAllRecipeIndexEntriesForArticle(canonicalArticleId);
   console.log(`Taken down article ${canonicalArticleId} had ${removedEntries.length} recipes in it which will also be removed`);
   await Promise.all(removedEntries.map(recep=>removeRecipeContent(recep.checksum, "hard")));
+
+  try {
+    await announce_new_recipe([], removedEntries)
+  } catch(err) {
+    console.error("Unable to announce takedowns");
+  }
+
   try {
     await Promise.all(removedEntries.map(recep=>sendTelemetryEvent("TakenDown", recep.recipeUID, "")));
   } catch(err) {

--- a/lib/recipes-data/src/lib/takedown.ts
+++ b/lib/recipes-data/src/lib/takedown.ts
@@ -2,7 +2,7 @@ import {recipesforArticle, removeAllRecipeIndexEntriesForArticle, removeRecipe} 
 import type { RecipeIndexEntry } from './models';
 import {removeRecipeContent} from "./s3";
 import {sendTelemetryEvent} from "./telemetry";
-import {announce_new_recipe} from "./eventbus";
+import {announceNewRecipe} from "./eventbus";
 
 enum TakedownMode {
   AllVersions,
@@ -64,9 +64,10 @@ export async function removeAllRecipesForArticle(canonicalArticleId: string): Pr
   await Promise.all(removedEntries.map(recep=>removeRecipeContent(recep.checksum, "hard")));
 
   try {
-    await announce_new_recipe([], removedEntries)
-  } catch(err) {
-    console.error("Unable to announce takedowns");
+    await announceNewRecipe([], removedEntries)
+  } catch(e) {
+    const err = e as Error;
+    console.error(`Unable to announce takedowns: ${err.toString()}`);
   }
 
   try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.621.0",
         "@aws-sdk/client-dynamodb": "^3.621.0",
+        "@aws-sdk/client-eventbridge": "^3.621.0",
         "@aws-sdk/client-s3": "^3.621.0",
         "@aws-sdk/client-sns": "^3.621.0",
         "@aws-sdk/client-sts": "^3.621.0",
@@ -699,6 +700,392 @@
         "@smithy/util-waiter": "^3.1.2",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge": {
+      "version": "3.633.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.633.0.tgz",
+      "integrity": "sha512-IqBaTKvOxcgMx7cU2tVMTXhehcl/M5Lkl9pVKyS8yu2OH6Fa/C9s7Hk5LArERX9+qrPG4Ro3KNMQ3+rLAXV8tA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.632.0",
+        "@aws-sdk/client-sts": "3.632.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.632.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.632.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/signature-v4-multi-region": "3.633.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.632.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/client-sso": {
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.632.0.tgz",
+      "integrity": "sha512-iYWHiKBz44m3chCFvtvHnvCpL2rALzyr1e6tOZV3dLlOKtQtDUlPy6OtnXDu4y+wyJCniy8ivG3+LAe4klzn1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.632.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.632.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.632.0.tgz",
+      "integrity": "sha512-Oh1fIWaoZluihOCb/zDEpRTi+6an82fgJz7fyRBugyLhEtDjmvpCQ3oKjzaOhoN+4EvXAm1ZS/ZgpvXBlIRTgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.632.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.632.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.632.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.632.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/client-sts": {
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.632.0.tgz",
+      "integrity": "sha512-Ss5cBH09icpTvT+jtGGuQlRdwtO7RyE9BF4ZV/CEPATdd9whtJt4Qxdya8BUnkWR7h5HHTrQHqai3YVYjku41A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.632.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.632.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.632.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.632.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/core": {
+      "version": "3.629.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
+      "integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.3.2",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.622.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
+      "integrity": "sha512-VUHbr24Oll1RK3WR8XLUugLpgK9ZuxEm/NVeVqyFts1Ck9gsKpRg1x4eH7L7tW3SJ4TDEQNMbD7/7J+eoL2svg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.632.0.tgz",
+      "integrity": "sha512-m6epoW41xa1ajU5OiHcmQHoGVtrbXBaRBOUhlCLZmcaqMLYsboM4iD/WZP8aatKEON5tTnVXh/4StV8D/+wemw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.622.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.632.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.632.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.632.0.tgz",
+      "integrity": "sha512-cL8fuJWm/xQBO4XJPkeuZzl3XinIn9EExWgzpG48NRMKR5us1RI/ucv7xFbBBaG+r/sDR2HpYBIA3lVIpm1H3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.622.0",
+        "@aws-sdk/credential-provider-ini": "3.632.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.632.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.632.0.tgz",
+      "integrity": "sha512-P/4wB6j7ym5QCPTL2xlMfvf2NcXSh+z0jmsZP4WW/tVwab4hvgabPPbLeEZDSWZ0BpgtxKGvRq0GSHuGeirQbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.632.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.633.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.633.0.tgz",
+      "integrity": "sha512-7jjmWVw28wIHOdrHyTCvwKr1EYGrZI13DviwAOwRC0y9dB8gGCdRiA4fNczripUBxolCCE9mpqLrqy5pXtTzvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-arn-parser": "3.568.0",
+        "@smithy/core": "^2.3.2",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-stream": "^3.1.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.632.0.tgz",
+      "integrity": "sha512-yY/sFsHKwG9yzSf/DTclqWJaGPI2gPBJDCGBujSqTG1zlS7Ot4fqi91DZ6088BFWzbOorDzJFcAhAEFzc6LuQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.632.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.633.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.633.0.tgz",
+      "integrity": "sha512-96F7Mx4lybMZdE0TTEkw6EKpeB0hxqp3J8fUJasesekTnO7jsklc47GHL5R3whyS/L4/JaPazm0Pi2DEH3kw1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.633.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.632.0.tgz",
+      "integrity": "sha512-LlYMU8pAbcEQphOpE6xaNLJ8kPGhklZZTVzZVpVW477NaaGgoGTMYNXTABYHcxeF5E2lLrxql9OmVpvr8GWN8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-endpoints": "^2.0.5",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.621.0",
     "@aws-sdk/client-dynamodb": "^3.621.0",
+    "@aws-sdk/client-eventbridge": "^3.621.0",
     "@aws-sdk/client-s3": "^3.621.0",
     "@aws-sdk/client-sns": "^3.621.0",
     "@aws-sdk/client-sts": "^3.621.0",


### PR DESCRIPTION
## What does this change?

Outputs contents of new recipes to the eventbus as well as takedown notifications for recipes.

## How to test

- Create an SQS queue for testing
- Add a Rule to the `crier-eventbus-content-api-crier-v2-CODE` event bus with the following subscription, and link it to your SQS queue:
```json
{
  "source": ["recipe-responder"]
}
```
- (these two steps have been done already, going to the queue `test-recipes`)
- Go to the SQS console and open your queue
- Publish a recipe in CODE, using Composer (publishing only to the Feast channel will work too 😁 )
- In the SQS console, poll for new messages
- You should see messages coming through, indicating that a recipe was updated
- Perform a takedown on your recipe (or channel takedown)
- You should see another message indicating that the recipe was removed

## How can we measure success?

Able to update the search index automatically

## Have we considered potential risks?

n/a.  We have discussed potential issues from clustering a lot of messages on one bus, but concluded that since the buses are stateless and we are not throwing around millions of messages per second it should be fine.
