### PR TITLE
Ready Fronts feast curation for production

### DIFF
--- a/lambda/facia-responder/src/main.ts
+++ b/lambda/facia-responder/src/main.ts
@@ -26,16 +26,18 @@ function parseFeastCuration(
 
 async function deployCuration(curation: facia.FeastCuration) {
 	const issueDate = new Date(curation.issueDate);
+	const region = curation.path ?? curation.edition;
 	for (const frontName of Object.keys(curation.fronts)) {
 		console.log(
-			`Deploying new front for ${frontName} in ${
-				curation.edition as string
-			} on ${format(issueDate, 'yyyy-MM-dd')}`,
+			`Deploying new front for ${frontName} in ${region} on ${format(
+				issueDate,
+				'yyyy-MM-dd',
+			)}`,
 		);
 		const serializedFront = JSON.stringify(curation.fronts[frontName]);
 		await deployCurationData(
 			serializedFront,
-			curation.edition,
+			region,
 			frontName,
 			issueDate,
 		);

--- a/lib/facia/src/lib/facia-models.ts
+++ b/lib/facia/src/lib/facia-models.ts
@@ -72,6 +72,9 @@ const DateString = z.custom<string>((val) => {
 export const FeastCurationEnvelope = z.object({
 	id: z.string(),
 	edition: z.string(),
+	// The path to publish the issue under, e.g. 'northern', 'southern'.
+	// If it is not present, we can fall back to the `edition`.
+	path: z.string().optional(),
 	issueDate: DateString,
 	version: z.string(),
 });

--- a/lib/facia/src/lib/facia-models.ts
+++ b/lib/facia/src/lib/facia-models.ts
@@ -36,11 +36,12 @@ export type Palette = z.infer<typeof Palette>;
 
 export const SubCollectionData = z.object({
 	byline: z.string().optional(),
+	body: z.string().optional(),
 	darkPalette: Palette.optional(),
 	image: z.string().optional(),
 	title: z.string(),
 	lightPalette: Palette.optional(),
-	recipes: z.array(z.string())
+	recipes: z.array(z.string()),
 });
 
 export const SubCollection = z.object({

--- a/lib/facia/src/lib/facia-models.ts
+++ b/lib/facia/src/lib/facia-models.ts
@@ -60,20 +60,6 @@ export const FeastAppContainer = z.object({
 
 export type FeastAppContainer = z.infer<typeof FeastAppContainer>;
 
-const AvailableEditions = [
-	'feast-northern-hemisphere',
-	'feast-southern-hemisphere',
-] as const;
-export type Edition = (typeof AvailableEditions)[number];
-export const Edition = z.custom<Edition>(
-	(val) => AvailableEditions.includes(val),
-	{
-		message: `Edition name must be one of the following: ${AvailableEditions.join(
-			', ',
-		)}`,
-	},
-);
-
 const DateString = z.custom<string>((val) => {
 	try {
 		const d = Date.parse(val as string);
@@ -85,7 +71,7 @@ const DateString = z.custom<string>((val) => {
 
 export const FeastCurationEnvelope = z.object({
 	id: z.string(),
-	edition: Edition,
+	edition: z.string(),
 	issueDate: DateString,
 	version: z.string(),
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds two things that were necessary to test Fronts curation end-to-end in CODE:

- Adds a 'body' property to Feast Collections, which is always empty in PROD data – but the Android app will not display feast collections without it! (We can co-ordinate with Feast apps teams to manage correcting this behaviour.)
- Removes the restriction on Front names currently present in the Zod typings, to permit the Fronts tool upstream to publish to `northern`/`southern` fronts, and add `-test` suffixes in PROD.

(I think it's fine for recipes-backend not to have opinions about front names at all – otherwise we couple Fronts and recipes-backend together for simple changes like 'add a new front to an issue'.)

## How to test

- Deploy this branch alongside [this facia-tool branch](https://github.com/guardian/facia-tool/pull/1648)
- Publish a front.
- [App logs](https://logs.gutools.co.uk/s/content-platforms/goto/9a56f9d0-686d-11ef-b82f-05230116435d) should look good.
- The new data should appear at the appropriate URL, e.g. `recipes.code.dev-guardianapis.com/northern/all-recipes/curation.json`.