### PR TITLE
Insert article time data into recipe model

### DIFF
--- a/lambda/recipes-responder/src/update_retrievable_processor.test.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.test.ts
@@ -54,7 +54,7 @@ describe('handleContentUpdateRetrievable',  ()=> {
 				'/path/to/article',
 				'/channel/feast/item/path/to/article',
 			) +
-				'?show-fields=internalRevision&show-blocks=all&show-channels=all&api-key=fake-api-key&format=thrift',
+				'?show-fields=internalRevision,lastModifiedDate,firstPublishedDate,publishedDate&show-blocks=all&show-channels=all&api-key=fake-api-key&format=thrift',
 		);
     // @ts-ignore -- Typescript doesn't know that this is a mock
     expect(handleContentUpdate.mock.calls.length).toEqual(1);

--- a/lambda/recipes-responder/src/update_retrievable_processor.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.ts
@@ -26,7 +26,7 @@ export async function retrieveContent(capiUrl:string) :Promise<PollingResult>{
   }
 
   const params = [
-    `show-fields=internalRevision`,
+    `show-fields=internalRevision,lastModifiedDate,firstPublishedDate,publishedDate`,
     `show-blocks=all`,
     `show-channels=all`,
     `api-key=${CapiKey}`,

--- a/lib/recipes-data/src/lib/extract-recipes.test.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.test.ts
@@ -7,7 +7,6 @@ import Int64 from 'node-int64';
 import { extractRecipeData } from './extract-recipes';
 import type { RecipeWithImageData } from './transform';
 import { capiDateTimeToDate, makeCapiDateTime } from './utils';
-import { RecipeDates } from './models';
 
 jest.mock('./config', () => ({
 	FeaturedImageWidth: 700,

--- a/lib/recipes-data/src/lib/extract-recipes.test.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.test.ts
@@ -1,6 +1,6 @@
 import type { Sponsorship } from '@guardian/content-api-models/v1/sponsorship';
 import { extractRecipeData } from './extract-recipes';
-import { activeSponsorships, block, canonicalId, invalidRecipeElements, multipleRecipeElements, noRecipeElements, recipeDates, singleRecipeElement } from './recipe-fixtures';
+import { activeSponsorships, block, content, invalidRecipeElements, multipleRecipeElements, noRecipeElements, recipeDates, singleRecipeElement } from './recipe-fixtures';
 import type { RecipeWithImageData } from './transform';
 import { capiDateTimeToDate } from './utils';
 
@@ -13,7 +13,7 @@ jest.mock('./config', () => ({
 describe('extractRecipeData', () => {
 	it('should work when block containing single recipe element', () => {
 		const testBlock = { ...block, elements: singleRecipeElement };
-		const result = extractRecipeData(canonicalId, testBlock, []);
+		const result = extractRecipeData(content, testBlock, []);
 		expect(result.length).toEqual(1);
 		expect(result[0]?.recipeUID).toEqual(
 			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
@@ -34,7 +34,7 @@ describe('extractRecipeData', () => {
 
 	it('should work when block containing multiple recipe elements', () => {
 		const testBlock = { ...block, elements: multipleRecipeElements}
-		const result = extractRecipeData(canonicalId, testBlock, []);
+		const result = extractRecipeData(content, testBlock, []);
 		expect(result.length).toEqual(3);
 		expect(result[2]?.recipeUID).toEqual(
 			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
@@ -55,20 +55,20 @@ describe('extractRecipeData', () => {
 
 	it('should work when block containing no recipe elements ', () => {
 		const testBlock = { ...block, elements: noRecipeElements}
-		const result = extractRecipeData(canonicalId, testBlock, []);
+		const result = extractRecipeData(content, testBlock, []);
 		expect(result.length).toEqual(0);
 	});
 
 	it('should return empty array when block has got invalid recipe element (no ID field) ', () => {
 		const testBlock = { ...block, elements: invalidRecipeElements}
-		const recipesFound = extractRecipeData(canonicalId, testBlock, []);
+		const recipesFound = extractRecipeData(content, testBlock, []);
 		expect(recipesFound).toEqual([null]);
 		expect(recipesFound.length).toEqual(1);
 	});
 
 	it('should work when block containing recipe element and is sponsored, means we have sponsorship data as well', () => {
 		const testBlock = { ...block, elements: singleRecipeElement };
-		const result = extractRecipeData(canonicalId, testBlock, activeSponsorships);
+		const result = extractRecipeData(content, testBlock, activeSponsorships);
 		expect(result.length).toEqual(1);
 		expect(result[0]?.recipeUID).toEqual(
 			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
@@ -88,7 +88,7 @@ describe('extractRecipeData', () => {
 	it('should work when block containing recipe element but not sponsored, means no sponsor data available', () => {
 		const testBlock = { ...block, elements: singleRecipeElement };
 		const activeSponsorships: Sponsorship[] = [];
-		const result = extractRecipeData(canonicalId, testBlock, activeSponsorships);
+		const result = extractRecipeData(content, testBlock, activeSponsorships);
 		expect(result.length).toEqual(1);
 		expect(result[0]?.recipeUID).toEqual(
 			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
@@ -103,8 +103,9 @@ describe('extractRecipeData', () => {
 
 	it('should update the canonicalArticle with the content ID', () => {
 		const canonicalId = 'a-new-path';
+    const testContent = { ...content, id: canonicalId };
     const testBlock = { ...block, elements: singleRecipeElement };
-		const result = extractRecipeData(canonicalId, testBlock, []);
+		const result = extractRecipeData(testContent, testBlock, []);
 		expect(result.length).toEqual(1);
 		const data = JSON.parse(
 			result[0]?.jsonBlob as string,
@@ -114,7 +115,7 @@ describe('extractRecipeData', () => {
 
 	it('should add recipe dates where specified', () => {
 		const testBlock = { ...block, elements: singleRecipeElement, ...recipeDates };
-		const result = extractRecipeData(canonicalId, testBlock, []);
+		const result = extractRecipeData(content, testBlock, []);
 		expect(result.length).toEqual(1);
 		expect(result[0]?.recipeUID).toEqual(
 			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
@@ -143,7 +144,7 @@ describe('extractRecipeData', () => {
 			publishedDate: undefined,
 		};
 		const testBlock = { ...block, elements: singleRecipeElement, ...recipeDates };
-		const result = extractRecipeData(canonicalId, testBlock, []);
+		const result = extractRecipeData(content, testBlock, []);
 		expect(result.length).toEqual(1);
 		expect(result[0]?.recipeUID).toEqual(
 			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',

--- a/lib/recipes-data/src/lib/extract-recipes.test.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.test.ts
@@ -1,689 +1,1024 @@
-import {AssetType} from "@guardian/content-api-models/v1/assetType";
-import type {Block} from "@guardian/content-api-models/v1/block";
-import {ElementType} from "@guardian/content-api-models/v1/elementType";
-import type {Sponsorship} from "@guardian/content-api-models/v1/sponsorship";
-import {SponsorshipType} from "@guardian/content-api-models/v1/sponsorshipType";
-import {extractRecipeData} from "./extract-recipes";
-import type {RecipeWithImageData} from "./transform";
-import {makeCapiDateTime} from './utils';
+import { AssetType } from '@guardian/content-api-models/v1/assetType';
+import type { Block } from '@guardian/content-api-models/v1/block';
+import { ElementType } from '@guardian/content-api-models/v1/elementType';
+import type { Sponsorship } from '@guardian/content-api-models/v1/sponsorship';
+import { SponsorshipType } from '@guardian/content-api-models/v1/sponsorshipType';
+import Int64 from 'node-int64';
+import { extractRecipeData } from './extract-recipes';
+import type { RecipeWithImageData } from './transform';
+import { capiDateTimeToDate, makeCapiDateTime } from './utils';
+import { RecipeDates } from './models';
 
 jest.mock('./config', () => ({
-  FeaturedImageWidth: 700,
-  PreviewImageWidth: 300,
-  ImageDpr: 1,
+	FeaturedImageWidth: 700,
+	PreviewImageWidth: 300,
+	ImageDpr: 1,
 }));
 
-describe("extractRecipeData", () => {
+describe('extractRecipeData', () => {
+	it('should work when block containing single recipe element', () => {
+		const canonicalId =
+			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
+		const block: Block = {
+			id: '5a4b754ce4b0e33567c465c7',
+			bodyHtml:
+				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
+			bodyTextSummary: '',
+			attributes: {},
+			published: true,
+			contributors: [],
+			createdBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			lastModifiedBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			elements: [
+				{
+					type: ElementType.TEXT,
+					assets: [],
+					textTypeData: {
+						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+					},
+				},
+				{
+					type: ElementType.RECIPE,
+					assets: [],
+					recipeTypeData: {
+						recipeJson:
+							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+					},
+				},
+				{
+					type: ElementType.IMAGE,
+					assets: [
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 1000,
+								height: 600,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 500,
+								height: 300,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 5512,
+								height: 3308,
+								isMaster: true,
+							},
+						},
+					],
+					imageTypeData: {
+						caption:
+							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						copyright: 'LOUISE HAGGER',
+						displayCredit: true,
+						credit:
+							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						source:
+							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						mediaApiUri:
+							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						suppliersReference:
+							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+						imageType: 'Photograph',
+					},
+				},
+			],
+		};
+		const result = extractRecipeData(canonicalId, block, []);
+		expect(result.length).toEqual(1);
+		expect(result[0]?.recipeUID).toEqual(
+			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
+		);
+		const originalContent = block.elements[1].recipeTypeData?.recipeJson
+			? (JSON.parse(block.elements[1].recipeTypeData.recipeJson) as Record<
+					string,
+					unknown
+			  >)
+			: {};
+		const expected = JSON.stringify({
+			...originalContent,
+			contributors: ['profile/thomasina-miers'],
+			byline: [],
+		});
+		expect(result[0]?.jsonBlob).toEqual(expected);
+	});
 
-  it("should work when block containing single recipe element", () => {
-    const canonicalId = "lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers"
-    const block: Block = {
-      id: "5a4b754ce4b0e33567c465c7",
-      bodyHtml: "<figure class=\"element element-image\" data-media-id=\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\"> <img src=\"https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg\" alt=\"Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.\" width=\"1000\" height=\"600\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class=\"element-image__credit\">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>",
-      bodyTextSummary: "",
-      attributes: {},
-      published: true,
-      contributors: [],
-      createdBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      lastModifiedBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      elements: [
-        {
-          type: ElementType.TEXT,
-          assets: [],
-          textTypeData: {
-            html: "<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>"
-          }
-        },
-        {
-          type: ElementType.RECIPE,
-          assets: [],
-          recipeTypeData: {
-            recipeJson: "{\"id\":\"1\",\"canonicalArticle\":\"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers\",\"title\":\"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing\",\"featuredImage\":\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\",\"contributors\":[{\"type\":\"contributor\",\"tagId\":\"profile/thomasina-miers\"}],\"ingredients\":[{\"recipeSection\":\"For the dressing\",\"ingredientsList\":[{\"item\":\"soba\",\"unit\":\"g\",\"comment\":\"or glass noodles\",\"text\":\"200g soba or glass noodles\"},{\"item\":\"frozen soya beans\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g frozen soya beans\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp sesame oil\"},{\"item\":\"carrots\",\"unit\":\"\",\"comment\":\"peeled then grated or cut into thin ribbons\",\"text\":\"2 carrots, peeled, then grated or cut into thin ribbons\"},{\"item\":\"red cabbage\",\"unit\":\"g\",\"comment\":\"finely shredded\",\"text\":\"150g red cabbage, finely shredded\"},{\"item\":\"mooli\",\"unit\":\"g\",\"comment\":\"or radishes cut into matchsticks or thin slivers\",\"text\":\"100g mooli or radishes, cut into matchsticks or thin slivers\"},{\"item\":\"green apple\",\"unit\":\"\",\"comment\":\"\",\"text\":\"1 green apple\"},{\"item\":\"spring onions\",\"unit\":\"\",\"comment\":\"finely sliced\",\"text\":\"3 spring onions, finely sliced\"},{\"item\":\"coriander\",\"unit\":\"small bunch\",\"comment\":\"roughly chopped\",\"text\":\"1 small bunch coriander, roughly chopped\"},{\"item\":\"mint leaves\",\"unit\":\"handful\",\"comment\":\"roughly torn\",\"text\":\"1 handful mint leaves, roughly torn\"},{\"item\":\"basil leaves\",\"unit\":\"handful\",\"comment\":\"or more coriander roughly chopped\",\"text\":\"1 handful basil leaves (or more coriander), roughly chopped\"},{\"item\":\"toasted sunflower seeds\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"40g toasted sunflower seeds\"},{\"item\":\"toasted sesame seeds\",\"unit\":\"g\",\"comment\":\"a mixture of black and white looks good to serve\",\"text\":\"25g toasted sesame seeds (a mixture of black and white looks good), to serve\"}]},{\"recipeSection\":\"And for the rest of the week…\",\"ingredientsList\":[{\"item\":\"fresh ginger\",\"unit\":\"thumb\",\"comment\":\"sized chunk  peeled\",\"text\":\"1 thumb-sized chunk fresh ginger, peeled\"},{\"item\":\"garlic\",\"unit\":\"clove\",\"comment\":\"\",\"text\":\"½ garlic clove\"},{\"item\":\"tahini\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g tahini\"},{\"item\":\"lime\",\"unit\":\"\",\"comment\":\"Juice of\",\"text\":\"Juice of 1 lime\"},{\"item\":\"sriracha\",\"unit\":\"tbsp\",\"comment\":\"or your favourite style of chilli sauce\",\"text\":\"1 tbsp sriracha (or your favourite style of chilli sauce)\"},{\"item\":\"bird’s\",\"unit\":\"\",\"comment\":\"eye chilli stalked removed optional\",\"text\":\"1 bird’s-eye chilli, stalked removed (optional)\"},{\"item\":\"soy sauce\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp soy sauce\"},{\"item\":\"demerara sugar\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp demerara sugar\"},{\"item\":\"\",\"unit\":\"\",\"comment\":\"or honey\",\"text\":\"(or honey)\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"3 tbsp sesame oil\"},{\"item\":\"water\",\"unit\":\"ml\",\"comment\":\"\",\"text\":\"25ml water\"}]}],\"suitableForDietIds\":[],\"cuisineIds\":[],\"mealTypeIds\":[],\"celebrationsIds\":[\"summer-food-and-drink\"],\"utensilsAndApplianceIds\":[],\"techniquesUsedIds\":[],\"timings\":[],\"instructions\":[{\"stepNumber\":0,\"description\":\"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.\",\"images\":[]},{\"stepNumber\":1,\"description\":\"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).\",\"images\":[]},{\"stepNumber\":2,\"description\":\"Add the carrots, red cabbage and mooli or radishes to the bowl.\",\"images\":[]},{\"stepNumber\":3,\"description\":\"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.\",\"images\":[]},{\"stepNumber\":4,\"description\":\"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).\",\"images\":[]},{\"stepNumber\":5,\"description\":\"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.\",\"images\":[]},{\"stepNumber\":6,\"description\":\"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.\",\"images\":[]},{\"stepNumber\":7,\"description\":\"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.\",\"images\":[]},{\"stepNumber\":8,\"description\":\"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.\",\"images\":[]},{\"stepNumber\":9,\"description\":\"Toss the dressing through the salad and season to taste; it may need more lime juice.\",\"images\":[]},{\"stepNumber\":10,\"description\":\"Scatter the sesame seeds on top and serve.\",\"images\":[]},{\"stepNumber\":11,\"description\":\"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.\",\"images\":[]}]}"
-          }
-        },
-        {
-          type: ElementType.IMAGE,
-          assets: [
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 1000,
-                height: 600
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 500,
-                height: 300
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 5512,
-                height: 3308,
-                isMaster: true
-              }
-            }
-          ],
-          imageTypeData: {
-            caption: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            copyright: "LOUISE HAGGER",
-            displayCredit: true,
-            credit: "Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            source: "Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            alt: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            mediaId: "58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            mediaApiUri: "https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            suppliersReference: "Soba noodles with crisp rainbow vegetables and a spicy sesame se",
-            imageType: "Photograph"
-          }
-        }
-      ]
-    }
-    const result = extractRecipeData(canonicalId, block, [])
-    expect(result.length).toEqual(1)
-    expect(result[0]?.recipeUID).toEqual("62ac3f0f98f6495cbefd72c11fac6d1e26390e99")
-    const originalContent = block.elements[1].recipeTypeData?.recipeJson ? JSON.parse(block.elements[1].recipeTypeData.recipeJson) as Record<string, unknown> : {};
-    const expected = JSON.stringify({...originalContent, contributors: ["profile/thomasina-miers"], byline: []});
-    expect(result[0]?.jsonBlob).toEqual(expected);
-  })
+	it('should work when block containing multiple recipe elements', () => {
+		const canonicalId =
+			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
+		const block: Block = {
+			id: '5a4b754ce4b0e33567c465c7',
+			bodyHtml:
+				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
+			bodyTextSummary: '',
+			attributes: {},
+			published: true,
+			contributors: [],
+			createdBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			lastModifiedBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			elements: [
+				{
+					type: ElementType.TEXT,
+					assets: [],
+					textTypeData: {
+						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+					},
+				},
+				{
+					type: ElementType.RECIPE,
+					assets: [],
+					recipeTypeData: {
+						recipeJson:
+							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+					},
+				},
+				{
+					type: ElementType.RECIPE,
+					assets: [],
+					recipeTypeData: {
+						recipeJson:
+							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+					},
+				},
+				{
+					type: ElementType.RECIPE,
+					assets: [],
+					recipeTypeData: {
+						recipeJson:
+							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+					},
+				},
+				{
+					type: ElementType.IMAGE,
+					assets: [
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 1000,
+								height: 600,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 500,
+								height: 300,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 5512,
+								height: 3308,
+								isMaster: true,
+							},
+						},
+					],
+					imageTypeData: {
+						caption:
+							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						copyright: 'LOUISE HAGGER',
+						displayCredit: true,
+						credit:
+							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						source:
+							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						mediaApiUri:
+							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						suppliersReference:
+							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+						imageType: 'Photograph',
+					},
+				},
+			],
+		};
+		const result = extractRecipeData(canonicalId, block, []);
+		expect(result.length).toEqual(3);
+		expect(result[2]?.recipeUID).toEqual(
+			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
+		);
+		const originalContent = block.elements[3].recipeTypeData?.recipeJson
+			? (JSON.parse(block.elements[3].recipeTypeData.recipeJson) as Record<
+					string,
+					unknown
+			  >)
+			: {};
+		const expected = JSON.stringify({
+			...originalContent,
+			contributors: ['profile/thomasina-miers'],
+			byline: [],
+		});
+		expect(result[2]?.jsonBlob).toEqual(expected);
+	});
 
-  it("should work when block containing multiple recipe elements", () => {
-    const canonicalId = "lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers"
-    const block: Block = {
-      id: "5a4b754ce4b0e33567c465c7",
-      bodyHtml: "<figure class=\"element element-image\" data-media-id=\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\"> <img src=\"https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg\" alt=\"Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.\" width=\"1000\" height=\"600\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class=\"element-image__credit\">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>",
-      bodyTextSummary: "",
-      attributes: {},
-      published: true,
-      contributors: [],
-      createdBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      lastModifiedBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      elements: [
-        {
-          type: ElementType.TEXT,
-          assets: [],
-          textTypeData: {
-            html: "<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>"
-          }
-        },
-        {
-          type: ElementType.RECIPE,
-          assets: [],
-          recipeTypeData: {
-            recipeJson: "{\"id\":\"1\",\"canonicalArticle\":\"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers\",\"title\":\"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing\",\"featuredImage\":\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\",\"contributors\":[{\"type\":\"contributor\",\"tagId\":\"profile/thomasina-miers\"}],\"ingredients\":[{\"recipeSection\":\"For the dressing\",\"ingredientsList\":[{\"item\":\"soba\",\"unit\":\"g\",\"comment\":\"or glass noodles\",\"text\":\"200g soba or glass noodles\"},{\"item\":\"frozen soya beans\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g frozen soya beans\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp sesame oil\"},{\"item\":\"carrots\",\"unit\":\"\",\"comment\":\"peeled then grated or cut into thin ribbons\",\"text\":\"2 carrots, peeled, then grated or cut into thin ribbons\"},{\"item\":\"red cabbage\",\"unit\":\"g\",\"comment\":\"finely shredded\",\"text\":\"150g red cabbage, finely shredded\"},{\"item\":\"mooli\",\"unit\":\"g\",\"comment\":\"or radishes cut into matchsticks or thin slivers\",\"text\":\"100g mooli or radishes, cut into matchsticks or thin slivers\"},{\"item\":\"green apple\",\"unit\":\"\",\"comment\":\"\",\"text\":\"1 green apple\"},{\"item\":\"spring onions\",\"unit\":\"\",\"comment\":\"finely sliced\",\"text\":\"3 spring onions, finely sliced\"},{\"item\":\"coriander\",\"unit\":\"small bunch\",\"comment\":\"roughly chopped\",\"text\":\"1 small bunch coriander, roughly chopped\"},{\"item\":\"mint leaves\",\"unit\":\"handful\",\"comment\":\"roughly torn\",\"text\":\"1 handful mint leaves, roughly torn\"},{\"item\":\"basil leaves\",\"unit\":\"handful\",\"comment\":\"or more coriander roughly chopped\",\"text\":\"1 handful basil leaves (or more coriander), roughly chopped\"},{\"item\":\"toasted sunflower seeds\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"40g toasted sunflower seeds\"},{\"item\":\"toasted sesame seeds\",\"unit\":\"g\",\"comment\":\"a mixture of black and white looks good to serve\",\"text\":\"25g toasted sesame seeds (a mixture of black and white looks good), to serve\"}]},{\"recipeSection\":\"And for the rest of the week…\",\"ingredientsList\":[{\"item\":\"fresh ginger\",\"unit\":\"thumb\",\"comment\":\"sized chunk  peeled\",\"text\":\"1 thumb-sized chunk fresh ginger, peeled\"},{\"item\":\"garlic\",\"unit\":\"clove\",\"comment\":\"\",\"text\":\"½ garlic clove\"},{\"item\":\"tahini\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g tahini\"},{\"item\":\"lime\",\"unit\":\"\",\"comment\":\"Juice of\",\"text\":\"Juice of 1 lime\"},{\"item\":\"sriracha\",\"unit\":\"tbsp\",\"comment\":\"or your favourite style of chilli sauce\",\"text\":\"1 tbsp sriracha (or your favourite style of chilli sauce)\"},{\"item\":\"bird’s\",\"unit\":\"\",\"comment\":\"eye chilli stalked removed optional\",\"text\":\"1 bird’s-eye chilli, stalked removed (optional)\"},{\"item\":\"soy sauce\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp soy sauce\"},{\"item\":\"demerara sugar\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp demerara sugar\"},{\"item\":\"\",\"unit\":\"\",\"comment\":\"or honey\",\"text\":\"(or honey)\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"3 tbsp sesame oil\"},{\"item\":\"water\",\"unit\":\"ml\",\"comment\":\"\",\"text\":\"25ml water\"}]}],\"suitableForDietIds\":[],\"cuisineIds\":[],\"mealTypeIds\":[],\"celebrationsIds\":[\"summer-food-and-drink\"],\"utensilsAndApplianceIds\":[],\"techniquesUsedIds\":[],\"timings\":[],\"instructions\":[{\"stepNumber\":0,\"description\":\"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.\",\"images\":[]},{\"stepNumber\":1,\"description\":\"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).\",\"images\":[]},{\"stepNumber\":2,\"description\":\"Add the carrots, red cabbage and mooli or radishes to the bowl.\",\"images\":[]},{\"stepNumber\":3,\"description\":\"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.\",\"images\":[]},{\"stepNumber\":4,\"description\":\"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).\",\"images\":[]},{\"stepNumber\":5,\"description\":\"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.\",\"images\":[]},{\"stepNumber\":6,\"description\":\"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.\",\"images\":[]},{\"stepNumber\":7,\"description\":\"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.\",\"images\":[]},{\"stepNumber\":8,\"description\":\"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.\",\"images\":[]},{\"stepNumber\":9,\"description\":\"Toss the dressing through the salad and season to taste; it may need more lime juice.\",\"images\":[]},{\"stepNumber\":10,\"description\":\"Scatter the sesame seeds on top and serve.\",\"images\":[]},{\"stepNumber\":11,\"description\":\"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.\",\"images\":[]}]}"
-          }
-        },
-        {
-          type: ElementType.RECIPE,
-          assets: [],
-          recipeTypeData: {
-            recipeJson: "{\"id\":\"1\",\"canonicalArticle\":\"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers\",\"title\":\"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing\",\"featuredImage\":\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\",\"contributors\":[{\"type\":\"contributor\",\"tagId\":\"profile/thomasina-miers\"}],\"ingredients\":[{\"recipeSection\":\"For the dressing\",\"ingredientsList\":[{\"item\":\"soba\",\"unit\":\"g\",\"comment\":\"or glass noodles\",\"text\":\"200g soba or glass noodles\"},{\"item\":\"frozen soya beans\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g frozen soya beans\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp sesame oil\"},{\"item\":\"carrots\",\"unit\":\"\",\"comment\":\"peeled then grated or cut into thin ribbons\",\"text\":\"2 carrots, peeled, then grated or cut into thin ribbons\"},{\"item\":\"red cabbage\",\"unit\":\"g\",\"comment\":\"finely shredded\",\"text\":\"150g red cabbage, finely shredded\"},{\"item\":\"mooli\",\"unit\":\"g\",\"comment\":\"or radishes cut into matchsticks or thin slivers\",\"text\":\"100g mooli or radishes, cut into matchsticks or thin slivers\"},{\"item\":\"green apple\",\"unit\":\"\",\"comment\":\"\",\"text\":\"1 green apple\"},{\"item\":\"spring onions\",\"unit\":\"\",\"comment\":\"finely sliced\",\"text\":\"3 spring onions, finely sliced\"},{\"item\":\"coriander\",\"unit\":\"small bunch\",\"comment\":\"roughly chopped\",\"text\":\"1 small bunch coriander, roughly chopped\"},{\"item\":\"mint leaves\",\"unit\":\"handful\",\"comment\":\"roughly torn\",\"text\":\"1 handful mint leaves, roughly torn\"},{\"item\":\"basil leaves\",\"unit\":\"handful\",\"comment\":\"or more coriander roughly chopped\",\"text\":\"1 handful basil leaves (or more coriander), roughly chopped\"},{\"item\":\"toasted sunflower seeds\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"40g toasted sunflower seeds\"},{\"item\":\"toasted sesame seeds\",\"unit\":\"g\",\"comment\":\"a mixture of black and white looks good to serve\",\"text\":\"25g toasted sesame seeds (a mixture of black and white looks good), to serve\"}]},{\"recipeSection\":\"And for the rest of the week…\",\"ingredientsList\":[{\"item\":\"fresh ginger\",\"unit\":\"thumb\",\"comment\":\"sized chunk  peeled\",\"text\":\"1 thumb-sized chunk fresh ginger, peeled\"},{\"item\":\"garlic\",\"unit\":\"clove\",\"comment\":\"\",\"text\":\"½ garlic clove\"},{\"item\":\"tahini\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g tahini\"},{\"item\":\"lime\",\"unit\":\"\",\"comment\":\"Juice of\",\"text\":\"Juice of 1 lime\"},{\"item\":\"sriracha\",\"unit\":\"tbsp\",\"comment\":\"or your favourite style of chilli sauce\",\"text\":\"1 tbsp sriracha (or your favourite style of chilli sauce)\"},{\"item\":\"bird’s\",\"unit\":\"\",\"comment\":\"eye chilli stalked removed optional\",\"text\":\"1 bird’s-eye chilli, stalked removed (optional)\"},{\"item\":\"soy sauce\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp soy sauce\"},{\"item\":\"demerara sugar\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp demerara sugar\"},{\"item\":\"\",\"unit\":\"\",\"comment\":\"or honey\",\"text\":\"(or honey)\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"3 tbsp sesame oil\"},{\"item\":\"water\",\"unit\":\"ml\",\"comment\":\"\",\"text\":\"25ml water\"}]}],\"suitableForDietIds\":[],\"cuisineIds\":[],\"mealTypeIds\":[],\"celebrationsIds\":[\"summer-food-and-drink\"],\"utensilsAndApplianceIds\":[],\"techniquesUsedIds\":[],\"timings\":[],\"instructions\":[{\"stepNumber\":0,\"description\":\"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.\",\"images\":[]},{\"stepNumber\":1,\"description\":\"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).\",\"images\":[]},{\"stepNumber\":2,\"description\":\"Add the carrots, red cabbage and mooli or radishes to the bowl.\",\"images\":[]},{\"stepNumber\":3,\"description\":\"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.\",\"images\":[]},{\"stepNumber\":4,\"description\":\"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).\",\"images\":[]},{\"stepNumber\":5,\"description\":\"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.\",\"images\":[]},{\"stepNumber\":6,\"description\":\"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.\",\"images\":[]},{\"stepNumber\":7,\"description\":\"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.\",\"images\":[]},{\"stepNumber\":8,\"description\":\"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.\",\"images\":[]},{\"stepNumber\":9,\"description\":\"Toss the dressing through the salad and season to taste; it may need more lime juice.\",\"images\":[]},{\"stepNumber\":10,\"description\":\"Scatter the sesame seeds on top and serve.\",\"images\":[]},{\"stepNumber\":11,\"description\":\"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.\",\"images\":[]}]}"
-          }
-        },
-        {
-          type: ElementType.RECIPE,
-          assets: [],
-          recipeTypeData: {
-            recipeJson: "{\"id\":\"1\",\"canonicalArticle\":\"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers\",\"title\":\"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing\",\"featuredImage\":\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\",\"contributors\":[{\"type\":\"contributor\",\"tagId\":\"profile/thomasina-miers\"}],\"ingredients\":[{\"recipeSection\":\"For the dressing\",\"ingredientsList\":[{\"item\":\"soba\",\"unit\":\"g\",\"comment\":\"or glass noodles\",\"text\":\"200g soba or glass noodles\"},{\"item\":\"frozen soya beans\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g frozen soya beans\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp sesame oil\"},{\"item\":\"carrots\",\"unit\":\"\",\"comment\":\"peeled then grated or cut into thin ribbons\",\"text\":\"2 carrots, peeled, then grated or cut into thin ribbons\"},{\"item\":\"red cabbage\",\"unit\":\"g\",\"comment\":\"finely shredded\",\"text\":\"150g red cabbage, finely shredded\"},{\"item\":\"mooli\",\"unit\":\"g\",\"comment\":\"or radishes cut into matchsticks or thin slivers\",\"text\":\"100g mooli or radishes, cut into matchsticks or thin slivers\"},{\"item\":\"green apple\",\"unit\":\"\",\"comment\":\"\",\"text\":\"1 green apple\"},{\"item\":\"spring onions\",\"unit\":\"\",\"comment\":\"finely sliced\",\"text\":\"3 spring onions, finely sliced\"},{\"item\":\"coriander\",\"unit\":\"small bunch\",\"comment\":\"roughly chopped\",\"text\":\"1 small bunch coriander, roughly chopped\"},{\"item\":\"mint leaves\",\"unit\":\"handful\",\"comment\":\"roughly torn\",\"text\":\"1 handful mint leaves, roughly torn\"},{\"item\":\"basil leaves\",\"unit\":\"handful\",\"comment\":\"or more coriander roughly chopped\",\"text\":\"1 handful basil leaves (or more coriander), roughly chopped\"},{\"item\":\"toasted sunflower seeds\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"40g toasted sunflower seeds\"},{\"item\":\"toasted sesame seeds\",\"unit\":\"g\",\"comment\":\"a mixture of black and white looks good to serve\",\"text\":\"25g toasted sesame seeds (a mixture of black and white looks good), to serve\"}]},{\"recipeSection\":\"And for the rest of the week…\",\"ingredientsList\":[{\"item\":\"fresh ginger\",\"unit\":\"thumb\",\"comment\":\"sized chunk  peeled\",\"text\":\"1 thumb-sized chunk fresh ginger, peeled\"},{\"item\":\"garlic\",\"unit\":\"clove\",\"comment\":\"\",\"text\":\"½ garlic clove\"},{\"item\":\"tahini\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g tahini\"},{\"item\":\"lime\",\"unit\":\"\",\"comment\":\"Juice of\",\"text\":\"Juice of 1 lime\"},{\"item\":\"sriracha\",\"unit\":\"tbsp\",\"comment\":\"or your favourite style of chilli sauce\",\"text\":\"1 tbsp sriracha (or your favourite style of chilli sauce)\"},{\"item\":\"bird’s\",\"unit\":\"\",\"comment\":\"eye chilli stalked removed optional\",\"text\":\"1 bird’s-eye chilli, stalked removed (optional)\"},{\"item\":\"soy sauce\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp soy sauce\"},{\"item\":\"demerara sugar\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp demerara sugar\"},{\"item\":\"\",\"unit\":\"\",\"comment\":\"or honey\",\"text\":\"(or honey)\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"3 tbsp sesame oil\"},{\"item\":\"water\",\"unit\":\"ml\",\"comment\":\"\",\"text\":\"25ml water\"}]}],\"suitableForDietIds\":[],\"cuisineIds\":[],\"mealTypeIds\":[],\"celebrationsIds\":[\"summer-food-and-drink\"],\"utensilsAndApplianceIds\":[],\"techniquesUsedIds\":[],\"timings\":[],\"instructions\":[{\"stepNumber\":0,\"description\":\"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.\",\"images\":[]},{\"stepNumber\":1,\"description\":\"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).\",\"images\":[]},{\"stepNumber\":2,\"description\":\"Add the carrots, red cabbage and mooli or radishes to the bowl.\",\"images\":[]},{\"stepNumber\":3,\"description\":\"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.\",\"images\":[]},{\"stepNumber\":4,\"description\":\"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).\",\"images\":[]},{\"stepNumber\":5,\"description\":\"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.\",\"images\":[]},{\"stepNumber\":6,\"description\":\"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.\",\"images\":[]},{\"stepNumber\":7,\"description\":\"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.\",\"images\":[]},{\"stepNumber\":8,\"description\":\"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.\",\"images\":[]},{\"stepNumber\":9,\"description\":\"Toss the dressing through the salad and season to taste; it may need more lime juice.\",\"images\":[]},{\"stepNumber\":10,\"description\":\"Scatter the sesame seeds on top and serve.\",\"images\":[]},{\"stepNumber\":11,\"description\":\"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.\",\"images\":[]}]}"
-          }
-        },
-        {
-          type: ElementType.IMAGE,
-          assets: [
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 1000,
-                height: 600
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 500,
-                height: 300
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 5512,
-                height: 3308,
-                isMaster: true
-              }
-            }
-          ],
-          imageTypeData: {
-            caption: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            copyright: "LOUISE HAGGER",
-            displayCredit: true,
-            credit: "Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            source: "Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            alt: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            mediaId: "58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            mediaApiUri: "https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            suppliersReference: "Soba noodles with crisp rainbow vegetables and a spicy sesame se",
-            imageType: "Photograph"
-          }
-        }
-      ]
-    }
-    const result = extractRecipeData(canonicalId, block, [])
-    expect(result.length).toEqual(3)
-    expect(result[2]?.recipeUID).toEqual("62ac3f0f98f6495cbefd72c11fac6d1e26390e99")
-    const originalContent = block.elements[3].recipeTypeData?.recipeJson ? JSON.parse(block.elements[3].recipeTypeData.recipeJson) as Record<string, unknown> : {};
-    const expected = JSON.stringify({...originalContent, contributors: ["profile/thomasina-miers"], byline: []});
-    expect(result[2]?.jsonBlob).toEqual(expected);
-  })
+	it('should work when block containing no recipe elements ', () => {
+		const canonicalId =
+			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
+		const block: Block = {
+			id: '5a4b754ce4b0e33567c465c7',
+			bodyHtml:
+				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
+			bodyTextSummary: '',
+			attributes: {},
+			published: true,
+			contributors: [],
+			createdBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			lastModifiedBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			elements: [
+				{
+					type: ElementType.TEXT,
+					assets: [],
+					textTypeData: {
+						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+					},
+				},
+				{
+					type: ElementType.IMAGE,
+					assets: [
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 1000,
+								height: 600,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 500,
+								height: 300,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 5512,
+								height: 3308,
+								isMaster: true,
+							},
+						},
+					],
+					imageTypeData: {
+						caption:
+							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						copyright: 'LOUISE HAGGER',
+						displayCredit: true,
+						credit:
+							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						source:
+							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						mediaApiUri:
+							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						suppliersReference:
+							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+						imageType: 'Photograph',
+					},
+				},
+			],
+		};
+		const result = extractRecipeData(canonicalId, block, []);
+		expect(result.length).toEqual(0);
+	});
 
-  it("should work when block containing no recipe elements ", () => {
-    const canonicalId = "lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers"
-    const block: Block = {
-      id: "5a4b754ce4b0e33567c465c7",
-      bodyHtml: "<figure class=\"element element-image\" data-media-id=\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\"> <img src=\"https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg\" alt=\"Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.\" width=\"1000\" height=\"600\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class=\"element-image__credit\">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>",
-      bodyTextSummary: "",
-      attributes: {},
-      published: true,
-      contributors: [],
-      createdBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      lastModifiedBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      elements: [
-        {
-          type: ElementType.TEXT,
-          assets: [],
-          textTypeData: {
-            html: "<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>"
-          }
-        },
-        {
-          type: ElementType.IMAGE,
-          assets: [
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 1000,
-                height: 600
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 500,
-                height: 300
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 5512,
-                height: 3308,
-                isMaster: true
-              }
-            }
-          ],
-          imageTypeData: {
-            caption: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            copyright: "LOUISE HAGGER",
-            displayCredit: true,
-            credit: "Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            source: "Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            alt: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            mediaId: "58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            mediaApiUri: "https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            suppliersReference: "Soba noodles with crisp rainbow vegetables and a spicy sesame se",
-            imageType: "Photograph"
-          }
-        }
-      ]
-    }
-    const result = extractRecipeData(canonicalId, block, [])
-    expect(result.length).toEqual(0)
-  })
+	it('should return empty array when block has got invalid recipe element (no ID field) ', () => {
+		const canonicalId =
+			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
+		const block: Block = {
+			id: '5a4b754ce4b0e33567c465c7',
+			bodyHtml:
+				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
+			bodyTextSummary: '',
+			attributes: {},
+			published: true,
+			contributors: [],
+			createdBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			lastModifiedBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			elements: [
+				{
+					type: ElementType.TEXT,
+					assets: [],
+					textTypeData: {
+						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+					},
+				},
+				{
+					type: ElementType.RECIPE,
+					assets: [],
+					recipeTypeData: {
+						recipeJson:
+							'{"canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[],"byline":"Thomasina Miers","ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+					},
+				},
+				{
+					type: ElementType.IMAGE,
+					assets: [
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 1000,
+								height: 600,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 500,
+								height: 300,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 5512,
+								height: 3308,
+								isMaster: true,
+							},
+						},
+					],
+					imageTypeData: {
+						caption:
+							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						copyright: 'LOUISE HAGGER',
+						displayCredit: true,
+						credit:
+							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						source:
+							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						mediaApiUri:
+							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						suppliersReference:
+							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+						imageType: 'Photograph',
+					},
+				},
+			],
+		};
+		const recipesFound = extractRecipeData(canonicalId, block, []);
+		expect(recipesFound).toEqual([null]);
+		expect(recipesFound.length).toEqual(1);
+	});
 
+	it('should work when block containing recipe element and is sponsored, means we have sponsorship data as well', () => {
+		const canonicalId =
+			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
+		const block: Block = {
+			id: '5a4b754ce4b0e33567c465c7',
+			bodyHtml:
+				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
+			bodyTextSummary: '',
+			attributes: {},
+			published: true,
+			contributors: [],
+			createdBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			lastModifiedBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			elements: [
+				{
+					type: ElementType.TEXT,
+					assets: [],
+					textTypeData: {
+						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+					},
+				},
+				{
+					type: ElementType.RECIPE,
+					assets: [],
+					recipeTypeData: {
+						recipeJson:
+							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+					},
+				},
+				{
+					type: ElementType.IMAGE,
+					assets: [
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 1000,
+								height: 600,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 500,
+								height: 300,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 5512,
+								height: 3308,
+								isMaster: true,
+							},
+						},
+					],
+					imageTypeData: {
+						caption:
+							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						copyright: 'LOUISE HAGGER',
+						displayCredit: true,
+						credit:
+							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						source:
+							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						mediaApiUri:
+							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						suppliersReference:
+							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+						imageType: 'Photograph',
+					},
+				},
+			],
+		};
+		const activeSponsorships: Sponsorship[] = [
+			{
+				sponsorshipType: SponsorshipType.SPONSORED,
+				sponsorName: 'theguardian.org',
+				sponsorLogo:
+					'https://static.theguardian.com/commercial/sponsor/22/Feb/2024/f459c58b-6553-486d-939a-5f23fd935f78-Guardian.orglogos-for badge.png',
+				sponsorLink: 'https://theguardian.org/',
+				aboutLink:
+					'https://www.theguardian.com/global-development/2010/sep/14/about-this-site',
+				sponsorLogoDimensions: {
+					width: 280,
+					height: 180,
+				},
+				highContrastSponsorLogo:
+					'https://static.theguardian.com/commercial/sponsor/22/Feb/2024/3d8e52dc-1d0b-4f95-8cd1-48a674e1309d-guardian.org new logo - white version (3).png',
+				highContrastSponsorLogoDimensions: {
+					width: 280,
+					height: 180,
+				},
+				validFrom: makeCapiDateTime('2023-09-21T16:18:10Z'),
+				validTo: makeCapiDateTime('2026-08-30T23:00:00Z'),
+			},
+		];
+		const result = extractRecipeData(canonicalId, block, activeSponsorships);
+		expect(result.length).toEqual(1);
+		expect(result[0]?.recipeUID).toEqual(
+			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
+		);
+		const data = JSON.parse(result[0]?.jsonBlob as string) as JSON;
+		const sponsorsExists = 'sponsors' in data;
+		expect(sponsorsExists).toBe(true);
+		expect(data).toHaveProperty('sponsors[0].sponsorshipType', 'Sponsored');
+		expect(data).toHaveProperty(
+			'sponsors[0].sponsorLink',
+			'https://theguardian.org/',
+		);
+		expect(data).not.toHaveProperty('sponsors[0].targeting');
+		expect(result[0]?.sponsorshipCount).toEqual(1);
+	});
 
-  it("should return empty array when block has got invalid recipe element (no ID field) ", () => {
-    const canonicalId = "lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers"
-    const block: Block = {
-      id: "5a4b754ce4b0e33567c465c7",
-      bodyHtml: "<figure class=\"element element-image\" data-media-id=\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\"> <img src=\"https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg\" alt=\"Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.\" width=\"1000\" height=\"600\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class=\"element-image__credit\">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>",
-      bodyTextSummary: "",
-      attributes: {},
-      published: true,
-      contributors: [],
-      createdBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      lastModifiedBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      elements: [
-        {
-          type: ElementType.TEXT,
-          assets: [],
-          textTypeData: {
-            html: "<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>"
-          }
-        },
-        {
-          type: ElementType.RECIPE,
-          assets: [],
-          recipeTypeData: {
-            recipeJson: "{\"canonicalArticle\":\"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers\",\"title\":\"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing\",\"featuredImage\":\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\",\"contributors\":[],\"byline\":\"Thomasina Miers\",\"ingredients\":[{\"recipeSection\":\"For the dressing\",\"ingredientsList\":[{\"item\":\"soba\",\"unit\":\"g\",\"comment\":\"or glass noodles\",\"text\":\"200g soba or glass noodles\"},{\"item\":\"frozen soya beans\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g frozen soya beans\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp sesame oil\"},{\"item\":\"carrots\",\"unit\":\"\",\"comment\":\"peeled then grated or cut into thin ribbons\",\"text\":\"2 carrots, peeled, then grated or cut into thin ribbons\"},{\"item\":\"red cabbage\",\"unit\":\"g\",\"comment\":\"finely shredded\",\"text\":\"150g red cabbage, finely shredded\"},{\"item\":\"mooli\",\"unit\":\"g\",\"comment\":\"or radishes cut into matchsticks or thin slivers\",\"text\":\"100g mooli or radishes, cut into matchsticks or thin slivers\"},{\"item\":\"green apple\",\"unit\":\"\",\"comment\":\"\",\"text\":\"1 green apple\"},{\"item\":\"spring onions\",\"unit\":\"\",\"comment\":\"finely sliced\",\"text\":\"3 spring onions, finely sliced\"},{\"item\":\"coriander\",\"unit\":\"small bunch\",\"comment\":\"roughly chopped\",\"text\":\"1 small bunch coriander, roughly chopped\"},{\"item\":\"mint leaves\",\"unit\":\"handful\",\"comment\":\"roughly torn\",\"text\":\"1 handful mint leaves, roughly torn\"},{\"item\":\"basil leaves\",\"unit\":\"handful\",\"comment\":\"or more coriander roughly chopped\",\"text\":\"1 handful basil leaves (or more coriander), roughly chopped\"},{\"item\":\"toasted sunflower seeds\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"40g toasted sunflower seeds\"},{\"item\":\"toasted sesame seeds\",\"unit\":\"g\",\"comment\":\"a mixture of black and white looks good to serve\",\"text\":\"25g toasted sesame seeds (a mixture of black and white looks good), to serve\"}]},{\"recipeSection\":\"And for the rest of the week…\",\"ingredientsList\":[{\"item\":\"fresh ginger\",\"unit\":\"thumb\",\"comment\":\"sized chunk  peeled\",\"text\":\"1 thumb-sized chunk fresh ginger, peeled\"},{\"item\":\"garlic\",\"unit\":\"clove\",\"comment\":\"\",\"text\":\"½ garlic clove\"},{\"item\":\"tahini\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g tahini\"},{\"item\":\"lime\",\"unit\":\"\",\"comment\":\"Juice of\",\"text\":\"Juice of 1 lime\"},{\"item\":\"sriracha\",\"unit\":\"tbsp\",\"comment\":\"or your favourite style of chilli sauce\",\"text\":\"1 tbsp sriracha (or your favourite style of chilli sauce)\"},{\"item\":\"bird’s\",\"unit\":\"\",\"comment\":\"eye chilli stalked removed optional\",\"text\":\"1 bird’s-eye chilli, stalked removed (optional)\"},{\"item\":\"soy sauce\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp soy sauce\"},{\"item\":\"demerara sugar\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp demerara sugar\"},{\"item\":\"\",\"unit\":\"\",\"comment\":\"or honey\",\"text\":\"(or honey)\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"3 tbsp sesame oil\"},{\"item\":\"water\",\"unit\":\"ml\",\"comment\":\"\",\"text\":\"25ml water\"}]}],\"suitableForDietIds\":[],\"cuisineIds\":[],\"mealTypeIds\":[],\"celebrationsIds\":[\"summer-food-and-drink\"],\"utensilsAndApplianceIds\":[],\"techniquesUsedIds\":[],\"timings\":[],\"instructions\":[{\"stepNumber\":0,\"description\":\"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.\",\"images\":[]},{\"stepNumber\":1,\"description\":\"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).\",\"images\":[]},{\"stepNumber\":2,\"description\":\"Add the carrots, red cabbage and mooli or radishes to the bowl.\",\"images\":[]},{\"stepNumber\":3,\"description\":\"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.\",\"images\":[]},{\"stepNumber\":4,\"description\":\"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).\",\"images\":[]},{\"stepNumber\":5,\"description\":\"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.\",\"images\":[]},{\"stepNumber\":6,\"description\":\"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.\",\"images\":[]},{\"stepNumber\":7,\"description\":\"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.\",\"images\":[]},{\"stepNumber\":8,\"description\":\"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.\",\"images\":[]},{\"stepNumber\":9,\"description\":\"Toss the dressing through the salad and season to taste; it may need more lime juice.\",\"images\":[]},{\"stepNumber\":10,\"description\":\"Scatter the sesame seeds on top and serve.\",\"images\":[]},{\"stepNumber\":11,\"description\":\"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.\",\"images\":[]}]}"
-          }
-        },
-        {
-          type: ElementType.IMAGE,
-          assets: [
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 1000,
-                height: 600
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 500,
-                height: 300
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 5512,
-                height: 3308,
-                isMaster: true
-              }
-            }
-          ],
-          imageTypeData: {
-            caption: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            copyright: "LOUISE HAGGER",
-            displayCredit: true,
-            credit: "Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            source: "Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            alt: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            mediaId: "58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            mediaApiUri: "https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            suppliersReference: "Soba noodles with crisp rainbow vegetables and a spicy sesame se",
-            imageType: "Photograph"
-          }
-        }
-      ]
-    }
-    const recipesFound = extractRecipeData(canonicalId, block, [])
-    expect(recipesFound).toEqual([null])
-    expect(recipesFound.length).toEqual(1)
-  })
+	it('should work when block containing recipe element but not sponsored, means no sponsor data available', () => {
+		const canonicalId =
+			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
+		const block: Block = {
+			id: '5a4b754ce4b0e33567c465c7',
+			bodyHtml:
+				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
+			bodyTextSummary: '',
+			attributes: {},
+			published: true,
+			contributors: [],
+			createdBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			lastModifiedBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			elements: [
+				{
+					type: ElementType.TEXT,
+					assets: [],
+					textTypeData: {
+						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+					},
+				},
+				{
+					type: ElementType.RECIPE,
+					assets: [],
+					recipeTypeData: {
+						recipeJson:
+							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+					},
+				},
+				{
+					type: ElementType.IMAGE,
+					assets: [
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 1000,
+								height: 600,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 500,
+								height: 300,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 5512,
+								height: 3308,
+								isMaster: true,
+							},
+						},
+					],
+					imageTypeData: {
+						caption:
+							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						copyright: 'LOUISE HAGGER',
+						displayCredit: true,
+						credit:
+							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						source:
+							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						mediaApiUri:
+							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						suppliersReference:
+							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+						imageType: 'Photograph',
+					},
+				},
+			],
+		};
+		const activeSponsorships: Sponsorship[] = [];
+		const result = extractRecipeData(canonicalId, block, activeSponsorships);
+		expect(result.length).toEqual(1);
+		expect(result[0]?.recipeUID).toEqual(
+			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
+		);
+		const data = JSON.parse(result[0]?.jsonBlob as string) as JSON;
+		const sponsorsExists = 'sponsors' in data;
+		expect(sponsorsExists).toBe(false);
+		expect(data).not.toHaveProperty('sponsors[0].sponsorshipType');
+		expect(data).not.toHaveProperty('sponsors[0].sponsorLink');
+		expect(result[0]?.sponsorshipCount).toEqual(0);
+	});
 
-  it("should work when block containing recipe element and is sponsored, means we have sponsorship data as well", () => {
-    const canonicalId = "lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers"
-    const block: Block = {
-      id: "5a4b754ce4b0e33567c465c7",
-      bodyHtml: "<figure class=\"element element-image\" data-media-id=\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\"> <img src=\"https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg\" alt=\"Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.\" width=\"1000\" height=\"600\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class=\"element-image__credit\">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>",
-      bodyTextSummary: "",
-      attributes: {},
-      published: true,
-      contributors: [],
-      createdBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      lastModifiedBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      elements: [
-        {
-          type: ElementType.TEXT,
-          assets: [],
-          textTypeData: {
-            html: "<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>"
-          }
-        },
-        {
-          type: ElementType.RECIPE,
-          assets: [],
-          recipeTypeData: {
-            recipeJson: "{\"id\":\"1\",\"canonicalArticle\":\"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers\",\"title\":\"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing\",\"featuredImage\":\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\",\"contributors\":[{\"type\":\"contributor\",\"tagId\":\"profile/thomasina-miers\"}],\"ingredients\":[{\"recipeSection\":\"For the dressing\",\"ingredientsList\":[{\"item\":\"soba\",\"unit\":\"g\",\"comment\":\"or glass noodles\",\"text\":\"200g soba or glass noodles\"},{\"item\":\"frozen soya beans\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g frozen soya beans\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp sesame oil\"},{\"item\":\"carrots\",\"unit\":\"\",\"comment\":\"peeled then grated or cut into thin ribbons\",\"text\":\"2 carrots, peeled, then grated or cut into thin ribbons\"},{\"item\":\"red cabbage\",\"unit\":\"g\",\"comment\":\"finely shredded\",\"text\":\"150g red cabbage, finely shredded\"},{\"item\":\"mooli\",\"unit\":\"g\",\"comment\":\"or radishes cut into matchsticks or thin slivers\",\"text\":\"100g mooli or radishes, cut into matchsticks or thin slivers\"},{\"item\":\"green apple\",\"unit\":\"\",\"comment\":\"\",\"text\":\"1 green apple\"},{\"item\":\"spring onions\",\"unit\":\"\",\"comment\":\"finely sliced\",\"text\":\"3 spring onions, finely sliced\"},{\"item\":\"coriander\",\"unit\":\"small bunch\",\"comment\":\"roughly chopped\",\"text\":\"1 small bunch coriander, roughly chopped\"},{\"item\":\"mint leaves\",\"unit\":\"handful\",\"comment\":\"roughly torn\",\"text\":\"1 handful mint leaves, roughly torn\"},{\"item\":\"basil leaves\",\"unit\":\"handful\",\"comment\":\"or more coriander roughly chopped\",\"text\":\"1 handful basil leaves (or more coriander), roughly chopped\"},{\"item\":\"toasted sunflower seeds\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"40g toasted sunflower seeds\"},{\"item\":\"toasted sesame seeds\",\"unit\":\"g\",\"comment\":\"a mixture of black and white looks good to serve\",\"text\":\"25g toasted sesame seeds (a mixture of black and white looks good), to serve\"}]},{\"recipeSection\":\"And for the rest of the week…\",\"ingredientsList\":[{\"item\":\"fresh ginger\",\"unit\":\"thumb\",\"comment\":\"sized chunk  peeled\",\"text\":\"1 thumb-sized chunk fresh ginger, peeled\"},{\"item\":\"garlic\",\"unit\":\"clove\",\"comment\":\"\",\"text\":\"½ garlic clove\"},{\"item\":\"tahini\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g tahini\"},{\"item\":\"lime\",\"unit\":\"\",\"comment\":\"Juice of\",\"text\":\"Juice of 1 lime\"},{\"item\":\"sriracha\",\"unit\":\"tbsp\",\"comment\":\"or your favourite style of chilli sauce\",\"text\":\"1 tbsp sriracha (or your favourite style of chilli sauce)\"},{\"item\":\"bird’s\",\"unit\":\"\",\"comment\":\"eye chilli stalked removed optional\",\"text\":\"1 bird’s-eye chilli, stalked removed (optional)\"},{\"item\":\"soy sauce\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp soy sauce\"},{\"item\":\"demerara sugar\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp demerara sugar\"},{\"item\":\"\",\"unit\":\"\",\"comment\":\"or honey\",\"text\":\"(or honey)\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"3 tbsp sesame oil\"},{\"item\":\"water\",\"unit\":\"ml\",\"comment\":\"\",\"text\":\"25ml water\"}]}],\"suitableForDietIds\":[],\"cuisineIds\":[],\"mealTypeIds\":[],\"celebrationsIds\":[\"summer-food-and-drink\"],\"utensilsAndApplianceIds\":[],\"techniquesUsedIds\":[],\"timings\":[],\"instructions\":[{\"stepNumber\":0,\"description\":\"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.\",\"images\":[]},{\"stepNumber\":1,\"description\":\"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).\",\"images\":[]},{\"stepNumber\":2,\"description\":\"Add the carrots, red cabbage and mooli or radishes to the bowl.\",\"images\":[]},{\"stepNumber\":3,\"description\":\"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.\",\"images\":[]},{\"stepNumber\":4,\"description\":\"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).\",\"images\":[]},{\"stepNumber\":5,\"description\":\"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.\",\"images\":[]},{\"stepNumber\":6,\"description\":\"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.\",\"images\":[]},{\"stepNumber\":7,\"description\":\"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.\",\"images\":[]},{\"stepNumber\":8,\"description\":\"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.\",\"images\":[]},{\"stepNumber\":9,\"description\":\"Toss the dressing through the salad and season to taste; it may need more lime juice.\",\"images\":[]},{\"stepNumber\":10,\"description\":\"Scatter the sesame seeds on top and serve.\",\"images\":[]},{\"stepNumber\":11,\"description\":\"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.\",\"images\":[]}]}"
-          }
-        },
-        {
-          type: ElementType.IMAGE,
-          assets: [
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 1000,
-                height: 600
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 500,
-                height: 300
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 5512,
-                height: 3308,
-                isMaster: true
-              }
-            }
-          ],
-          imageTypeData: {
-            caption: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            copyright: "LOUISE HAGGER",
-            displayCredit: true,
-            credit: "Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            source: "Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            alt: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            mediaId: "58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            mediaApiUri: "https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            suppliersReference: "Soba noodles with crisp rainbow vegetables and a spicy sesame se",
-            imageType: "Photograph"
-          }
-        }
-      ]
-    }
-    const activeSponsorships: Sponsorship[] = [
-      {
-        sponsorshipType: SponsorshipType.SPONSORED,
-        sponsorName: "theguardian.org",
-        sponsorLogo: "https://static.theguardian.com/commercial/sponsor/22/Feb/2024/f459c58b-6553-486d-939a-5f23fd935f78-Guardian.orglogos-for badge.png",
-        sponsorLink: "https://theguardian.org/",
-        aboutLink: "https://www.theguardian.com/global-development/2010/sep/14/about-this-site",
-        sponsorLogoDimensions: {
-          width: 280,
-          height: 180
-        },
-        highContrastSponsorLogo: "https://static.theguardian.com/commercial/sponsor/22/Feb/2024/3d8e52dc-1d0b-4f95-8cd1-48a674e1309d-guardian.org new logo - white version (3).png",
-        highContrastSponsorLogoDimensions: {
-          width: 280,
-          height: 180
-        },
-        validFrom: makeCapiDateTime("2023-09-21T16:18:10Z"),
-        validTo: makeCapiDateTime("2026-08-30T23:00:00Z"),
-      }
-    ]
-    const result = extractRecipeData(canonicalId, block, activeSponsorships)
-    expect(result.length).toEqual(1)
-    expect(result[0]?.recipeUID).toEqual("62ac3f0f98f6495cbefd72c11fac6d1e26390e99")
-    const data = JSON.parse(result[0]?.jsonBlob as string) as JSON
-    const sponsorsExists = "sponsors" in data
-    expect(sponsorsExists).toBe(true)
-    expect(data).toHaveProperty("sponsors[0].sponsorshipType", "Sponsored")
-    expect(data).toHaveProperty("sponsors[0].sponsorLink", "https://theguardian.org/")
-    expect(data).not.toHaveProperty("sponsors[0].targeting")
-    expect(result[0]?.sponsorshipCount).toEqual(1)
-  })
+	it('should update the canonicalArticle with the content ID', () => {
+		const canonicalId = 'a-new-path';
+		const block: Block = {
+			id: '5a4b754ce4b0e33567c465c7',
+			bodyHtml:
+				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
+			bodyTextSummary: '',
+			attributes: {},
+			published: true,
+			contributors: [],
+			createdBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			lastModifiedBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			elements: [
+				{
+					type: ElementType.TEXT,
+					assets: [],
+					textTypeData: {
+						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+					},
+				},
+				{
+					type: ElementType.RECIPE,
+					assets: [],
+					recipeTypeData: {
+						recipeJson:
+							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+					},
+				},
+				{
+					type: ElementType.IMAGE,
+					assets: [
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 1000,
+								height: 600,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 500,
+								height: 300,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 5512,
+								height: 3308,
+								isMaster: true,
+							},
+						},
+					],
+					imageTypeData: {
+						caption:
+							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						copyright: 'LOUISE HAGGER',
+						displayCredit: true,
+						credit:
+							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						source:
+							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						mediaApiUri:
+							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						suppliersReference:
+							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+						imageType: 'Photograph',
+					},
+				},
+			],
+		};
+		const result = extractRecipeData(canonicalId, block, []);
+		expect(result.length).toEqual(1);
+		const data = JSON.parse(
+			result[0]?.jsonBlob as string,
+		) as RecipeWithImageData;
+		expect(data.canonicalArticle).toBe(canonicalId);
+	});
 
-  it("should work when block containing recipe element but not sponsored, means no sponsor data available", () => {
-    const canonicalId = "lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers"
-    const block: Block = {
-      id: "5a4b754ce4b0e33567c465c7",
-      bodyHtml: "<figure class=\"element element-image\" data-media-id=\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\"> <img src=\"https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg\" alt=\"Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.\" width=\"1000\" height=\"600\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class=\"element-image__credit\">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>",
-      bodyTextSummary: "",
-      attributes: {},
-      published: true,
-      contributors: [],
-      createdBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      lastModifiedBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      elements: [
-        {
-          type: ElementType.TEXT,
-          assets: [],
-          textTypeData: {
-            html: "<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>"
-          }
-        },
-        {
-          type: ElementType.RECIPE,
-          assets: [],
-          recipeTypeData: {
-            recipeJson: "{\"id\":\"1\",\"canonicalArticle\":\"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers\",\"title\":\"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing\",\"featuredImage\":\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\",\"contributors\":[{\"type\":\"contributor\",\"tagId\":\"profile/thomasina-miers\"}],\"ingredients\":[{\"recipeSection\":\"For the dressing\",\"ingredientsList\":[{\"item\":\"soba\",\"unit\":\"g\",\"comment\":\"or glass noodles\",\"text\":\"200g soba or glass noodles\"},{\"item\":\"frozen soya beans\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g frozen soya beans\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp sesame oil\"},{\"item\":\"carrots\",\"unit\":\"\",\"comment\":\"peeled then grated or cut into thin ribbons\",\"text\":\"2 carrots, peeled, then grated or cut into thin ribbons\"},{\"item\":\"red cabbage\",\"unit\":\"g\",\"comment\":\"finely shredded\",\"text\":\"150g red cabbage, finely shredded\"},{\"item\":\"mooli\",\"unit\":\"g\",\"comment\":\"or radishes cut into matchsticks or thin slivers\",\"text\":\"100g mooli or radishes, cut into matchsticks or thin slivers\"},{\"item\":\"green apple\",\"unit\":\"\",\"comment\":\"\",\"text\":\"1 green apple\"},{\"item\":\"spring onions\",\"unit\":\"\",\"comment\":\"finely sliced\",\"text\":\"3 spring onions, finely sliced\"},{\"item\":\"coriander\",\"unit\":\"small bunch\",\"comment\":\"roughly chopped\",\"text\":\"1 small bunch coriander, roughly chopped\"},{\"item\":\"mint leaves\",\"unit\":\"handful\",\"comment\":\"roughly torn\",\"text\":\"1 handful mint leaves, roughly torn\"},{\"item\":\"basil leaves\",\"unit\":\"handful\",\"comment\":\"or more coriander roughly chopped\",\"text\":\"1 handful basil leaves (or more coriander), roughly chopped\"},{\"item\":\"toasted sunflower seeds\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"40g toasted sunflower seeds\"},{\"item\":\"toasted sesame seeds\",\"unit\":\"g\",\"comment\":\"a mixture of black and white looks good to serve\",\"text\":\"25g toasted sesame seeds (a mixture of black and white looks good), to serve\"}]},{\"recipeSection\":\"And for the rest of the week…\",\"ingredientsList\":[{\"item\":\"fresh ginger\",\"unit\":\"thumb\",\"comment\":\"sized chunk  peeled\",\"text\":\"1 thumb-sized chunk fresh ginger, peeled\"},{\"item\":\"garlic\",\"unit\":\"clove\",\"comment\":\"\",\"text\":\"½ garlic clove\"},{\"item\":\"tahini\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g tahini\"},{\"item\":\"lime\",\"unit\":\"\",\"comment\":\"Juice of\",\"text\":\"Juice of 1 lime\"},{\"item\":\"sriracha\",\"unit\":\"tbsp\",\"comment\":\"or your favourite style of chilli sauce\",\"text\":\"1 tbsp sriracha (or your favourite style of chilli sauce)\"},{\"item\":\"bird’s\",\"unit\":\"\",\"comment\":\"eye chilli stalked removed optional\",\"text\":\"1 bird’s-eye chilli, stalked removed (optional)\"},{\"item\":\"soy sauce\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp soy sauce\"},{\"item\":\"demerara sugar\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp demerara sugar\"},{\"item\":\"\",\"unit\":\"\",\"comment\":\"or honey\",\"text\":\"(or honey)\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"3 tbsp sesame oil\"},{\"item\":\"water\",\"unit\":\"ml\",\"comment\":\"\",\"text\":\"25ml water\"}]}],\"suitableForDietIds\":[],\"cuisineIds\":[],\"mealTypeIds\":[],\"celebrationsIds\":[\"summer-food-and-drink\"],\"utensilsAndApplianceIds\":[],\"techniquesUsedIds\":[],\"timings\":[],\"instructions\":[{\"stepNumber\":0,\"description\":\"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.\",\"images\":[]},{\"stepNumber\":1,\"description\":\"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).\",\"images\":[]},{\"stepNumber\":2,\"description\":\"Add the carrots, red cabbage and mooli or radishes to the bowl.\",\"images\":[]},{\"stepNumber\":3,\"description\":\"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.\",\"images\":[]},{\"stepNumber\":4,\"description\":\"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).\",\"images\":[]},{\"stepNumber\":5,\"description\":\"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.\",\"images\":[]},{\"stepNumber\":6,\"description\":\"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.\",\"images\":[]},{\"stepNumber\":7,\"description\":\"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.\",\"images\":[]},{\"stepNumber\":8,\"description\":\"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.\",\"images\":[]},{\"stepNumber\":9,\"description\":\"Toss the dressing through the salad and season to taste; it may need more lime juice.\",\"images\":[]},{\"stepNumber\":10,\"description\":\"Scatter the sesame seeds on top and serve.\",\"images\":[]},{\"stepNumber\":11,\"description\":\"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.\",\"images\":[]}]}"
-          }
-        },
-        {
-          type: ElementType.IMAGE,
-          assets: [
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 1000,
-                height: 600
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 500,
-                height: 300
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 5512,
-                height: 3308,
-                isMaster: true
-              }
-            }
-          ],
-          imageTypeData: {
-            caption: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            copyright: "LOUISE HAGGER",
-            displayCredit: true,
-            credit: "Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            source: "Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            alt: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            mediaId: "58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            mediaApiUri: "https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            suppliersReference: "Soba noodles with crisp rainbow vegetables and a spicy sesame se",
-            imageType: "Photograph"
-          }
-        }
-      ]
-    }
-    const activeSponsorships: Sponsorship[] = []
-    const result = extractRecipeData(canonicalId, block, activeSponsorships)
-    expect(result.length).toEqual(1)
-    expect(result[0]?.recipeUID).toEqual("62ac3f0f98f6495cbefd72c11fac6d1e26390e99")
-    const data = JSON.parse(result[0]?.jsonBlob as string) as JSON
-    const sponsorsExists = "sponsors" in data
-    expect(sponsorsExists).toBe(false)
-    expect(data).not.toHaveProperty("sponsors[0].sponsorshipType")
-    expect(data).not.toHaveProperty("sponsors[0].sponsorLink")
-    expect(result[0]?.sponsorshipCount).toEqual(0)
-  })
+	it('should add recipe dates where specified', () => {
+		const canonicalId =
+			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
+		const recipeDates = {
+			lastModifiedDate: {
+				dateTime: new Int64(new Date('2024-09-10T16:18:10Z').getTime()),
+				iso8601: '2024-09-10T16:18:10Z',
+			},
+			firstPublishedDate: {
+				dateTime: new Int64(new Date('2024-09-02T10:04:16Z').getTime()),
+				iso8601: '2024-09-02T10:04:16Z',
+			},
+			publishedDate: {
+				dateTime: new Int64(new Date('2024-09-10T16:22:07Z').getTime()),
+				iso8601: '2023-09-10T16:22:07Z',
+			},
+		};
+		const block: Block = {
+			id: '5a4b754ce4b0e33567c465c7',
+			bodyHtml:
+				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
+			bodyTextSummary: '',
+			attributes: {},
+			published: true,
+			contributors: [],
+			createdBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			lastModifiedBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			elements: [
+				{
+					type: ElementType.TEXT,
+					assets: [],
+					textTypeData: {
+						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+					},
+				},
+				{
+					type: ElementType.RECIPE,
+					assets: [],
+					recipeTypeData: {
+						recipeJson:
+							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+					},
+				},
+				{
+					type: ElementType.IMAGE,
+					assets: [
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 1000,
+								height: 600,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 500,
+								height: 300,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 5512,
+								height: 3308,
+								isMaster: true,
+							},
+						},
+					],
+					imageTypeData: {
+						caption:
+							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						copyright: 'LOUISE HAGGER',
+						displayCredit: true,
+						credit:
+							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						source:
+							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						mediaApiUri:
+							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						suppliersReference:
+							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+						imageType: 'Photograph',
+					},
+				},
+			],
+			...recipeDates,
+		};
+		const result = extractRecipeData(canonicalId, block, []);
+		expect(result.length).toEqual(1);
+		expect(result[0]?.recipeUID).toEqual(
+			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
+		);
+		const originalContent = block.elements[1].recipeTypeData?.recipeJson
+			? (JSON.parse(block.elements[1].recipeTypeData.recipeJson) as Record<
+					string,
+					unknown
+			  >)
+			: {};
+		const expected = JSON.stringify({
+			...originalContent,
+			contributors: ['profile/thomasina-miers'],
+			byline: [],
+			lastModifiedDate: capiDateTimeToDate(recipeDates.lastModifiedDate),
+      firstPublishedDate: capiDateTimeToDate(recipeDates.firstPublishedDate),
+      publishedDate: capiDateTimeToDate(recipeDates.publishedDate),
+		});
+		expect(result[0]?.jsonBlob).toEqual(expected);
+	});
 
-
-  it("should update the canonicalArticle with the content ID", () => {
-    const canonicalId = "a-new-path"
-    const block: Block = {
-      id: "5a4b754ce4b0e33567c465c7",
-      bodyHtml: "<figure class=\"element element-image\" data-media-id=\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\"> <img src=\"https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg\" alt=\"Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.\" width=\"1000\" height=\"600\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class=\"element-image__credit\">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>",
-      bodyTextSummary: "",
-      attributes: {},
-      published: true,
-      contributors: [],
-      createdBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      lastModifiedBy: {
-        email: "stephanie.fincham@guardian.co.uk",
-        firstName: "Stephanie",
-        lastName: "Fincham"
-      },
-      elements: [
-        {
-          type: ElementType.TEXT,
-          assets: [],
-          textTypeData: {
-            html: "<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>"
-          }
-        },
-        {
-          type: ElementType.RECIPE,
-          assets: [],
-          recipeTypeData: {
-            recipeJson: "{\"id\":\"1\",\"canonicalArticle\":\"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers\",\"title\":\"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing\",\"featuredImage\":\"58c32a98ae4463b5129bf717b1b2312d8ffc0d45\",\"contributors\":[{\"type\":\"contributor\",\"tagId\":\"profile/thomasina-miers\"}],\"ingredients\":[{\"recipeSection\":\"For the dressing\",\"ingredientsList\":[{\"item\":\"soba\",\"unit\":\"g\",\"comment\":\"or glass noodles\",\"text\":\"200g soba or glass noodles\"},{\"item\":\"frozen soya beans\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g frozen soya beans\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp sesame oil\"},{\"item\":\"carrots\",\"unit\":\"\",\"comment\":\"peeled then grated or cut into thin ribbons\",\"text\":\"2 carrots, peeled, then grated or cut into thin ribbons\"},{\"item\":\"red cabbage\",\"unit\":\"g\",\"comment\":\"finely shredded\",\"text\":\"150g red cabbage, finely shredded\"},{\"item\":\"mooli\",\"unit\":\"g\",\"comment\":\"or radishes cut into matchsticks or thin slivers\",\"text\":\"100g mooli or radishes, cut into matchsticks or thin slivers\"},{\"item\":\"green apple\",\"unit\":\"\",\"comment\":\"\",\"text\":\"1 green apple\"},{\"item\":\"spring onions\",\"unit\":\"\",\"comment\":\"finely sliced\",\"text\":\"3 spring onions, finely sliced\"},{\"item\":\"coriander\",\"unit\":\"small bunch\",\"comment\":\"roughly chopped\",\"text\":\"1 small bunch coriander, roughly chopped\"},{\"item\":\"mint leaves\",\"unit\":\"handful\",\"comment\":\"roughly torn\",\"text\":\"1 handful mint leaves, roughly torn\"},{\"item\":\"basil leaves\",\"unit\":\"handful\",\"comment\":\"or more coriander roughly chopped\",\"text\":\"1 handful basil leaves (or more coriander), roughly chopped\"},{\"item\":\"toasted sunflower seeds\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"40g toasted sunflower seeds\"},{\"item\":\"toasted sesame seeds\",\"unit\":\"g\",\"comment\":\"a mixture of black and white looks good to serve\",\"text\":\"25g toasted sesame seeds (a mixture of black and white looks good), to serve\"}]},{\"recipeSection\":\"And for the rest of the week…\",\"ingredientsList\":[{\"item\":\"fresh ginger\",\"unit\":\"thumb\",\"comment\":\"sized chunk  peeled\",\"text\":\"1 thumb-sized chunk fresh ginger, peeled\"},{\"item\":\"garlic\",\"unit\":\"clove\",\"comment\":\"\",\"text\":\"½ garlic clove\"},{\"item\":\"tahini\",\"unit\":\"g\",\"comment\":\"\",\"text\":\"50g tahini\"},{\"item\":\"lime\",\"unit\":\"\",\"comment\":\"Juice of\",\"text\":\"Juice of 1 lime\"},{\"item\":\"sriracha\",\"unit\":\"tbsp\",\"comment\":\"or your favourite style of chilli sauce\",\"text\":\"1 tbsp sriracha (or your favourite style of chilli sauce)\"},{\"item\":\"bird’s\",\"unit\":\"\",\"comment\":\"eye chilli stalked removed optional\",\"text\":\"1 bird’s-eye chilli, stalked removed (optional)\"},{\"item\":\"soy sauce\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp soy sauce\"},{\"item\":\"demerara sugar\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"1 tbsp demerara sugar\"},{\"item\":\"\",\"unit\":\"\",\"comment\":\"or honey\",\"text\":\"(or honey)\"},{\"item\":\"sesame oil\",\"unit\":\"tbsp\",\"comment\":\"\",\"text\":\"3 tbsp sesame oil\"},{\"item\":\"water\",\"unit\":\"ml\",\"comment\":\"\",\"text\":\"25ml water\"}]}],\"suitableForDietIds\":[],\"cuisineIds\":[],\"mealTypeIds\":[],\"celebrationsIds\":[\"summer-food-and-drink\"],\"utensilsAndApplianceIds\":[],\"techniquesUsedIds\":[],\"timings\":[],\"instructions\":[{\"stepNumber\":0,\"description\":\"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.\",\"images\":[]},{\"stepNumber\":1,\"description\":\"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).\",\"images\":[]},{\"stepNumber\":2,\"description\":\"Add the carrots, red cabbage and mooli or radishes to the bowl.\",\"images\":[]},{\"stepNumber\":3,\"description\":\"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.\",\"images\":[]},{\"stepNumber\":4,\"description\":\"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).\",\"images\":[]},{\"stepNumber\":5,\"description\":\"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.\",\"images\":[]},{\"stepNumber\":6,\"description\":\"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.\",\"images\":[]},{\"stepNumber\":7,\"description\":\"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.\",\"images\":[]},{\"stepNumber\":8,\"description\":\"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.\",\"images\":[]},{\"stepNumber\":9,\"description\":\"Toss the dressing through the salad and season to taste; it may need more lime juice.\",\"images\":[]},{\"stepNumber\":10,\"description\":\"Scatter the sesame seeds on top and serve.\",\"images\":[]},{\"stepNumber\":11,\"description\":\"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.\",\"images\":[]}]}"
-          }
-        },
-        {
-          type: ElementType.IMAGE,
-          assets: [
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 1000,
-                height: 600
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 500,
-                height: 300
-              }
-            },
-            {
-              type: AssetType.IMAGE,
-              mimeType: "image/jpeg",
-              file: "http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg",
-              typeData: {
-                aspectRatio: "5:3",
-                width: 5512,
-                height: 3308,
-                isMaster: true
-              }
-            }
-          ],
-          imageTypeData: {
-            caption: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            copyright: "LOUISE HAGGER",
-            displayCredit: true,
-            credit: "Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            source: "Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay",
-            alt: "Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.",
-            mediaId: "58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            mediaApiUri: "https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45",
-            suppliersReference: "Soba noodles with crisp rainbow vegetables and a spicy sesame se",
-            imageType: "Photograph"
-          }
-        }
-      ]
-    }
-    const result = extractRecipeData(canonicalId, block, []);
-    expect(result.length).toEqual(1);
-    const data = JSON.parse(result[0]?.jsonBlob as string) as RecipeWithImageData;
-    expect(data.canonicalArticle).toBe(canonicalId);
-  })
+	it('should not add recipe dates where undefined', () => {
+		const canonicalId =
+			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
+		const recipeDates = {
+			lastModifiedDate: undefined,
+			firstPublishedDate: undefined,
+			publishedDate: undefined,
+		};
+		const block: Block = {
+			id: '5a4b754ce4b0e33567c465c7',
+			bodyHtml:
+				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
+			bodyTextSummary: '',
+			attributes: {},
+			published: true,
+			contributors: [],
+			createdBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			lastModifiedBy: {
+				email: 'stephanie.fincham@guardian.co.uk',
+				firstName: 'Stephanie',
+				lastName: 'Fincham',
+			},
+			elements: [
+				{
+					type: ElementType.TEXT,
+					assets: [],
+					textTypeData: {
+						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+					},
+				},
+				{
+					type: ElementType.RECIPE,
+					assets: [],
+					recipeTypeData: {
+						recipeJson:
+							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+					},
+				},
+				{
+					type: ElementType.IMAGE,
+					assets: [
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 1000,
+								height: 600,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 500,
+								height: 300,
+							},
+						},
+						{
+							type: AssetType.IMAGE,
+							mimeType: 'image/jpeg',
+							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+							typeData: {
+								aspectRatio: '5:3',
+								width: 5512,
+								height: 3308,
+								isMaster: true,
+							},
+						},
+					],
+					imageTypeData: {
+						caption:
+							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						copyright: 'LOUISE HAGGER',
+						displayCredit: true,
+						credit:
+							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						source:
+							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						mediaApiUri:
+							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+						suppliersReference:
+							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+						imageType: 'Photograph',
+					},
+				},
+			],
+      ...recipeDates
+		};
+		const result = extractRecipeData(canonicalId, block, []);
+		expect(result.length).toEqual(1);
+		expect(result[0]?.recipeUID).toEqual(
+			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
+		);
+		const originalContent = block.elements[1].recipeTypeData?.recipeJson
+			? (JSON.parse(block.elements[1].recipeTypeData.recipeJson) as Record<
+					string,
+					unknown
+			  >)
+			: {};
+		const expected = JSON.stringify({
+			...originalContent,
+			contributors: ['profile/thomasina-miers'],
+			byline: [],
+		});
+		expect(result[0]?.jsonBlob).toEqual(expected);
+	});
 });

--- a/lib/recipes-data/src/lib/extract-recipes.test.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.test.ts
@@ -1,12 +1,8 @@
-import { AssetType } from '@guardian/content-api-models/v1/assetType';
-import type { Block } from '@guardian/content-api-models/v1/block';
-import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import type { Sponsorship } from '@guardian/content-api-models/v1/sponsorship';
-import { SponsorshipType } from '@guardian/content-api-models/v1/sponsorshipType';
-import Int64 from 'node-int64';
 import { extractRecipeData } from './extract-recipes';
+import { activeSponsorships, block, canonicalId, invalidRecipeElements, multipleRecipeElements, noRecipeElements, recipeDates, singleRecipeElement } from './recipe-fixtures';
 import type { RecipeWithImageData } from './transform';
-import { capiDateTimeToDate, makeCapiDateTime } from './utils';
+import { capiDateTimeToDate } from './utils';
 
 jest.mock('./config', () => ({
 	FeaturedImageWidth: 700,
@@ -16,104 +12,14 @@ jest.mock('./config', () => ({
 
 describe('extractRecipeData', () => {
 	it('should work when block containing single recipe element', () => {
-		const canonicalId =
-			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
-		const block: Block = {
-			id: '5a4b754ce4b0e33567c465c7',
-			bodyHtml:
-				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
-			bodyTextSummary: '',
-			attributes: {},
-			published: true,
-			contributors: [],
-			createdBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			lastModifiedBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			elements: [
-				{
-					type: ElementType.TEXT,
-					assets: [],
-					textTypeData: {
-						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
-					},
-				},
-				{
-					type: ElementType.RECIPE,
-					assets: [],
-					recipeTypeData: {
-						recipeJson:
-							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-					},
-				},
-				{
-					type: ElementType.IMAGE,
-					assets: [
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 1000,
-								height: 600,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 500,
-								height: 300,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 5512,
-								height: 3308,
-								isMaster: true,
-							},
-						},
-					],
-					imageTypeData: {
-						caption:
-							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						copyright: 'LOUISE HAGGER',
-						displayCredit: true,
-						credit:
-							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						source:
-							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						mediaApiUri:
-							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						suppliersReference:
-							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
-						imageType: 'Photograph',
-					},
-				},
-			],
-		};
-		const result = extractRecipeData(canonicalId, block, []);
+		const testBlock = { ...block, elements: singleRecipeElement };
+		const result = extractRecipeData(canonicalId, testBlock, []);
 		expect(result.length).toEqual(1);
 		expect(result[0]?.recipeUID).toEqual(
 			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
 		);
-		const originalContent = block.elements[1].recipeTypeData?.recipeJson
-			? (JSON.parse(block.elements[1].recipeTypeData.recipeJson) as Record<
+		const originalContent = testBlock.elements[1].recipeTypeData?.recipeJson
+			? (JSON.parse(testBlock.elements[1].recipeTypeData.recipeJson) as Record<
 					string,
 					unknown
 			  >)
@@ -127,120 +33,14 @@ describe('extractRecipeData', () => {
 	});
 
 	it('should work when block containing multiple recipe elements', () => {
-		const canonicalId =
-			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
-		const block: Block = {
-			id: '5a4b754ce4b0e33567c465c7',
-			bodyHtml:
-				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
-			bodyTextSummary: '',
-			attributes: {},
-			published: true,
-			contributors: [],
-			createdBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			lastModifiedBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			elements: [
-				{
-					type: ElementType.TEXT,
-					assets: [],
-					textTypeData: {
-						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
-					},
-				},
-				{
-					type: ElementType.RECIPE,
-					assets: [],
-					recipeTypeData: {
-						recipeJson:
-							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-					},
-				},
-				{
-					type: ElementType.RECIPE,
-					assets: [],
-					recipeTypeData: {
-						recipeJson:
-							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-					},
-				},
-				{
-					type: ElementType.RECIPE,
-					assets: [],
-					recipeTypeData: {
-						recipeJson:
-							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-					},
-				},
-				{
-					type: ElementType.IMAGE,
-					assets: [
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 1000,
-								height: 600,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 500,
-								height: 300,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 5512,
-								height: 3308,
-								isMaster: true,
-							},
-						},
-					],
-					imageTypeData: {
-						caption:
-							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						copyright: 'LOUISE HAGGER',
-						displayCredit: true,
-						credit:
-							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						source:
-							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						mediaApiUri:
-							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						suppliersReference:
-							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
-						imageType: 'Photograph',
-					},
-				},
-			],
-		};
-		const result = extractRecipeData(canonicalId, block, []);
+		const testBlock = { ...block, elements: multipleRecipeElements}
+		const result = extractRecipeData(canonicalId, testBlock, []);
 		expect(result.length).toEqual(3);
 		expect(result[2]?.recipeUID).toEqual(
 			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
 		);
-		const originalContent = block.elements[3].recipeTypeData?.recipeJson
-			? (JSON.parse(block.elements[3].recipeTypeData.recipeJson) as Record<
+		const originalContent = testBlock.elements[3].recipeTypeData?.recipeJson
+			? (JSON.parse(testBlock.elements[3].recipeTypeData.recipeJson) as Record<
 					string,
 					unknown
 			  >)
@@ -254,306 +54,21 @@ describe('extractRecipeData', () => {
 	});
 
 	it('should work when block containing no recipe elements ', () => {
-		const canonicalId =
-			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
-		const block: Block = {
-			id: '5a4b754ce4b0e33567c465c7',
-			bodyHtml:
-				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
-			bodyTextSummary: '',
-			attributes: {},
-			published: true,
-			contributors: [],
-			createdBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			lastModifiedBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			elements: [
-				{
-					type: ElementType.TEXT,
-					assets: [],
-					textTypeData: {
-						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
-					},
-				},
-				{
-					type: ElementType.IMAGE,
-					assets: [
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 1000,
-								height: 600,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 500,
-								height: 300,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 5512,
-								height: 3308,
-								isMaster: true,
-							},
-						},
-					],
-					imageTypeData: {
-						caption:
-							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						copyright: 'LOUISE HAGGER',
-						displayCredit: true,
-						credit:
-							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						source:
-							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						mediaApiUri:
-							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						suppliersReference:
-							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
-						imageType: 'Photograph',
-					},
-				},
-			],
-		};
-		const result = extractRecipeData(canonicalId, block, []);
+		const testBlock = { ...block, elements: noRecipeElements}
+		const result = extractRecipeData(canonicalId, testBlock, []);
 		expect(result.length).toEqual(0);
 	});
 
 	it('should return empty array when block has got invalid recipe element (no ID field) ', () => {
-		const canonicalId =
-			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
-		const block: Block = {
-			id: '5a4b754ce4b0e33567c465c7',
-			bodyHtml:
-				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
-			bodyTextSummary: '',
-			attributes: {},
-			published: true,
-			contributors: [],
-			createdBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			lastModifiedBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			elements: [
-				{
-					type: ElementType.TEXT,
-					assets: [],
-					textTypeData: {
-						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
-					},
-				},
-				{
-					type: ElementType.RECIPE,
-					assets: [],
-					recipeTypeData: {
-						recipeJson:
-							'{"canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[],"byline":"Thomasina Miers","ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-					},
-				},
-				{
-					type: ElementType.IMAGE,
-					assets: [
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 1000,
-								height: 600,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 500,
-								height: 300,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 5512,
-								height: 3308,
-								isMaster: true,
-							},
-						},
-					],
-					imageTypeData: {
-						caption:
-							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						copyright: 'LOUISE HAGGER',
-						displayCredit: true,
-						credit:
-							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						source:
-							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						mediaApiUri:
-							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						suppliersReference:
-							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
-						imageType: 'Photograph',
-					},
-				},
-			],
-		};
-		const recipesFound = extractRecipeData(canonicalId, block, []);
+		const testBlock = { ...block, elements: invalidRecipeElements}
+		const recipesFound = extractRecipeData(canonicalId, testBlock, []);
 		expect(recipesFound).toEqual([null]);
 		expect(recipesFound.length).toEqual(1);
 	});
 
 	it('should work when block containing recipe element and is sponsored, means we have sponsorship data as well', () => {
-		const canonicalId =
-			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
-		const block: Block = {
-			id: '5a4b754ce4b0e33567c465c7',
-			bodyHtml:
-				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
-			bodyTextSummary: '',
-			attributes: {},
-			published: true,
-			contributors: [],
-			createdBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			lastModifiedBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			elements: [
-				{
-					type: ElementType.TEXT,
-					assets: [],
-					textTypeData: {
-						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
-					},
-				},
-				{
-					type: ElementType.RECIPE,
-					assets: [],
-					recipeTypeData: {
-						recipeJson:
-							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-					},
-				},
-				{
-					type: ElementType.IMAGE,
-					assets: [
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 1000,
-								height: 600,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 500,
-								height: 300,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 5512,
-								height: 3308,
-								isMaster: true,
-							},
-						},
-					],
-					imageTypeData: {
-						caption:
-							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						copyright: 'LOUISE HAGGER',
-						displayCredit: true,
-						credit:
-							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						source:
-							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						mediaApiUri:
-							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						suppliersReference:
-							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
-						imageType: 'Photograph',
-					},
-				},
-			],
-		};
-		const activeSponsorships: Sponsorship[] = [
-			{
-				sponsorshipType: SponsorshipType.SPONSORED,
-				sponsorName: 'theguardian.org',
-				sponsorLogo:
-					'https://static.theguardian.com/commercial/sponsor/22/Feb/2024/f459c58b-6553-486d-939a-5f23fd935f78-Guardian.orglogos-for badge.png',
-				sponsorLink: 'https://theguardian.org/',
-				aboutLink:
-					'https://www.theguardian.com/global-development/2010/sep/14/about-this-site',
-				sponsorLogoDimensions: {
-					width: 280,
-					height: 180,
-				},
-				highContrastSponsorLogo:
-					'https://static.theguardian.com/commercial/sponsor/22/Feb/2024/3d8e52dc-1d0b-4f95-8cd1-48a674e1309d-guardian.org new logo - white version (3).png',
-				highContrastSponsorLogoDimensions: {
-					width: 280,
-					height: 180,
-				},
-				validFrom: makeCapiDateTime('2023-09-21T16:18:10Z'),
-				validTo: makeCapiDateTime('2026-08-30T23:00:00Z'),
-			},
-		];
-		const result = extractRecipeData(canonicalId, block, activeSponsorships);
+		const testBlock = { ...block, elements: singleRecipeElement };
+		const result = extractRecipeData(canonicalId, testBlock, activeSponsorships);
 		expect(result.length).toEqual(1);
 		expect(result[0]?.recipeUID).toEqual(
 			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
@@ -571,99 +86,9 @@ describe('extractRecipeData', () => {
 	});
 
 	it('should work when block containing recipe element but not sponsored, means no sponsor data available', () => {
-		const canonicalId =
-			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
-		const block: Block = {
-			id: '5a4b754ce4b0e33567c465c7',
-			bodyHtml:
-				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
-			bodyTextSummary: '',
-			attributes: {},
-			published: true,
-			contributors: [],
-			createdBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			lastModifiedBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			elements: [
-				{
-					type: ElementType.TEXT,
-					assets: [],
-					textTypeData: {
-						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
-					},
-				},
-				{
-					type: ElementType.RECIPE,
-					assets: [],
-					recipeTypeData: {
-						recipeJson:
-							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-					},
-				},
-				{
-					type: ElementType.IMAGE,
-					assets: [
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 1000,
-								height: 600,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 500,
-								height: 300,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 5512,
-								height: 3308,
-								isMaster: true,
-							},
-						},
-					],
-					imageTypeData: {
-						caption:
-							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						copyright: 'LOUISE HAGGER',
-						displayCredit: true,
-						credit:
-							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						source:
-							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						mediaApiUri:
-							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						suppliersReference:
-							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
-						imageType: 'Photograph',
-					},
-				},
-			],
-		};
+		const testBlock = { ...block, elements: singleRecipeElement };
 		const activeSponsorships: Sponsorship[] = [];
-		const result = extractRecipeData(canonicalId, block, activeSponsorships);
+		const result = extractRecipeData(canonicalId, testBlock, activeSponsorships);
 		expect(result.length).toEqual(1);
 		expect(result[0]?.recipeUID).toEqual(
 			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
@@ -678,96 +103,8 @@ describe('extractRecipeData', () => {
 
 	it('should update the canonicalArticle with the content ID', () => {
 		const canonicalId = 'a-new-path';
-		const block: Block = {
-			id: '5a4b754ce4b0e33567c465c7',
-			bodyHtml:
-				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
-			bodyTextSummary: '',
-			attributes: {},
-			published: true,
-			contributors: [],
-			createdBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			lastModifiedBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			elements: [
-				{
-					type: ElementType.TEXT,
-					assets: [],
-					textTypeData: {
-						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
-					},
-				},
-				{
-					type: ElementType.RECIPE,
-					assets: [],
-					recipeTypeData: {
-						recipeJson:
-							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-					},
-				},
-				{
-					type: ElementType.IMAGE,
-					assets: [
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 1000,
-								height: 600,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 500,
-								height: 300,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 5512,
-								height: 3308,
-								isMaster: true,
-							},
-						},
-					],
-					imageTypeData: {
-						caption:
-							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						copyright: 'LOUISE HAGGER',
-						displayCredit: true,
-						credit:
-							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						source:
-							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						mediaApiUri:
-							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						suppliersReference:
-							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
-						imageType: 'Photograph',
-					},
-				},
-			],
-		};
-		const result = extractRecipeData(canonicalId, block, []);
+    const testBlock = { ...block, elements: singleRecipeElement };
+		const result = extractRecipeData(canonicalId, testBlock, []);
 		expect(result.length).toEqual(1);
 		const data = JSON.parse(
 			result[0]?.jsonBlob as string,
@@ -776,119 +113,14 @@ describe('extractRecipeData', () => {
 	});
 
 	it('should add recipe dates where specified', () => {
-		const canonicalId =
-			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
-		const recipeDates = {
-			lastModifiedDate: {
-				dateTime: new Int64(new Date('2024-09-10T16:18:10Z').getTime()),
-				iso8601: '2024-09-10T16:18:10Z',
-			},
-			firstPublishedDate: {
-				dateTime: new Int64(new Date('2024-09-02T10:04:16Z').getTime()),
-				iso8601: '2024-09-02T10:04:16Z',
-			},
-			publishedDate: {
-				dateTime: new Int64(new Date('2024-09-10T16:22:07Z').getTime()),
-				iso8601: '2023-09-10T16:22:07Z',
-			},
-		};
-		const block: Block = {
-			id: '5a4b754ce4b0e33567c465c7',
-			bodyHtml:
-				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
-			bodyTextSummary: '',
-			attributes: {},
-			published: true,
-			contributors: [],
-			createdBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			lastModifiedBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			elements: [
-				{
-					type: ElementType.TEXT,
-					assets: [],
-					textTypeData: {
-						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
-					},
-				},
-				{
-					type: ElementType.RECIPE,
-					assets: [],
-					recipeTypeData: {
-						recipeJson:
-							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-					},
-				},
-				{
-					type: ElementType.IMAGE,
-					assets: [
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 1000,
-								height: 600,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 500,
-								height: 300,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 5512,
-								height: 3308,
-								isMaster: true,
-							},
-						},
-					],
-					imageTypeData: {
-						caption:
-							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						copyright: 'LOUISE HAGGER',
-						displayCredit: true,
-						credit:
-							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						source:
-							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						mediaApiUri:
-							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						suppliersReference:
-							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
-						imageType: 'Photograph',
-					},
-				},
-			],
-			...recipeDates,
-		};
-		const result = extractRecipeData(canonicalId, block, []);
+		const testBlock = { ...block, elements: singleRecipeElement, ...recipeDates };
+		const result = extractRecipeData(canonicalId, testBlock, []);
 		expect(result.length).toEqual(1);
 		expect(result[0]?.recipeUID).toEqual(
 			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
 		);
-		const originalContent = block.elements[1].recipeTypeData?.recipeJson
-			? (JSON.parse(block.elements[1].recipeTypeData.recipeJson) as Record<
+		const originalContent = testBlock.elements[1].recipeTypeData?.recipeJson
+			? (JSON.parse(testBlock.elements[1].recipeTypeData.recipeJson) as Record<
 					string,
 					unknown
 			  >)
@@ -905,110 +137,19 @@ describe('extractRecipeData', () => {
 	});
 
 	it('should not add recipe dates where undefined', () => {
-		const canonicalId =
-			'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
 		const recipeDates = {
 			lastModifiedDate: undefined,
 			firstPublishedDate: undefined,
 			publishedDate: undefined,
 		};
-		const block: Block = {
-			id: '5a4b754ce4b0e33567c465c7',
-			bodyHtml:
-				'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
-			bodyTextSummary: '',
-			attributes: {},
-			published: true,
-			contributors: [],
-			createdBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			lastModifiedBy: {
-				email: 'stephanie.fincham@guardian.co.uk',
-				firstName: 'Stephanie',
-				lastName: 'Fincham',
-			},
-			elements: [
-				{
-					type: ElementType.TEXT,
-					assets: [],
-					textTypeData: {
-						html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
-					},
-				},
-				{
-					type: ElementType.RECIPE,
-					assets: [],
-					recipeTypeData: {
-						recipeJson:
-							'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-					},
-				},
-				{
-					type: ElementType.IMAGE,
-					assets: [
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 1000,
-								height: 600,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 500,
-								height: 300,
-							},
-						},
-						{
-							type: AssetType.IMAGE,
-							mimeType: 'image/jpeg',
-							file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
-							typeData: {
-								aspectRatio: '5:3',
-								width: 5512,
-								height: 3308,
-								isMaster: true,
-							},
-						},
-					],
-					imageTypeData: {
-						caption:
-							'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						copyright: 'LOUISE HAGGER',
-						displayCredit: true,
-						credit:
-							'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						source:
-							'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-						alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-						mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						mediaApiUri:
-							'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-						suppliersReference:
-							'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
-						imageType: 'Photograph',
-					},
-				},
-			],
-      ...recipeDates
-		};
-		const result = extractRecipeData(canonicalId, block, []);
+		const testBlock = { ...block, elements: singleRecipeElement, ...recipeDates };
+		const result = extractRecipeData(canonicalId, testBlock, []);
 		expect(result.length).toEqual(1);
 		expect(result[0]?.recipeUID).toEqual(
 			'62ac3f0f98f6495cbefd72c11fac6d1e26390e99',
 		);
-		const originalContent = block.elements[1].recipeTypeData?.recipeJson
-			? (JSON.parse(block.elements[1].recipeTypeData.recipeJson) as Record<
+		const originalContent = testBlock.elements[1].recipeTypeData?.recipeJson
+			? (JSON.parse(testBlock.elements[1].recipeTypeData.recipeJson) as Record<
 					string,
 					unknown
 			  >)

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -24,9 +24,9 @@ export async function extractAllRecipesFromArticle(content: Content): Promise<Re
   if (content.type == ContentType.ARTICLE && content.blocks) {
     const sponsorship = content.tags.flatMap(t => t.activeSponsorships ?? [])
     const articleBlocks: Blocks = content.blocks
-    const getAllMainBlockRecipesIfPresent = extractRecipeData(content.id, articleBlocks.main as Block, sponsorship)
+    const getAllMainBlockRecipesIfPresent = extractRecipeData(content, articleBlocks.main as Block, sponsorship)
     const bodyBlocks = articleBlocks.body as Block[]
-    const getAllBodyBlocksRecipesIfPresent = bodyBlocks.flatMap(bodyBlock => extractRecipeData(content.id, bodyBlock, sponsorship))
+    const getAllBodyBlocksRecipesIfPresent = bodyBlocks.flatMap(bodyBlock => extractRecipeData(content, bodyBlock, sponsorship))
     const recipes = getAllMainBlockRecipesIfPresent.concat(getAllBodyBlocksRecipesIfPresent)
     const failureCount = recipes.filter(recp => !recp).length
     await registerMetric("FailedRecipes", failureCount)
@@ -39,7 +39,7 @@ export async function extractAllRecipesFromArticle(content: Content): Promise<Re
 }
 
 
-export function extractRecipeData(canonicalId: string, block: Block, sponsorship: Sponsorship[]): Array<RecipeReferenceWithoutChecksum | null> {
+export function extractRecipeData(content: Content, block: Block, sponsorship: Sponsorship[]): Array<RecipeReferenceWithoutChecksum | null> {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- to fix error when elements are undefined , example if main block does not have any elements.
   if (!block?.elements) return [];
   else {
@@ -50,7 +50,7 @@ export function extractRecipeData(canonicalId: string, block: Block, sponsorship
     }
     return block.elements
       .filter(elem => elem.type === ElementType.RECIPE)
-      .map(recp => parseJsonBlob(canonicalId, recp.recipeTypeData?.recipeJson as string, sponsorship, recipeDates))
+      .map(recp => parseJsonBlob(content.id, recp.recipeTypeData?.recipeJson as string, sponsorship, recipeDates))
   }
 }
 

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -45,13 +45,24 @@ export function extractRecipeData(content: Content, block: Block, sponsorship: S
   else {
     const recipeDates: RecipeDates = {
       lastModifiedDate: capiDateTimeToDate(block.lastModifiedDate),
-      firstPublishedDate: capiDateTimeToDate(block.firstPublishedDate),
-      publishedDate: capiDateTimeToDate(block.publishedDate)
+      firstPublishedDate: getFirstPublishedDate(block, content),
+      publishedDate: getPublishedDate(block, content)
     }
     return block.elements
       .filter(elem => elem.type === ElementType.RECIPE)
       .map(recp => parseJsonBlob(content.id, recp.recipeTypeData?.recipeJson as string, sponsorship, recipeDates))
   }
+}
+
+function getFirstPublishedDate(block: Block, content: Content): Date | undefined {
+  return block.firstPublishedDate ? capiDateTimeToDate(block.firstPublishedDate) :
+    (content.fields?.firstPublicationDate ? capiDateTimeToDate(content.fields.firstPublicationDate) : undefined);
+}
+
+function getPublishedDate(block: Block, content: Content): Date | undefined {
+  const feastChannel = content.channels?.find(channel => channel.channelId === 'feast');
+  return block.publishedDate ? capiDateTimeToDate(block.publishedDate) :
+    (feastChannel?.fields.publicationDate ? capiDateTimeToDate(feastChannel.fields.publicationDate) : undefined);
 }
 
 /**

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -54,12 +54,12 @@ export function extractRecipeData(content: Content, block: Block, sponsorship: S
   }
 }
 
-function getFirstPublishedDate(block: Block, content: Content): Date | undefined {
+export function getFirstPublishedDate(block: Block, content: Content): Date | undefined {
   return block.firstPublishedDate ? capiDateTimeToDate(block.firstPublishedDate) :
     (content.fields?.firstPublicationDate ? capiDateTimeToDate(content.fields.firstPublicationDate) : undefined);
 }
 
-function getPublishedDate(block: Block, content: Content): Date | undefined {
+export function getPublishedDate(block: Block, content: Content): Date | undefined {
   const feastChannel = content.channels?.find(channel => channel.channelId === 'feast');
   return block.publishedDate ? capiDateTimeToDate(block.publishedDate) :
     (feastChannel?.fields.publicationDate ? capiDateTimeToDate(feastChannel.fields.publicationDate) : undefined);

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -8,6 +8,7 @@ import type {Sponsorship} from "@guardian/content-api-models/v1/sponsorship";
 import {registerMetric} from "@recipes-api/cwmetrics";
 import type {Contributor, RecipeReferenceWithoutChecksum} from './models';
 import {
+  addPublicationDateTransform,
   addSponsorsTransform,
   handleFreeTextContribs,
   replaceCanonicalArticle,
@@ -66,7 +67,7 @@ function determineRecipeUID(recipeIdField: string, canonicalId: string): string 
   }
 }
 
-function parseJsonBlob(canonicalId: string, recipeJson: string, sponsorship: Sponsorship[]): RecipeReferenceWithoutChecksum | null {
+function parseJsonBlob(canonicalId: string, recipeJson: string, sponsorship: Sponsorship[], pubDate:Date): RecipeReferenceWithoutChecksum | null {
   try {
     const recipeData = JSON.parse(recipeJson) as (Record<string, unknown> & {
       contributors: Array<string | Contributor>;
@@ -76,6 +77,7 @@ function parseJsonBlob(canonicalId: string, recipeJson: string, sponsorship: Spo
       handleFreeTextContribs,
       replaceImageUrlsWithFastly,
       addSponsorsTransform(sponsorship),
+      addPublicationDateTransform(pubDate),
       replaceCanonicalArticle(canonicalId)
     ];
 

--- a/lib/recipes-data/src/lib/models.ts
+++ b/lib/recipes-data/src/lib/models.ts
@@ -64,6 +64,15 @@ interface RecipeReference extends RecipeReferenceWithoutChecksum {
   checksum: string;
 }
 
+/**
+ * RecipeDates is a subset of the RecipeReference structure, containing date fields that may be useful for sorting search results
+ */
+export interface RecipeDates {
+  lastModifiedDate?: Date;
+  firstPublishedDate?: Date;
+  publishedDate?: Date;
+}
+
 export type Contributor = { "type": "contributor"; "tagId": string } | { "type": "freetext"; "text": string };
 
 /**

--- a/lib/recipes-data/src/lib/recipe-fixtures.ts
+++ b/lib/recipes-data/src/lib/recipe-fixtures.ts
@@ -1,4 +1,12 @@
+import { AssetType } from '@guardian/content-api-models/v1/assetType';
+import type { Block } from "@guardian/content-api-models/v1/block";
+import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
+import { ElementType } from '@guardian/content-api-models/v1/elementType';
+import type { Sponsorship } from '@guardian/content-api-models/v1/sponsorship';
+import { SponsorshipType } from '@guardian/content-api-models/v1/sponsorshipType';
+import Int64 from 'node-int64';
 import type { RecipeImage } from "./models";
+import { makeCapiDateTime } from './utils';
 
 export type RecipeFixture = Record<string, unknown> & {
 	id: string;
@@ -355,3 +363,358 @@ export const recipes = [
 		utensilsAndApplianceIds: [],
 	},
 ] as RecipeFixture[];
+
+export const canonicalId =
+'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
+
+export const block: Block = {
+  id: '5a4b754ce4b0e33567c465c7',
+  bodyHtml:
+    '<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
+  bodyTextSummary: '',
+  attributes: {},
+  published: true,
+  contributors: [],
+  createdBy: {
+    email: 'stephanie.fincham@guardian.co.uk',
+    firstName: 'Stephanie',
+    lastName: 'Fincham',
+  },
+  lastModifiedBy: {
+    email: 'stephanie.fincham@guardian.co.uk',
+    firstName: 'Stephanie',
+    lastName: 'Fincham',
+  },
+  elements: []
+};
+
+export const singleRecipeElement: BlockElement[] = [
+  {
+    type: ElementType.TEXT,
+    assets: [],
+    textTypeData: {
+      html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+    },
+  },
+  {
+    type: ElementType.RECIPE,
+    assets: [],
+    recipeTypeData: {
+      recipeJson:
+        '{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+    },
+  },
+  {
+    type: ElementType.IMAGE,
+    assets: [
+      {
+        type: AssetType.IMAGE,
+        mimeType: 'image/jpeg',
+        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+        typeData: {
+          aspectRatio: '5:3',
+          width: 1000,
+          height: 600,
+        },
+      },
+      {
+        type: AssetType.IMAGE,
+        mimeType: 'image/jpeg',
+        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+        typeData: {
+          aspectRatio: '5:3',
+          width: 500,
+          height: 300,
+        },
+      },
+      {
+        type: AssetType.IMAGE,
+        mimeType: 'image/jpeg',
+        file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+        typeData: {
+          aspectRatio: '5:3',
+          width: 5512,
+          height: 3308,
+          isMaster: true,
+        },
+      },
+    ],
+    imageTypeData: {
+      caption:
+        'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+      copyright: 'LOUISE HAGGER',
+      displayCredit: true,
+      credit:
+        'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+      source:
+        'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+      alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+      mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+      mediaApiUri:
+        'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+      suppliersReference:
+        'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+      imageType: 'Photograph',
+    },
+  },
+];
+
+export const multipleRecipeElements: BlockElement[] = [
+  {
+    type: ElementType.TEXT,
+    assets: [],
+    textTypeData: {
+      html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+    },
+  },
+  {
+    type: ElementType.RECIPE,
+    assets: [],
+    recipeTypeData: {
+      recipeJson:
+        '{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+    },
+  },
+  {
+    type: ElementType.RECIPE,
+    assets: [],
+    recipeTypeData: {
+      recipeJson:
+        '{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+    },
+  },
+  {
+    type: ElementType.RECIPE,
+    assets: [],
+    recipeTypeData: {
+      recipeJson:
+        '{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+    },
+  },
+  {
+    type: ElementType.IMAGE,
+    assets: [
+      {
+        type: AssetType.IMAGE,
+        mimeType: 'image/jpeg',
+        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+        typeData: {
+          aspectRatio: '5:3',
+          width: 1000,
+          height: 600,
+        },
+      },
+      {
+        type: AssetType.IMAGE,
+        mimeType: 'image/jpeg',
+        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+        typeData: {
+          aspectRatio: '5:3',
+          width: 500,
+          height: 300,
+        },
+      },
+      {
+        type: AssetType.IMAGE,
+        mimeType: 'image/jpeg',
+        file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+        typeData: {
+          aspectRatio: '5:3',
+          width: 5512,
+          height: 3308,
+          isMaster: true,
+        },
+      },
+    ],
+    imageTypeData: {
+      caption:
+        'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+      copyright: 'LOUISE HAGGER',
+      displayCredit: true,
+      credit:
+        'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+      source:
+        'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+      alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+      mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+      mediaApiUri:
+        'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+      suppliersReference:
+        'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+      imageType: 'Photograph',
+    },
+  },
+];
+
+export const noRecipeElements: BlockElement[] = [
+  {
+    type: ElementType.TEXT,
+    assets: [],
+    textTypeData: {
+      html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+    },
+  },
+  {
+    type: ElementType.IMAGE,
+    assets: [
+      {
+        type: AssetType.IMAGE,
+        mimeType: 'image/jpeg',
+        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+        typeData: {
+          aspectRatio: '5:3',
+          width: 1000,
+          height: 600,
+        },
+      },
+      {
+        type: AssetType.IMAGE,
+        mimeType: 'image/jpeg',
+        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+        typeData: {
+          aspectRatio: '5:3',
+          width: 500,
+          height: 300,
+        },
+      },
+      {
+        type: AssetType.IMAGE,
+        mimeType: 'image/jpeg',
+        file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+        typeData: {
+          aspectRatio: '5:3',
+          width: 5512,
+          height: 3308,
+          isMaster: true,
+        },
+      },
+    ],
+    imageTypeData: {
+      caption:
+        'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+      copyright: 'LOUISE HAGGER',
+      displayCredit: true,
+      credit:
+        'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+      source:
+        'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+      alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+      mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+      mediaApiUri:
+        'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+      suppliersReference:
+        'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+      imageType: 'Photograph',
+    },
+  },
+];
+
+export const invalidRecipeElements: BlockElement[] = [
+  {
+    type: ElementType.TEXT,
+    assets: [],
+    textTypeData: {
+      html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+    },
+  },
+  {
+    type: ElementType.RECIPE,
+    assets: [],
+    recipeTypeData: {
+      recipeJson:
+        '{"canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[],"byline":"Thomasina Miers","ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+    },
+  },
+  {
+    type: ElementType.IMAGE,
+    assets: [
+      {
+        type: AssetType.IMAGE,
+        mimeType: 'image/jpeg',
+        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+        typeData: {
+          aspectRatio: '5:3',
+          width: 1000,
+          height: 600,
+        },
+      },
+      {
+        type: AssetType.IMAGE,
+        mimeType: 'image/jpeg',
+        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+        typeData: {
+          aspectRatio: '5:3',
+          width: 500,
+          height: 300,
+        },
+      },
+      {
+        type: AssetType.IMAGE,
+        mimeType: 'image/jpeg',
+        file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+        typeData: {
+          aspectRatio: '5:3',
+          width: 5512,
+          height: 3308,
+          isMaster: true,
+        },
+      },
+    ],
+    imageTypeData: {
+      caption:
+        'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+      copyright: 'LOUISE HAGGER',
+      displayCredit: true,
+      credit:
+        'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+      source:
+        'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+      alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+      mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+      mediaApiUri:
+        'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+      suppliersReference:
+        'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+      imageType: 'Photograph',
+    },
+  },
+];
+
+export const activeSponsorships: Sponsorship[] = [
+  {
+    sponsorshipType: SponsorshipType.SPONSORED,
+    sponsorName: 'theguardian.org',
+    sponsorLogo:
+      'https://static.theguardian.com/commercial/sponsor/22/Feb/2024/f459c58b-6553-486d-939a-5f23fd935f78-Guardian.orglogos-for badge.png',
+    sponsorLink: 'https://theguardian.org/',
+    aboutLink:
+      'https://www.theguardian.com/global-development/2010/sep/14/about-this-site',
+    sponsorLogoDimensions: {
+      width: 280,
+      height: 180,
+    },
+    highContrastSponsorLogo:
+      'https://static.theguardian.com/commercial/sponsor/22/Feb/2024/3d8e52dc-1d0b-4f95-8cd1-48a674e1309d-guardian.org new logo - white version (3).png',
+    highContrastSponsorLogoDimensions: {
+      width: 280,
+      height: 180,
+    },
+    validFrom: makeCapiDateTime('2023-09-21T16:18:10Z'),
+    validTo: makeCapiDateTime('2026-08-30T23:00:00Z'),
+  },
+];
+
+export const recipeDates = {
+  lastModifiedDate: {
+    dateTime: new Int64(new Date('2024-09-10T16:18:10Z').getTime()),
+    iso8601: '2024-09-10T16:18:10Z',
+  },
+  firstPublishedDate: {
+    dateTime: new Int64(new Date('2024-09-02T10:04:16Z').getTime()),
+    iso8601: '2024-09-02T10:04:16Z',
+  },
+  publishedDate: {
+    dateTime: new Int64(new Date('2024-09-10T16:22:07Z').getTime()),
+    iso8601: '2023-09-10T16:22:07Z',
+  },
+};

--- a/lib/recipes-data/src/lib/recipe-fixtures.ts
+++ b/lib/recipes-data/src/lib/recipe-fixtures.ts
@@ -1,6 +1,8 @@
 import { AssetType } from '@guardian/content-api-models/v1/assetType';
 import type { Block } from "@guardian/content-api-models/v1/block";
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
+import type { Content } from '@guardian/content-api-models/v1/content';
+import { ContentType } from '@guardian/content-api-models/v1/contentType';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import type { Sponsorship } from '@guardian/content-api-models/v1/sponsorship';
 import { SponsorshipType } from '@guardian/content-api-models/v1/sponsorshipType';
@@ -366,6 +368,17 @@ export const recipes = [
 
 export const canonicalId =
 'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
+
+export const content: Content = {
+  id: canonicalId,
+  type: ContentType.ARTICLE,
+  webTitle: 'Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing',
+  webUrl: `https://www.theguardian.com/${canonicalId}`,
+  apiUrl: `https://content.guardianapis.com/${canonicalId}`,
+  tags: [],
+  references: [],
+  isHosted: false,
+}
 
 export const block: Block = {
   id: '5a4b754ce4b0e33567c465c7',

--- a/lib/recipes-data/src/lib/recipe-fixtures.ts
+++ b/lib/recipes-data/src/lib/recipe-fixtures.ts
@@ -1,13 +1,14 @@
 import { AssetType } from '@guardian/content-api-models/v1/assetType';
-import type { Block } from "@guardian/content-api-models/v1/block";
+import type { Block } from '@guardian/content-api-models/v1/block';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import type { Content } from '@guardian/content-api-models/v1/content';
+import type { ContentChannel } from '@guardian/content-api-models/v1/contentChannel';
 import { ContentType } from '@guardian/content-api-models/v1/contentType';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import type { Sponsorship } from '@guardian/content-api-models/v1/sponsorship';
 import { SponsorshipType } from '@guardian/content-api-models/v1/sponsorshipType';
 import Int64 from 'node-int64';
-import type { RecipeImage } from "./models";
+import type { RecipeImage } from './models';
 import { makeCapiDateTime } from './utils';
 
 export type RecipeFixture = Record<string, unknown> & {
@@ -367,367 +368,403 @@ export const recipes = [
 ] as RecipeFixture[];
 
 export const canonicalId =
-'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
+	'lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers';
 
 export const content: Content = {
-  id: canonicalId,
-  type: ContentType.ARTICLE,
-  webTitle: 'Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing',
-  webUrl: `https://www.theguardian.com/${canonicalId}`,
-  apiUrl: `https://content.guardianapis.com/${canonicalId}`,
-  tags: [],
-  references: [],
-  isHosted: false,
-}
+	id: canonicalId,
+	type: ContentType.ARTICLE,
+	webTitle:
+		'Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing',
+	webUrl: `https://www.theguardian.com/${canonicalId}`,
+	apiUrl: `https://content.guardianapis.com/${canonicalId}`,
+	tags: [],
+	references: [],
+	isHosted: false,
+};
 
 export const block: Block = {
-  id: '5a4b754ce4b0e33567c465c7',
-  bodyHtml:
-    '<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
-  bodyTextSummary: '',
-  attributes: {},
-  published: true,
-  contributors: [],
-  createdBy: {
-    email: 'stephanie.fincham@guardian.co.uk',
-    firstName: 'Stephanie',
-    lastName: 'Fincham',
-  },
-  lastModifiedBy: {
-    email: 'stephanie.fincham@guardian.co.uk',
-    firstName: 'Stephanie',
-    lastName: 'Fincham',
-  },
-  elements: []
+	id: '5a4b754ce4b0e33567c465c7',
+	bodyHtml:
+		'<figure class="element element-image" data-media-id="58c32a98ae4463b5129bf717b1b2312d8ffc0d45"> <img src="https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg" alt="Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.</span> <span class="element-image__credit">Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay</span> </figcaption> </figure>',
+	bodyTextSummary: '',
+	attributes: {},
+	published: true,
+	contributors: [],
+	createdBy: {
+		email: 'stephanie.fincham@guardian.co.uk',
+		firstName: 'Stephanie',
+		lastName: 'Fincham',
+	},
+	lastModifiedBy: {
+		email: 'stephanie.fincham@guardian.co.uk',
+		firstName: 'Stephanie',
+		lastName: 'Fincham',
+	},
+	elements: [],
 };
 
 export const singleRecipeElement: BlockElement[] = [
-  {
-    type: ElementType.TEXT,
-    assets: [],
-    textTypeData: {
-      html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
-    },
-  },
-  {
-    type: ElementType.RECIPE,
-    assets: [],
-    recipeTypeData: {
-      recipeJson:
-        '{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-    },
-  },
-  {
-    type: ElementType.IMAGE,
-    assets: [
-      {
-        type: AssetType.IMAGE,
-        mimeType: 'image/jpeg',
-        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
-        typeData: {
-          aspectRatio: '5:3',
-          width: 1000,
-          height: 600,
-        },
-      },
-      {
-        type: AssetType.IMAGE,
-        mimeType: 'image/jpeg',
-        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
-        typeData: {
-          aspectRatio: '5:3',
-          width: 500,
-          height: 300,
-        },
-      },
-      {
-        type: AssetType.IMAGE,
-        mimeType: 'image/jpeg',
-        file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
-        typeData: {
-          aspectRatio: '5:3',
-          width: 5512,
-          height: 3308,
-          isMaster: true,
-        },
-      },
-    ],
-    imageTypeData: {
-      caption:
-        'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-      copyright: 'LOUISE HAGGER',
-      displayCredit: true,
-      credit:
-        'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-      source:
-        'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-      alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-      mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-      mediaApiUri:
-        'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-      suppliersReference:
-        'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
-      imageType: 'Photograph',
-    },
-  },
+	{
+		type: ElementType.TEXT,
+		assets: [],
+		textTypeData: {
+			html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+		},
+	},
+	{
+		type: ElementType.RECIPE,
+		assets: [],
+		recipeTypeData: {
+			recipeJson:
+				'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+		},
+	},
+	{
+		type: ElementType.IMAGE,
+		assets: [
+			{
+				type: AssetType.IMAGE,
+				mimeType: 'image/jpeg',
+				file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+				typeData: {
+					aspectRatio: '5:3',
+					width: 1000,
+					height: 600,
+				},
+			},
+			{
+				type: AssetType.IMAGE,
+				mimeType: 'image/jpeg',
+				file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+				typeData: {
+					aspectRatio: '5:3',
+					width: 500,
+					height: 300,
+				},
+			},
+			{
+				type: AssetType.IMAGE,
+				mimeType: 'image/jpeg',
+				file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+				typeData: {
+					aspectRatio: '5:3',
+					width: 5512,
+					height: 3308,
+					isMaster: true,
+				},
+			},
+		],
+		imageTypeData: {
+			caption:
+				'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+			copyright: 'LOUISE HAGGER',
+			displayCredit: true,
+			credit:
+				'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+			source:
+				'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+			alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+			mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+			mediaApiUri:
+				'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+			suppliersReference:
+				'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+			imageType: 'Photograph',
+		},
+	},
 ];
 
 export const multipleRecipeElements: BlockElement[] = [
-  {
-    type: ElementType.TEXT,
-    assets: [],
-    textTypeData: {
-      html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
-    },
-  },
-  {
-    type: ElementType.RECIPE,
-    assets: [],
-    recipeTypeData: {
-      recipeJson:
-        '{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-    },
-  },
-  {
-    type: ElementType.RECIPE,
-    assets: [],
-    recipeTypeData: {
-      recipeJson:
-        '{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-    },
-  },
-  {
-    type: ElementType.RECIPE,
-    assets: [],
-    recipeTypeData: {
-      recipeJson:
-        '{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-    },
-  },
-  {
-    type: ElementType.IMAGE,
-    assets: [
-      {
-        type: AssetType.IMAGE,
-        mimeType: 'image/jpeg',
-        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
-        typeData: {
-          aspectRatio: '5:3',
-          width: 1000,
-          height: 600,
-        },
-      },
-      {
-        type: AssetType.IMAGE,
-        mimeType: 'image/jpeg',
-        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
-        typeData: {
-          aspectRatio: '5:3',
-          width: 500,
-          height: 300,
-        },
-      },
-      {
-        type: AssetType.IMAGE,
-        mimeType: 'image/jpeg',
-        file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
-        typeData: {
-          aspectRatio: '5:3',
-          width: 5512,
-          height: 3308,
-          isMaster: true,
-        },
-      },
-    ],
-    imageTypeData: {
-      caption:
-        'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-      copyright: 'LOUISE HAGGER',
-      displayCredit: true,
-      credit:
-        'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-      source:
-        'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-      alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-      mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-      mediaApiUri:
-        'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-      suppliersReference:
-        'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
-      imageType: 'Photograph',
-    },
-  },
+	{
+		type: ElementType.TEXT,
+		assets: [],
+		textTypeData: {
+			html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+		},
+	},
+	{
+		type: ElementType.RECIPE,
+		assets: [],
+		recipeTypeData: {
+			recipeJson:
+				'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+		},
+	},
+	{
+		type: ElementType.RECIPE,
+		assets: [],
+		recipeTypeData: {
+			recipeJson:
+				'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+		},
+	},
+	{
+		type: ElementType.RECIPE,
+		assets: [],
+		recipeTypeData: {
+			recipeJson:
+				'{"id":"1","canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[{"type":"contributor","tagId":"profile/thomasina-miers"}],"ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+		},
+	},
+	{
+		type: ElementType.IMAGE,
+		assets: [
+			{
+				type: AssetType.IMAGE,
+				mimeType: 'image/jpeg',
+				file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+				typeData: {
+					aspectRatio: '5:3',
+					width: 1000,
+					height: 600,
+				},
+			},
+			{
+				type: AssetType.IMAGE,
+				mimeType: 'image/jpeg',
+				file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+				typeData: {
+					aspectRatio: '5:3',
+					width: 500,
+					height: 300,
+				},
+			},
+			{
+				type: AssetType.IMAGE,
+				mimeType: 'image/jpeg',
+				file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+				typeData: {
+					aspectRatio: '5:3',
+					width: 5512,
+					height: 3308,
+					isMaster: true,
+				},
+			},
+		],
+		imageTypeData: {
+			caption:
+				'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+			copyright: 'LOUISE HAGGER',
+			displayCredit: true,
+			credit:
+				'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+			source:
+				'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+			alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+			mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+			mediaApiUri:
+				'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+			suppliersReference:
+				'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+			imageType: 'Photograph',
+		},
+	},
 ];
 
 export const noRecipeElements: BlockElement[] = [
-  {
-    type: ElementType.TEXT,
-    assets: [],
-    textTypeData: {
-      html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
-    },
-  },
-  {
-    type: ElementType.IMAGE,
-    assets: [
-      {
-        type: AssetType.IMAGE,
-        mimeType: 'image/jpeg',
-        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
-        typeData: {
-          aspectRatio: '5:3',
-          width: 1000,
-          height: 600,
-        },
-      },
-      {
-        type: AssetType.IMAGE,
-        mimeType: 'image/jpeg',
-        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
-        typeData: {
-          aspectRatio: '5:3',
-          width: 500,
-          height: 300,
-        },
-      },
-      {
-        type: AssetType.IMAGE,
-        mimeType: 'image/jpeg',
-        file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
-        typeData: {
-          aspectRatio: '5:3',
-          width: 5512,
-          height: 3308,
-          isMaster: true,
-        },
-      },
-    ],
-    imageTypeData: {
-      caption:
-        'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-      copyright: 'LOUISE HAGGER',
-      displayCredit: true,
-      credit:
-        'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-      source:
-        'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-      alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-      mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-      mediaApiUri:
-        'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-      suppliersReference:
-        'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
-      imageType: 'Photograph',
-    },
-  },
+	{
+		type: ElementType.TEXT,
+		assets: [],
+		textTypeData: {
+			html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+		},
+	},
+	{
+		type: ElementType.IMAGE,
+		assets: [
+			{
+				type: AssetType.IMAGE,
+				mimeType: 'image/jpeg',
+				file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+				typeData: {
+					aspectRatio: '5:3',
+					width: 1000,
+					height: 600,
+				},
+			},
+			{
+				type: AssetType.IMAGE,
+				mimeType: 'image/jpeg',
+				file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+				typeData: {
+					aspectRatio: '5:3',
+					width: 500,
+					height: 300,
+				},
+			},
+			{
+				type: AssetType.IMAGE,
+				mimeType: 'image/jpeg',
+				file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+				typeData: {
+					aspectRatio: '5:3',
+					width: 5512,
+					height: 3308,
+					isMaster: true,
+				},
+			},
+		],
+		imageTypeData: {
+			caption:
+				'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+			copyright: 'LOUISE HAGGER',
+			displayCredit: true,
+			credit:
+				'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+			source:
+				'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+			alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+			mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+			mediaApiUri:
+				'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+			suppliersReference:
+				'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+			imageType: 'Photograph',
+		},
+	},
 ];
 
 export const invalidRecipeElements: BlockElement[] = [
-  {
-    type: ElementType.TEXT,
-    assets: [],
-    textTypeData: {
-      html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
-    },
-  },
-  {
-    type: ElementType.RECIPE,
-    assets: [],
-    recipeTypeData: {
-      recipeJson:
-        '{"canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[],"byline":"Thomasina Miers","ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
-    },
-  },
-  {
-    type: ElementType.IMAGE,
-    assets: [
-      {
-        type: AssetType.IMAGE,
-        mimeType: 'image/jpeg',
-        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
-        typeData: {
-          aspectRatio: '5:3',
-          width: 1000,
-          height: 600,
-        },
-      },
-      {
-        type: AssetType.IMAGE,
-        mimeType: 'image/jpeg',
-        file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
-        typeData: {
-          aspectRatio: '5:3',
-          width: 500,
-          height: 300,
-        },
-      },
-      {
-        type: AssetType.IMAGE,
-        mimeType: 'image/jpeg',
-        file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
-        typeData: {
-          aspectRatio: '5:3',
-          width: 5512,
-          height: 3308,
-          isMaster: true,
-        },
-      },
-    ],
-    imageTypeData: {
-      caption:
-        'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-      copyright: 'LOUISE HAGGER',
-      displayCredit: true,
-      credit:
-        'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-      source:
-        'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
-      alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
-      mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-      mediaApiUri:
-        'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
-      suppliersReference:
-        'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
-      imageType: 'Photograph',
-    },
-  },
+	{
+		type: ElementType.TEXT,
+		assets: [],
+		textTypeData: {
+			html: '<p>Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped. Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again. With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream. If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together. Toss the dressing through the salad and season to taste; it may need more lime juice. Scatter the sesame seeds on top and serve.</p> \n<p><strong>And for the rest of the week…</strong></p> \n<p>So long as it’s undressed and covered, the salad will keep in the crisper drawer for a few days. The dressing works well on all sorts of veg, from strips of red pepper to bean sprouts or sliced crisp turnips. And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.</p>',
+		},
+	},
+	{
+		type: ElementType.RECIPE,
+		assets: [],
+		recipeTypeData: {
+			recipeJson:
+				'{"canonicalArticle":"lifeandstyle/2018/jan/05/soba-noodle-salad-vegetables-spicy-sesame-dressing-recipe-thomasina-miers","title":"Soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing","featuredImage":"58c32a98ae4463b5129bf717b1b2312d8ffc0d45","contributors":[],"byline":"Thomasina Miers","ingredients":[{"recipeSection":"For the dressing","ingredientsList":[{"item":"soba","unit":"g","comment":"or glass noodles","text":"200g soba or glass noodles"},{"item":"frozen soya beans","unit":"g","comment":"","text":"50g frozen soya beans"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"1 tbsp sesame oil"},{"item":"carrots","unit":"","comment":"peeled then grated or cut into thin ribbons","text":"2 carrots, peeled, then grated or cut into thin ribbons"},{"item":"red cabbage","unit":"g","comment":"finely shredded","text":"150g red cabbage, finely shredded"},{"item":"mooli","unit":"g","comment":"or radishes cut into matchsticks or thin slivers","text":"100g mooli or radishes, cut into matchsticks or thin slivers"},{"item":"green apple","unit":"","comment":"","text":"1 green apple"},{"item":"spring onions","unit":"","comment":"finely sliced","text":"3 spring onions, finely sliced"},{"item":"coriander","unit":"small bunch","comment":"roughly chopped","text":"1 small bunch coriander, roughly chopped"},{"item":"mint leaves","unit":"handful","comment":"roughly torn","text":"1 handful mint leaves, roughly torn"},{"item":"basil leaves","unit":"handful","comment":"or more coriander roughly chopped","text":"1 handful basil leaves (or more coriander), roughly chopped"},{"item":"toasted sunflower seeds","unit":"g","comment":"","text":"40g toasted sunflower seeds"},{"item":"toasted sesame seeds","unit":"g","comment":"a mixture of black and white looks good to serve","text":"25g toasted sesame seeds (a mixture of black and white looks good), to serve"}]},{"recipeSection":"And for the rest of the week…","ingredientsList":[{"item":"fresh ginger","unit":"thumb","comment":"sized chunk  peeled","text":"1 thumb-sized chunk fresh ginger, peeled"},{"item":"garlic","unit":"clove","comment":"","text":"½ garlic clove"},{"item":"tahini","unit":"g","comment":"","text":"50g tahini"},{"item":"lime","unit":"","comment":"Juice of","text":"Juice of 1 lime"},{"item":"sriracha","unit":"tbsp","comment":"or your favourite style of chilli sauce","text":"1 tbsp sriracha (or your favourite style of chilli sauce)"},{"item":"bird’s","unit":"","comment":"eye chilli stalked removed optional","text":"1 bird’s-eye chilli, stalked removed (optional)"},{"item":"soy sauce","unit":"tbsp","comment":"","text":"1 tbsp soy sauce"},{"item":"demerara sugar","unit":"tbsp","comment":"","text":"1 tbsp demerara sugar"},{"item":"","unit":"","comment":"or honey","text":"(or honey)"},{"item":"sesame oil","unit":"tbsp","comment":"","text":"3 tbsp sesame oil"},{"item":"water","unit":"ml","comment":"","text":"25ml water"}]}],"suitableForDietIds":[],"cuisineIds":[],"mealTypeIds":[],"celebrationsIds":["summer-food-and-drink"],"utensilsAndApplianceIds":[],"techniquesUsedIds":[],"timings":[],"instructions":[{"stepNumber":0,"description":"Cook the noodles in boiling water according to the packet instructions, and add the soya beans for the final minute of cooking, to blanch.","images":[]},{"stepNumber":1,"description":"Drain and rinse under cold water until cool and no longer clumping together, then put in a large salad bowl and toss with a tablespoon of sesame oil to coat (this will help keep the noodles apart).","images":[]},{"stepNumber":2,"description":"Add the carrots, red cabbage and mooli or radishes to the bowl.","images":[]},{"stepNumber":3,"description":"Peel, core and finely shred the apple directly into the bowl, then add the spring onions and coriander.","images":[]},{"stepNumber":4,"description":"Add the picked herb leaves and pop the bowl in the fridge while you get on with the dressing (covered, if you’re not eating straight away).","images":[]},{"stepNumber":5,"description":"Roughly chop the ginger, put it in a food processor with the garlic and tahini, and blitz until finely chopped.","images":[]},{"stepNumber":6,"description":"Add the lime, sriracha, chilli (if using), soy sauce and sugar, and blitz again.","images":[]},{"stepNumber":7,"description":"With the motor running slowly, add the sesame oil bit by bit, followed by the water, and process until the dressing is the consistency of double cream.","images":[]},{"stepNumber":8,"description":"If the dressing looks as if it has split, put a tablespoon of tahini in a bowl, then slowly whisk in the split dressing – it should quickly come back together.","images":[]},{"stepNumber":9,"description":"Toss the dressing through the salad and season to taste; it may need more lime juice.","images":[]},{"stepNumber":10,"description":"Scatter the sesame seeds on top and serve.","images":[]},{"stepNumber":11,"description":"And if you want to add a meaty element, toss through some hot griddled strips of beef or pork tenderloin.","images":[]}]}',
+		},
+	},
+	{
+		type: ElementType.IMAGE,
+		assets: [
+			{
+				type: AssetType.IMAGE,
+				mimeType: 'image/jpeg',
+				file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/1000.jpg',
+				typeData: {
+					aspectRatio: '5:3',
+					width: 1000,
+					height: 600,
+				},
+			},
+			{
+				type: AssetType.IMAGE,
+				mimeType: 'image/jpeg',
+				file: 'https://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/500.jpg',
+				typeData: {
+					aspectRatio: '5:3',
+					width: 500,
+					height: 300,
+				},
+			},
+			{
+				type: AssetType.IMAGE,
+				mimeType: 'image/jpeg',
+				file: 'http://media.guim.co.uk/58c32a98ae4463b5129bf717b1b2312d8ffc0d45/0_318_5512_3308/master/5512.jpg',
+				typeData: {
+					aspectRatio: '5:3',
+					width: 5512,
+					height: 3308,
+					isMaster: true,
+				},
+			},
+		],
+		imageTypeData: {
+			caption:
+				'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+			copyright: 'LOUISE HAGGER',
+			displayCredit: true,
+			credit:
+				'Photograph: Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+			source:
+				'Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay',
+			alt: 'Thomasina Miers’ soba noodles with crisp rainbow vegetables and a spicy sesame seed dressing.',
+			mediaId: '58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+			mediaApiUri:
+				'https://api.media.gutools.co.uk/images/58c32a98ae4463b5129bf717b1b2312d8ffc0d45',
+			suppliersReference:
+				'Soba noodles with crisp rainbow vegetables and a spicy sesame se',
+			imageType: 'Photograph',
+		},
+	},
 ];
 
 export const activeSponsorships: Sponsorship[] = [
-  {
-    sponsorshipType: SponsorshipType.SPONSORED,
-    sponsorName: 'theguardian.org',
-    sponsorLogo:
-      'https://static.theguardian.com/commercial/sponsor/22/Feb/2024/f459c58b-6553-486d-939a-5f23fd935f78-Guardian.orglogos-for badge.png',
-    sponsorLink: 'https://theguardian.org/',
-    aboutLink:
-      'https://www.theguardian.com/global-development/2010/sep/14/about-this-site',
-    sponsorLogoDimensions: {
-      width: 280,
-      height: 180,
-    },
-    highContrastSponsorLogo:
-      'https://static.theguardian.com/commercial/sponsor/22/Feb/2024/3d8e52dc-1d0b-4f95-8cd1-48a674e1309d-guardian.org new logo - white version (3).png',
-    highContrastSponsorLogoDimensions: {
-      width: 280,
-      height: 180,
-    },
-    validFrom: makeCapiDateTime('2023-09-21T16:18:10Z'),
-    validTo: makeCapiDateTime('2026-08-30T23:00:00Z'),
-  },
+	{
+		sponsorshipType: SponsorshipType.SPONSORED,
+		sponsorName: 'theguardian.org',
+		sponsorLogo:
+			'https://static.theguardian.com/commercial/sponsor/22/Feb/2024/f459c58b-6553-486d-939a-5f23fd935f78-Guardian.orglogos-for badge.png',
+		sponsorLink: 'https://theguardian.org/',
+		aboutLink:
+			'https://www.theguardian.com/global-development/2010/sep/14/about-this-site',
+		sponsorLogoDimensions: {
+			width: 280,
+			height: 180,
+		},
+		highContrastSponsorLogo:
+			'https://static.theguardian.com/commercial/sponsor/22/Feb/2024/3d8e52dc-1d0b-4f95-8cd1-48a674e1309d-guardian.org new logo - white version (3).png',
+		highContrastSponsorLogoDimensions: {
+			width: 280,
+			height: 180,
+		},
+		validFrom: makeCapiDateTime('2023-09-21T16:18:10Z'),
+		validTo: makeCapiDateTime('2026-08-30T23:00:00Z'),
+	},
 ];
 
 export const recipeDates = {
-  lastModifiedDate: {
-    dateTime: new Int64(new Date('2024-09-10T16:18:10Z').getTime()),
-    iso8601: '2024-09-10T16:18:10Z',
-  },
-  firstPublishedDate: {
-    dateTime: new Int64(new Date('2024-09-02T10:04:16Z').getTime()),
-    iso8601: '2024-09-02T10:04:16Z',
-  },
-  publishedDate: {
-    dateTime: new Int64(new Date('2024-09-10T16:22:07Z').getTime()),
-    iso8601: '2023-09-10T16:22:07Z',
-  },
+	lastModifiedDate: {
+		dateTime: new Int64(new Date('2024-09-10T16:18:10Z').getTime()),
+		iso8601: '2024-09-10T16:18:10Z',
+	},
+	firstPublishedDate: {
+		dateTime: new Int64(new Date('2024-09-02T10:04:16Z').getTime()),
+		iso8601: '2024-09-02T10:04:16Z',
+	},
+	publishedDate: {
+		dateTime: new Int64(new Date('2024-09-10T16:22:07Z').getTime()),
+		iso8601: '2023-09-10T16:22:07Z',
+	},
 };
+
+export const fields = {
+	fields: {
+		firstPublicationDate: makeCapiDateTime('2024-09-03T11:05:17Z'),
+	},
+};
+
+export const nonFeastChannel = [
+	{
+		channelId: 'not-feast',
+		fields: {
+			isAvailable: true,
+			publicationDate: makeCapiDateTime('2024-09-17T11:00:26Z'),
+		},
+	},
+];
+
+export const feastChannel = [
+	{
+		channelId: 'feast',
+		fields: {
+			isAvailable: true,
+			publicationDate: makeCapiDateTime('2024-09-17T11:00:28Z'),
+		},
+	},
+];
+
+export const feastChannelNoDate: ContentChannel[] = [
+	{
+		channelId: 'feast',
+		fields: {
+			isAvailable: true,
+		},
+	},
+];

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -1,6 +1,5 @@
 import type {Sponsorship} from "@guardian/content-api-models/v1/sponsorship";
 import {SponsorshipType} from "@guardian/content-api-models/v1/sponsorshipType";
-import {formatISO} from "date-fns";
 import {FeaturedImageWidth, ImageDpr, PreviewImageWidth} from './config';
 import type {Contributor, RecipeDates, RecipeImage} from './models';
 import {extractCropDataFromGuimUrl} from './utils';

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -1,5 +1,6 @@
 import type {Sponsorship} from "@guardian/content-api-models/v1/sponsorship";
 import {SponsorshipType} from "@guardian/content-api-models/v1/sponsorshipType";
+import {formatISO} from "date-fns";
 import {FeaturedImageWidth, ImageDpr, PreviewImageWidth} from './config';
 import type {Contributor, RecipeImage} from './models';
 import {extractCropDataFromGuimUrl} from './utils';
@@ -67,6 +68,19 @@ export const addSponsorsTransform: (sponsors: Sponsorship[]) => RecipeTransforma
       }
     })
   })
+}
+
+export interface RecipeDates {
+  lastModified?: Date;
+  firstPublished?: Date;
+  published?: Date;
+}
+
+export const addPublicationDateTransform: (dates: RecipeDates) => RecipeTransformationFunction = dates => {
+  return (recipeData) => ({
+    ...recipeData,
+    publicationDate: formatISO(dates.published)
+  });
 }
 
 export const replaceCanonicalArticle: (

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -2,7 +2,7 @@ import type {Sponsorship} from "@guardian/content-api-models/v1/sponsorship";
 import {SponsorshipType} from "@guardian/content-api-models/v1/sponsorshipType";
 import {formatISO} from "date-fns";
 import {FeaturedImageWidth, ImageDpr, PreviewImageWidth} from './config';
-import type {Contributor, RecipeImage} from './models';
+import type {Contributor, RecipeDates, RecipeImage} from './models';
 import {extractCropDataFromGuimUrl} from './utils';
 
 export type RecipeTransformationFunction = (recipeData: Record<string, unknown>) => Record<string, unknown>;
@@ -70,16 +70,12 @@ export const addSponsorsTransform: (sponsors: Sponsorship[]) => RecipeTransforma
   })
 }
 
-export interface RecipeDates {
-  lastModified?: Date;
-  firstPublished?: Date;
-  published?: Date;
-}
-
-export const addPublicationDateTransform: (dates: RecipeDates) => RecipeTransformationFunction = dates => {
+export const addRecipeDatesTransform: (recipeDates: RecipeDates) => RecipeTransformationFunction = recipeDates => {
   return (recipeData) => ({
     ...recipeData,
-    publicationDate: formatISO(dates.published)
+    ...(recipeDates.lastModifiedDate && { lastModifiedDate: formatISO(recipeDates.lastModifiedDate) }),
+    ...(recipeDates.firstPublishedDate && { firstPublishedDate: formatISO(recipeDates.firstPublishedDate) }),
+    ...(recipeDates.publishedDate && { publishedDate: formatISO(recipeDates.publishedDate) }),
   });
 }
 

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -73,9 +73,9 @@ export const addSponsorsTransform: (sponsors: Sponsorship[]) => RecipeTransforma
 export const addRecipeDatesTransform: (recipeDates: RecipeDates) => RecipeTransformationFunction = recipeDates => {
   return (recipeData) => ({
     ...recipeData,
-    ...(recipeDates.lastModifiedDate && { lastModifiedDate: formatISO(recipeDates.lastModifiedDate) }),
-    ...(recipeDates.firstPublishedDate && { firstPublishedDate: formatISO(recipeDates.firstPublishedDate) }),
-    ...(recipeDates.publishedDate && { publishedDate: formatISO(recipeDates.publishedDate) }),
+    ...(recipeDates.lastModifiedDate && { lastModifiedDate: recipeDates.lastModifiedDate.toISOString() }),
+    ...(recipeDates.firstPublishedDate && { firstPublishedDate: recipeDates.firstPublishedDate.toISOString() }),
+    ...(recipeDates.publishedDate && { publishedDate: recipeDates.publishedDate.toISOString() }),
   });
 }
 

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -72,9 +72,9 @@ export const addSponsorsTransform: (sponsors: Sponsorship[]) => RecipeTransforma
 export const addRecipeDatesTransform: (recipeDates: RecipeDates) => RecipeTransformationFunction = recipeDates => {
   return (recipeData) => ({
     ...recipeData,
-    ...(recipeDates.lastModifiedDate && { lastModifiedDate: recipeDates.lastModifiedDate.toISOString() }),
-    ...(recipeDates.firstPublishedDate && { firstPublishedDate: recipeDates.firstPublishedDate.toISOString() }),
-    ...(recipeDates.publishedDate && { publishedDate: recipeDates.publishedDate.toISOString() }),
+    lastModifiedDate: recipeDates.lastModifiedDate ? recipeDates.lastModifiedDate.toISOString() : undefined,
+    firstPublishedDate: recipeDates.firstPublishedDate ? recipeDates.firstPublishedDate.toISOString() : undefined,
+    publishedDate: recipeDates.publishedDate ? recipeDates.publishedDate.toISOString() : undefined,
   });
 }
 

--- a/lib/recipes-data/src/lib/utils.test.ts
+++ b/lib/recipes-data/src/lib/utils.test.ts
@@ -1,5 +1,7 @@
+import type { CapiDateTime } from '@guardian/content-api-models/v1/capiDateTime';
 import type {RecipeReferenceWithoutChecksum} from './models';
-import {calculateChecksum, extractCropDataFromGuimUrl} from './utils';
+import {calculateChecksum, capiDateTimeToDate, extractCropDataFromGuimUrl} from './utils';
+import Int64 from 'node-int64';
 
 jest.mock('./config', () => ({}));
 
@@ -151,5 +153,20 @@ describe('extractCropIdFromGuimUrl', () => {
 
   it('should not give a crop id for a non-image URL', () => {
     expect(extractCropDataFromGuimUrl('https://google.com')).toBe(undefined);
+  });
+});
+
+describe('capiDateTimeToDate', () => {
+  it('should return undefined if the input is undefined', () => {
+    expect(capiDateTimeToDate(undefined)).toBe(undefined);
+  });
+
+  it('should return the date if the input is defined', () => {
+    const date = new Date();
+    const capiDateTime: CapiDateTime = {
+      dateTime: new Int64(date.getTime()),
+      iso8601: date.toISOString(),
+    };
+    expect(capiDateTimeToDate(capiDateTime)).toEqual(date);
   });
 });

--- a/lib/recipes-data/src/lib/utils.ts
+++ b/lib/recipes-data/src/lib/utils.ts
@@ -30,6 +30,13 @@ export function makeCapiDateTime(from: string): CapiDateTime {
   }
 }
 
+export function capiDateTimeToDate(date: CapiDateTime | undefined): Date | undefined {
+  if (!date) {
+    return undefined;
+  }
+  return new Date(date.dateTime.toNumber());
+}
+
 /**
  * Returns new Date().  Why? So we can mock it out easily in testing.
  */

--- a/lib/recipes-data/src/lib/utils.ts
+++ b/lib/recipes-data/src/lib/utils.ts
@@ -31,10 +31,7 @@ export function makeCapiDateTime(from: string): CapiDateTime {
 }
 
 export function capiDateTimeToDate(date: CapiDateTime | undefined): Date | undefined {
-  if (!date) {
-    return undefined;
-  }
-  return new Date(date.iso8601);
+  return date ? new Date(date.iso8601) : undefined
 }
 
 /**

--- a/lib/recipes-data/src/lib/utils.ts
+++ b/lib/recipes-data/src/lib/utils.ts
@@ -34,7 +34,7 @@ export function capiDateTimeToDate(date: CapiDateTime | undefined): Date | undef
   if (!date) {
     return undefined;
   }
-  return new Date(date.dateTime.toNumber());
+  return new Date(date.iso8601);
 }
 
 /**


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Extracts time data from the article and inserts into the recipe model, so that it can be used in the recipe search.  

It's currently unclear which time data will be most useful and so, for now, the following fields are being extracted:
- lastModifiedDate
- firstPublishedDate
- publishedDate

## How to test

Run `npm test` - tests pass

Deploy to CODE
Find a recipe article on the Guardian website and use `Teleporter | flexible composer | Management | View previous versions` to `Restore` the recipe to CODE
Access `recipe-responder` in ElasticSearch and filter to CODE - this will check it hasn't broken
Locate the DEBUG message with `urlToPurge` that does **not** relate to index.json, and extract the part of the url from `recipes.code` onwards
Append this to `https://` in a new browser window
View the output and check that the following have been populated:
- lastModifiedDate
- firstPublishedDate
- publishedDate

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
