### PR TITLE
Better publish messages on Fronts parse error

### DIFF
--- a/lambda/facia-responder/src/fixtures/sns.ts
+++ b/lambda/facia-responder/src/fixtures/sns.ts
@@ -39,10 +39,34 @@ export const validMessage = {
 	Message: JSON.stringify(validMessageContent),
 };
 
-export const brokenMessage = {
+export const messageWithBrokenIssueDate = {
 	...validMessage,
 	Message: JSON.stringify({
 		...validMessageContent,
 		issueDate: 'dfsdfsjk',
+	}),
+};
+
+export const messageWithMissingFrontsTitle = {
+	...validMessage,
+	Message: JSON.stringify({
+		...validMessageContent,
+		fronts: {
+			...validMessageContent.fronts,
+			'all-recipes': [
+				{
+					id: 'd353e2de-1a65-45de-85ca-d229bc1fafad',
+					title: null,
+					body: '',
+					items: [
+						{
+							recipe: {
+								id: '14129325',
+							},
+						},
+					],
+				},
+			],
+		},
 	}),
 };

--- a/lambda/facia-responder/src/main.ts
+++ b/lambda/facia-responder/src/main.ts
@@ -94,6 +94,7 @@ export const handler: SQSHandler = async (event) => {
 				timestamp: Date.now(),
 			});
 		} catch (e) {
+      console.error(e);
 			return notifyFaciaTool({
 				edition,
 				issueDate,

--- a/lib/facia/src/lib/facia-models.ts
+++ b/lib/facia/src/lib/facia-models.ts
@@ -1,14 +1,14 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 //This should mirror FeastAppModel in Facia backend
 export const RecipeIdentifier = z.object({
-  id: z.string()
-})
+	id: z.string(),
+});
 
 export type RecipeIdentifier = z.infer<typeof RecipeIdentifier>;
 
 export const Recipe = z.object({
-  recipe: RecipeIdentifier
+	recipe: RecipeIdentifier,
 });
 
 export type Recipe = z.infer<typeof Recipe>;
@@ -28,8 +28,8 @@ export const Chef = z.object({
 export type Chef = z.infer<typeof Chef>;
 
 export const Palette = z.object({
-  backgroundHex: z.string().optional(),
-  foregroundHex: z.string().optional(),
+	backgroundHex: z.string().optional(),
+	foregroundHex: z.string().optional(),
 });
 
 export type Palette = z.infer<typeof Palette>;
@@ -74,22 +74,30 @@ export const Edition = z.custom<Edition>(
 	},
 );
 
-const DateString = z.custom<string>((val)=>{
-  try {
-    const d = Date.parse(val as string);
-    return !isNaN(d)
-  } catch {
-    return false
-  }
+const DateString = z.custom<string>((val) => {
+	try {
+		const d = Date.parse(val as string);
+		return !isNaN(d);
+	} catch {
+		return false;
+	}
 });
 
-export const FeastCuration = z.object({
-  id: z.string(),
-  edition: Edition,
-  issueDate: DateString,
-  version: z.string(),
-  fronts: z.record(z.string(), z.array(FeastAppContainer))
+export const FeastCurationEnvelope = z.object({
+	id: z.string(),
+	edition: Edition,
+	issueDate: DateString,
+	version: z.string(),
 });
+
+export type FeastCurationEnvelope = z.infer<typeof FeastCurationEnvelope>;
+
+export const FeastCuration = z.intersection(
+	FeastCurationEnvelope,
+	z.object({
+		fronts: z.record(z.string(), z.array(FeastAppContainer)),
+	}),
+);
 
 export type FeastCuration = z.infer<typeof FeastCuration>;
 export const MiseEnPlaceData = z.array(FeastAppContainer);

--- a/lib/facia/src/lib/facia-models.ts
+++ b/lib/facia/src/lib/facia-models.ts
@@ -14,15 +14,15 @@ export const Recipe = z.object({
 export type Recipe = z.infer<typeof Recipe>;
 
 export const ChefData = z.object({
-  backgroundHex: z.string().optional(),
-  id: z.string(),
-  image: z.string().optional(),
-  bio: z.string().optional(),
-  foregroundHex: z.string().optional()
+	backgroundHex: z.string().optional(),
+	id: z.string(),
+	image: z.string().optional(),
+	bio: z.string().optional(),
+	foregroundHex: z.string().optional()
 });
 
 export const Chef = z.object({
-  chef: ChefData
+	chef: ChefData
 });
 
 export type Chef = z.infer<typeof Chef>;
@@ -35,16 +35,16 @@ export const Palette = z.object({
 export type Palette = z.infer<typeof Palette>;
 
 export const SubCollectionData = z.object({
-  byline: z.string().optional(),
-  darkPalette: Palette.optional(),
-  image: z.string().optional(),
-  title: z.string(),
-  lightPalette: Palette.optional(),
-  recipes: z.array(z.string())
+	byline: z.string().optional(),
+	darkPalette: Palette.optional(),
+	image: z.string().optional(),
+	title: z.string(),
+	lightPalette: Palette.optional(),
+	recipes: z.array(z.string())
 });
 
 export const SubCollection = z.object({
-  collection: SubCollectionData,
+	collection: SubCollectionData,
 });
 
 export type SubCollection = z.infer<typeof SubCollection>;
@@ -52,10 +52,10 @@ export type SubCollection = z.infer<typeof SubCollection>;
 export type ContainerItem = SubCollection | Chef | Recipe;
 
 export const FeastAppContainer = z.object({
-  id: z.string().optional(),
-  title: z.string(),
-  body: z.string().optional(),
-  items: z.array(z.union([SubCollection, Chef, Recipe]))
+	id: z.string().optional(),
+	title: z.string(),
+	body: z.string().optional(),
+	items: z.array(z.union([SubCollection, Chef, Recipe]))
 });
 
 export type FeastAppContainer = z.infer<typeof FeastAppContainer>;


### PR DESCRIPTION
~NB: don't merge until we've merged https://github.com/guardian/facia-tool/pull/1612, which should fix any parsing issues!~ Now merged, this is ready for review.

## What does this change?

Better error messages sent to facia-tool's issue publication status queue when parsing the Fronts data fails.

To do this, we split the parsing into two steps – the first, for the message envelope containing the issue data that lets us post a notification containing the relevant information for facia-tool, and the second, parsing the Fronts data itself.

The Fronts data is much more likely to change over time, and it's nice to receive errors in the upstream tooling when downstream breaks.

## How to test

- The tests should pass. They test the happy path, an unparseable message, a failed envelope parse, and a failed fronts parse.
- Deploy a version of the Fronts tool prior to https://github.com/guardian/facia-tool/pull/1612, and publish a Feast issue. You should see a validation error appear in the publication status messages.

A few tab/space inconsistency issues are covered in facia-models.ts – perhaps better reviewed with the [whitespace diff off.](https://github.com/guardian/recipes-backend/pull/54/files?diff=split&w=1)