### PR TITLE
Endpoint for batch resolve uids

### DIFF
--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -3,7 +3,7 @@ import {renderFile as ejs} from "ejs";
 import express from 'express';
 import type {Request} from 'express';
 import {deployCurationData, multipleRecipesByUid, recipeByUID, RecipeIndexEntry} from "@recipes-api/lib/recipes-data";
-import {getBodyContentAsJson, validateDateParam} from "./helpers";
+import {getBodyContentAsJson, recursivelyGetIdList, validateDateParam} from "./helpers";
 import {FeastAppContainer, Recipe} from "@recipes-api/lib/facia";
 
 export const app = express();
@@ -122,41 +122,6 @@ router.get('/api/content/by-uid/:recipeUID', (req: Request<RecipeIdParams>, resp
     resp.status(500).json({status: "error", detail: "there was an internal error fetching the recipe. See server-side logs."})
   });
 });
-
-function asyncTimeout(timeout:number) {
-  return new Promise((resolve)=>setTimeout(resolve, timeout));
-}
-
-async function recursivelyGetIdList(uidList:string[], prevResults: RecipeIndexEntry[], attempt?:number): Promise<RecipeIndexEntry[]> {
-  const batchSize = 50; //ok so this is finger-in-the-air
-  const maxAttempts = 10;
-
-  const toLookUp = uidList.slice(0, batchSize);
-  try {
-    const results = await multipleRecipesByUid(toLookUp);
-    if(toLookUp.length==uidList.length) { //we got everything
-      return prevResults.concat(results);
-    } else {
-      return recursivelyGetIdList(uidList.slice(batchSize), prevResults.concat(results), 0)
-    }
-  } catch(err) {
-    //FIXME doh how to properly detect ThroughputException?
-    console.warn(err);
-    if(err.toString().includes("ProvisionedThroughputException")) {
-      const nextAttempt = attempt ? attempt + 1 : 1;
-      if(nextAttempt>maxAttempts) {
-        console.error(`Unable to make request after ${maxAttempts} attempts, giving up`);
-        throw err;
-      }
-
-      console.warn(`Attempt ${nextAttempt} - caught ProvisionedThroughputException`);
-      await asyncTimeout(100 + (20**nextAttempt));
-      return recursivelyGetIdList(uidList, prevResults, nextAttempt);
-    } else {
-      throw err;
-    }
-  }
-}
 
 router.get('/api/content/by-uid', (req, resp) => {
   const idListParam = req.query["ids"] as string | undefined;

--- a/lambda/rest-endpoints/src/helpers.test.ts
+++ b/lambda/rest-endpoints/src/helpers.test.ts
@@ -1,6 +1,7 @@
+import {ProvisionedThroughputExceededException} from "@aws-sdk/client-dynamodb";
 import {v4 as uuid} from "uuid";
-import {getBodyContentAsJson, recursivelyGetIdList, validateDateParam} from "./helpers";
 import {multipleRecipesByUid} from "@recipes-api/lib/recipes-data";
+import {getBodyContentAsJson, recursivelyGetIdList, validateDateParam} from "./helpers";
 
 jest.mock("./config");
 jest.mock("@recipes-api/lib/recipes-data");
@@ -74,5 +75,34 @@ describe("app.recursivelyGetIdList", ()=>{
     expect(results.map(e=>e.recipeUID)).toEqual(uidList);
     //we expect there to have been 3 parallel batches
     expect((multipleRecipesByUid as jest.Mock).mock.calls.length).toEqual(3);
+  });
+
+  it("should retry if ProvisionedThroughputExceeded is caught", async ()=>{
+    (multipleRecipesByUid as jest.Mock).mockImplementation((idList:string[])=>{
+      const shouldCrash = Math.random();
+      if(shouldCrash<0.05) {
+        // @ts-ignore -- $metadata should not be null, but we are not reading it anyway
+        throw new ProvisionedThroughputExceededException({$metadata: null, message: "This is a test"})
+      } else {
+        return idList.map((uuid) => ({
+          checksum: `cs-for-${uuid}`,
+          recipeUID: uuid,
+          capiArticleId: `article-for-${uuid}`,
+          sponsorshipCount: 0
+        }))
+      }
+    });
+
+    const uidList:string[] = [];
+
+    for(let i=0; i<120; i++) {
+      uidList.push(uuid());
+    }
+
+    const results = await recursivelyGetIdList(uidList, []);
+    expect(results.length).toEqual(120);
+    expect(results.map(e=>e.recipeUID)).toEqual(uidList);
+    //we expect there to have been 3 parallel batches
+    expect((multipleRecipesByUid as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(3);
   })
 })

--- a/lambda/rest-endpoints/src/helpers.ts
+++ b/lambda/rest-endpoints/src/helpers.ts
@@ -51,7 +51,6 @@ export async function recursivelyGetIdList(uidList:string[], prevResults: Recipe
       return recursivelyGetIdList(uidList.slice(batchSize), prevResults.concat(results), 0)
     }
   } catch(err) {
-    //FIXME doh how to properly detect ThroughputException?
     console.warn(err);
     if(err instanceof ProvisionedThroughputExceededException) {
       const nextAttempt = attempt ? attempt + 1 : 1;

--- a/lambda/rest-endpoints/src/helpers.ts
+++ b/lambda/rest-endpoints/src/helpers.ts
@@ -1,5 +1,6 @@
 import type { RecipeIndexEntry} from "@recipes-api/lib/recipes-data";
 import {multipleRecipesByUid} from "@recipes-api/lib/recipes-data";
+import {ProvisionedThroughputExceededException} from "@aws-sdk/client-dynamodb";
 
 export function getBodyContentAsJson(body:unknown): string {
   if(body instanceof Buffer) {
@@ -52,7 +53,7 @@ export async function recursivelyGetIdList(uidList:string[], prevResults: Recipe
   } catch(err) {
     //FIXME doh how to properly detect ThroughputException?
     console.warn(err);
-    if(err.toString().includes("ProvisionedThroughputException")) {
+    if(err instanceof ProvisionedThroughputExceededException) {
       const nextAttempt = attempt ? attempt + 1 : 1;
       if(nextAttempt>maxAttempts) {
         console.error(`Unable to make request after ${maxAttempts} attempts, giving up`);

--- a/lambda/rest-endpoints/src/helpers.ts
+++ b/lambda/rest-endpoints/src/helpers.ts
@@ -1,3 +1,6 @@
+import type { RecipeIndexEntry} from "@recipes-api/lib/recipes-data";
+import {multipleRecipesByUid} from "@recipes-api/lib/recipes-data";
+
 export function getBodyContentAsJson(body:unknown): string {
   if(body instanceof Buffer) {
     return body.toString('utf-8')
@@ -27,5 +30,40 @@ export function validateDateParam(dateParam:string):Date|null {
     if(day<1 || day>31) throw new Error("Invalid number of days");
 
     return new Date(year,month-1,day);
+  }
+}
+
+function asyncTimeout(timeout:number) {
+  return new Promise((resolve)=>setTimeout(resolve, timeout));
+}
+
+export async function recursivelyGetIdList(uidList:string[], prevResults: RecipeIndexEntry[], attempt?:number): Promise<RecipeIndexEntry[]> {
+  const batchSize = 50; //ok so this is finger-in-the-air
+  const maxAttempts = 10;
+
+  const toLookUp = uidList.slice(0, batchSize);
+  try {
+    const results = await multipleRecipesByUid(toLookUp);
+    if(toLookUp.length==uidList.length) { //we got everything
+      return prevResults.concat(results);
+    } else {
+      return recursivelyGetIdList(uidList.slice(batchSize), prevResults.concat(results), 0)
+    }
+  } catch(err) {
+    //FIXME doh how to properly detect ThroughputException?
+    console.warn(err);
+    if(err.toString().includes("ProvisionedThroughputException")) {
+      const nextAttempt = attempt ? attempt + 1 : 1;
+      if(nextAttempt>maxAttempts) {
+        console.error(`Unable to make request after ${maxAttempts} attempts, giving up`);
+        throw err;
+      }
+
+      console.warn(`Attempt ${nextAttempt} - caught ProvisionedThroughputException`);
+      await asyncTimeout(100 + (20**nextAttempt));
+      return recursivelyGetIdList(uidList, prevResults, nextAttempt);
+    } else {
+      throw err;
+    }
   }
 }

--- a/lib/recipes-data/src/lib/config.ts
+++ b/lib/recipes-data/src/lib/config.ts
@@ -20,7 +20,11 @@ export function mandatoryParameter(name:string):string {
   if(process.env[name]) {
     return process.env[name] as string;
   } else {
-    throw new Error(`You need to define the environment variable ${name} in the lambda config`)
+    if(process.env["CI"]) {
+      return "test"
+    } else {
+      throw new Error(`You need to define the environment variable ${name} in the lambda config`)
+    }
   }
 }
 

--- a/lib/recipes-data/src/lib/dynamo.ts
+++ b/lib/recipes-data/src/lib/dynamo.ts
@@ -75,6 +75,17 @@ export async function recipeByUID(recipeUID: string): Promise<RecipeIndexEntry |
   return response.Items && response.Items.length > 0 ? RecipeIndexEntryFromDynamo(response.Items[0]) : null
 }
 
+export async function multipleRecipesByUid(uidList: string[]): Promise<RecipeIndexEntry[]> {
+  console.debug(`Lookup request for ${uidList.length} ids`);
+
+  const results = await Promise.all(
+    uidList.map(recipeByUID)
+  );
+
+  //Filter out any "not found"
+  return results.filter(result=>!!result) as RecipeIndexEntry[];
+}
+
 /**
  * Remove a single recipe from the index.
  *

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "update-cdk": "nx run cdk:update",
     "build": "nx run-many --target=build --skip-nx-cache",
-    "test": "nx run-many --target=test",
+    "test": "CONTENT_URL_BASE=fake-base STATIC_BUCKET=fake-bucket nx run-many --target=test",
     "lint": "nx run-many --target=lint",
     "manual-takedown": "nx run tools-manual-takedown:run",
     "commandline-reindex": "nx run lambda-recipes-responder:commandline-reindex -- ",


### PR DESCRIPTION
## What does this change?

Adds a new endpoint that resolves recipe immutable IDs to index entries in bulk

**GET** /api/content/by-uid?ids=id-1,id-2,id-3,id-4

### Note

You should check the Fastly CDN settings when deploying this, as there are a couple of bugs which can cause the GET parameters on the request to be lost in transit.

1. Under "Hosts", the static backend has a condition called `IF Is not API`. The first part of this must read `! (req.url.path ~ "^/prod/api" `, NOT `! (req.url.path ~ "^/api" `
2. Under "VCL Snippets", the snipped called `Protected S3 Access` might need editing.  After the variable setup is an `if` statement which acts as a "master switch".  This must contain the directive ` && !(req.url.path ~ "/api")` in order for the parameters to be passed correctly. Note that it is `/api` NOT `/prod/api` as it is applied higher in the configuration than the rewrite for api path

## How to test

- Deploy to CODE and check CDN settings as above
- Grab some valid UUIDs from the CODE environment: 
```bash
curl https://recipes.code.dev-guardianapis.com/v2/index.json | jq -r '.recipes[].recipeUID' | head -n 5
```
- Build a GET request to the endpoint as above
- Remember to send your recipes API key in the `X-Api-Key` header. You can obtain this from the "recipes-backend-CODE" Usage Plan in the API Gateway console
- You should see a result like this:
```json
{
    "status": "ok",
    "resolved": 3,
    "requested": 3,
    "results": [
        {
            "checksum": "xyKmLw49Ro-tKGTioDqN-h4a_vgmbkchcvKq_hmoB8A",
            "recipeUID": "3f3410b0edae470abb76f5f48c02e8f4",
            "capiArticleId": "food/2021/aug/23/thomasina-miers-recipe-summer-tomato-tagliatelle-toasted-walnut-nduja-pesto",
            "sponsorshipCount": 0
        },
        {
            "checksum": "eKcNovgTsLfiXN9YLa13mXa3cs4O4oc5mg0YNbmMvKE",
            "recipeUID": "d90776464018f0515e6cf979790e446d14588413",
            "capiArticleId": "lifeandstyle/wordofmouth/2011/jan/20/how-make-perfect-orange-marmalade",
            "sponsorshipCount": 0
        },
        {
            "checksum": "5FoOLlNf2x_QNm5JE-f9nrDldhkgrilYzp4CFeYlznQ",
            "recipeUID": "37f0b96a9e8f2be46c5b70a2e58425b17c6f0a89",
            "capiArticleId": "lifeandstyle/2017/dec/08/christmas-cocktail-recipes-hawksmoor-hot-doddy-shaky-pete-gin-sherry",
            "sponsorshipCount": 0
        }
    ]
}
```
- Remove a character from one of the IDs and request again. You should see that the corresponding index entry disappears from the response and the `resolved` count drops.  The intention is that a client can see that one more more IDs is not valid by comparing the counts and if they are not equal should compare the list of returned `recipeUID` entries to the requested IDs if it needs to find the invalid ones

## How can we measure success?

Fronts tool is able to translate UUIDs to checksums more easily

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
