### PR TITLE
Make chef bio optional

### DIFF
--- a/lib/facia/src/lib/facia-models.ts
+++ b/lib/facia/src/lib/facia-models.ts
@@ -17,7 +17,7 @@ export const Chef = z.object({
   backgroundHex: z.string().optional(),
   id: z.string(),
   image: z.string().optional(),
-  bio: z.string(),                //FIXME - should this be Optional? Check with Basecamp team
+  bio: z.string().optional(),
   foregroundHex: z.string().optional()
 });
 


### PR DESCRIPTION
## What does this change?

Makes the chef bio optional. We'll want to pull in bio information from the tag page directly (as with images) in the curation lambda if there are no overrides.

## How to test

In Fronts CODE with https://github.com/guardian/facia-tool/pull/1612 deployed, add a chef to an issue, and publish. You should see the publish request succeed:

<img width="766" alt="Screenshot 2024-08-02 at 14 40 25" src="https://github.com/user-attachments/assets/74a3915c-ddda-423d-9391-b6495c79eaa9">

Previous requests would fail with a Zod error ([example logs.](https://logs.gutools.co.uk/s/content-platforms/app/discover#/doc/b0be43a0-59d7-11e8-a75a-b7af20e8f748/logstash-capi-2024.08.02?id=_D9LE5EBb0N6Anqergf0))