### PR TITLE
Improve the wording of the publication message

### DIFF
--- a/lambda/facia-responder/src/main.test.ts
+++ b/lambda/facia-responder/src/main.test.ts
@@ -72,7 +72,7 @@ describe('main', () => {
 		expect(notifyFaciaToolMock.mock.calls[0][0]).toMatchObject({
 			edition: 'feast-northern-hemisphere',
 			issueDate: '2024-01-02',
-			message: 'This issue has been published',
+			message: "This issue has been published but its date is in the past so it can only be seen in the Fronts Preview tool",
 			status: 'Published',
 			version: 'v1',
 		});

--- a/lambda/facia-responder/src/main.ts
+++ b/lambda/facia-responder/src/main.ts
@@ -4,7 +4,7 @@ import type { SNSMessage, SQSHandler, SQSRecord } from 'aws-lambda';
 import format from 'date-fns/format';
 import type { SafeParseReturnType } from 'zod';
 import { notifyFaciaTool } from './facia-notifications';
-import { getErrorMessage } from './util';
+import {generatePublicationMessage, getErrorMessage} from './util';
 
 function getMessageBodyAsObject(from: SQSRecord): unknown {
 	const parsedSNSMessage = JSON.parse(from.body) as SNSMessage; // will throw if the content is not valid;
@@ -92,7 +92,7 @@ export const handler: SQSHandler = async (event) => {
 				issueDate,
 				version,
 				status: 'Published',
-				message: 'This issue has been published',
+				message: generatePublicationMessage(issueDate),
 				timestamp: Date.now(),
 			});
 		} catch (e) {

--- a/lambda/facia-responder/src/util.test.ts
+++ b/lambda/facia-responder/src/util.test.ts
@@ -1,0 +1,16 @@
+import format from "date-fns/format";
+import {generatePublicationMessage} from "./util";
+
+describe("generatePublicationMessage", ()=>{
+  it("should generate a different message if the issueDate is today", ()=>{
+    const nowTime = new Date();
+    const formattedDateToday = format(nowTime, "yyyy-MM-dd");
+    const result = generatePublicationMessage(formattedDateToday);
+    expect(result).toEqual("This issue has been published and should be live in the app imminently");
+  });
+
+  it("should include the issue date if the issueDate is not today", ()=>{
+    const result = generatePublicationMessage("2023-02-10");
+    expect(result).toContain("Fri, 6th Feb 2023")
+  })
+})

--- a/lambda/facia-responder/src/util.test.ts
+++ b/lambda/facia-responder/src/util.test.ts
@@ -10,7 +10,12 @@ describe("generatePublicationMessage", ()=>{
   });
 
   it("should include the issue date if the issueDate is not today", ()=>{
-    const result = generatePublicationMessage("2023-02-10");
+    const result = generatePublicationMessage("2023-02-10", new Date(2023, 1, 1));
     expect(result).toContain("Fri, 6th Feb 2023")
-  })
+  });
+
+  it("should warn if the issue date is in the past", ()=>{
+    const result = generatePublicationMessage("2023-02-10", new Date(2024, 1, 1));
+    expect(result).toContain("This issue has been published but its date is in the past so it can only be seen in the Fronts Preview tool")
+  });
 })

