### PR TITLE
fix: Make re-indexing script more fault tolerant

### DIFF
--- a/lambda/recipes-responder/src/commandline-reindex.ts
+++ b/lambda/recipes-responder/src/commandline-reindex.ts
@@ -79,7 +79,8 @@ async function reindex(queryUri: string): Promise<void> {
 			}
 			break;
 		default:
-			throw new Error(`Unable to retrieve content from ${queryUri}`);
+			console.error(`Unable to retrieve content from ${queryUri}`);
+      await new Promise((resolve)=>setTimeout(resolve, 2000))
 	}
 }
 


### PR DESCRIPTION
## What does this change?

While re-indexing I came across a recipe in the index whose CAPI page did not resolve any more. This broke the entire re-index; so I made the error non-fatal.

It logs out an error then pauses for a couple of seconds so you can read it.

*Aside* - this is a rubbish way to re-index now we are properly in production. There is a card to do this properly.

## How to test

No need, I tested it already while making the PROD reindex work.

## How can we measure success?

Able to re-index properly

## Have we considered potential risks?

n/a at present. We should consider how to handle these cases better when we implement the improved re-indexing procedure
