### PR TITLE
Update Readme to reflect correct argument for recipeId

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ You need to have a large number of environment variables set for the tools to wo
 
 1. Get CAPI credentials from Janus. You'll need the AWS commandline, and `jq` utility, installed; but you should have these already.
 2. Run `STAGE=CODE ./get-local-config.sh` to generate the file `environ-CODE`. Substitute PROD for CODE to get setup for the Production environment (but be careful!)
-   - I'd recommend deleting the file once you're done with it.
+
+- I'd recommend deleting the file once you're done with it.
+
 3. It goes without saying that these environ files should NEVER be committed to the repo. They are gitignored, but still... don't do it.
 4. Once you have the file, run `source environ-CODE` to set up the environment variables you need to target the CODE environment.
 5. You can now run the tools outlined below.
@@ -27,7 +29,7 @@ For a tighter feedback loop, run individual projects or files, and watch, with `
 ## How do I re-index content from CAPI out to Feast?
 
 1. Set up for local operations, as above
-2. Run `npm run commandline-reindex -- [--composer-id 1234567] [--capi-uri path/to/article/in/capi] [--recipe-uid 0551534c8d93e8da7bb70553b10fa0d0f62534a3]`
+2. Run `npm run commandline-reindex -- [--composerId 1234567] [--capiUri path/to/article/in/capi] [--recipeUid 0551534c8d93e8da7bb70553b10fa0d0f62534a3]`
 
 Note that Content API publishes _articles_, wheras we publish _recipes_. There may well be more than one recipe in an article. This command will therefore
 re-publish _every_ recipe from the given article; it may well change the SHA value (mutable ID) of some of the recipes. The index will be updated to respect this;
@@ -35,11 +37,11 @@ it's necessary so that the client app knows that the content has changed.
 
 You must specify exactly one of the three optional arguments above.
 
-- `--composer-id` is the composer ID of an article to re-index. This can be found in the `internalComposerCode` field in CAPI or at the end of a Composer URL (when
+- `--composerId` is the composer ID of an article to re-index. This can be found in the `internalComposerCode` field in CAPI or at the end of a Composer URL (when
   editing a piece of content, the address your browser shows is `/content/{composer-id}`).
-- `--capi-uri` is the path under which the content can be found in CAPI. It's OK to use either the full URI or the path. Normally this is the same as the URL
+- `--capiUri` is the path under which the content can be found in CAPI. It's OK to use either the full URI or the path. Normally this is the same as the URL
   path under which the content can be found on the website.
-- `--recipe-uid` is an immutable recipe id (UUID) from the Feast app. This can be found in the index.json or at the bottom of a recipe in the feast app when you
+- `--recipeUid` is an immutable recipe id (UUID) from the Feast app. This can be found in the index.json or at the bottom of a recipe in the feast app when you
   have Developer Mode turned on.
 
 When this command is run, the normal publication process will be performed on your local machine. New content will be published, the index updated and the


### PR DESCRIPTION
## What does this change?

Their was a requirement came up by iOS devs to reindex a recipe. @paulmr and I tried running locally the script as mentioned in Readme and provided recipe id which ended up in an. error `TypeError [ERR_PARSE_ARGS_UNKNOWN_OPTION]: Unknown option '--recipe-uid'`

We found in the script that actually argument is `recipeUid` and not `recipe-uid` and hence changed it to make it work.

## How to test

Command should run without any error on recipe id.

## How can we measure success?

re index should run