--- a/lambda/facia-responder/src/util.test.ts
+++ b/lambda/facia-responder/src/util.test.ts
@@ -11,7 +11,7 @@ describe("generatePublicationMessage", ()=>{
 
   it("should include the issue date if the issueDate is not today", ()=>{
     const result = generatePublicationMessage("2023-02-10", new Date(2023, 1, 1));
-    expect(result).toContain("Fri, 6th Feb 2023")
+    expect(result).toContain("Fri, 10th Feb 2023")
   });
 
   it("should warn if the issue date is in the past", ()=>{

--- a/lambda/facia-responder/src/util.ts
+++ b/lambda/facia-responder/src/util.ts
@@ -1,4 +1,27 @@
+import format from "date-fns/format";
+import {parse} from "date-fns";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- this function must handle an any type
 export const getErrorMessage = (e: any) =>
 	e instanceof Error ? e.message : String(e);
+
+function fancifyIssueDate(issueDate:string) {
+  try {
+    const parsed = parse(issueDate, "yyyy-MM-dd", new Date());
+    return format(parsed, "eee, eo MMM yyyy")
+  } catch(err) {
+    console.error(err);
+    return "(invalid date)"
+  }
+}
+
+export function generatePublicationMessage(issueDate:string) {
+  const nowTime = new Date();
+  const formattedDateToday = format(nowTime, "yyyy-MM-dd");
+
+  if(formattedDateToday==issueDate) {
+    return "This issue has been published and should be live in the app imminently"
+  } else {
+    return `This issue has been published and will launch after midnight GMT on ${fancifyIssueDate(issueDate)}`;
+  }
+}

--- a/lambda/facia-responder/src/util.ts
+++ b/lambda/facia-responder/src/util.ts
@@ -1,27 +1,24 @@
-import format from "date-fns/format";
-import {parse} from "date-fns";
+import {format, isAfter, parse} from "date-fns";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- this function must handle an any type
 export const getErrorMessage = (e: any) =>
 	e instanceof Error ? e.message : String(e);
 
-function fancifyIssueDate(issueDate:string) {
-  try {
-    const parsed = parse(issueDate, "yyyy-MM-dd", new Date());
-    return format(parsed, "eee, eo MMM yyyy")
-  } catch(err) {
-    console.error(err);
-    return "(invalid date)"
-  }
+function fancifyIssueDate(issueDate:Date) {
+    return format(issueDate, "eee, eo MMM yyyy")
 }
 
-export function generatePublicationMessage(issueDate:string) {
-  const nowTime = new Date();
+export function generatePublicationMessage(issueDate:string, overrideDate?: Date) {
+  const nowTime = overrideDate ??  new Date();
   const formattedDateToday = format(nowTime, "yyyy-MM-dd");
+
+  const parsedIssueDate = parse(issueDate, "yyyy-MM-dd", new Date());
 
   if(formattedDateToday==issueDate) {
     return "This issue has been published and should be live in the app imminently"
+  } else if(isAfter(parsedIssueDate, nowTime)) {
+    return `This issue has been published and will launch after midnight GMT on ${fancifyIssueDate(parsedIssueDate)}`;
   } else {
-    return `This issue has been published and will launch after midnight GMT on ${fancifyIssueDate(issueDate)}`;
+    return `This issue has been published but its date is in the past so it can only be seen in the Fronts Preview tool`
   }
 }

--- a/lambda/facia-responder/src/util.ts
+++ b/lambda/facia-responder/src/util.ts
@@ -5,7 +5,7 @@ export const getErrorMessage = (e: any) =>
 	e instanceof Error ? e.message : String(e);
 
 function fancifyIssueDate(issueDate:Date) {
-    return format(issueDate, "eee, eo MMM yyyy")
+    return format(issueDate, "eee, do MMM yyyy")
 }
 
 export function generatePublicationMessage(issueDate:string, overrideDate?: Date) {


### PR DESCRIPTION
## What does this change?

The publication message we generate here is shown to users in the Fronts tool once publication is complete:

![Screenshot 2024-09-18 at 18 19 18](https://github.com/user-attachments/assets/708c0d9d-d659-4594-b203-49c3e37a4cbe)

At the moment it's fairly generic and does not tell use user what to expect.

This PR updates the message to tell them:
- if the issue date is today, that it should be live immediately
- if the issue date is in the future, which day it will go live
- if the issue date is in the past, that it can be seen in the fronts preview tool but will never actually be made live

## How to test

- Deploy to CODE
- Open the Northern Hemisphere / 18th Sep 2024 front (or generate your own with the new script 😀 )
- Publish it. See the message
- If you're particularly keen, generate some future ones to see that message too

## How can we measure success?

Slightly nicer UX
