### PR TITLE
Supply a cache of information about contributor profiles to the app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,3 +60,5 @@ jobs:
               - dist/lambda/recipes-reindex.zip
             dynamic-fronts-fetcher:
               - dist/lambda/dynamic-fronts-fetcher.zip
+            recipes-publish-contributor-information:
+              - dist/lambda/profile-cache-rebuild.zip

--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ inherent in checking for them. Furthermore, it's important the the app can work 
 
 ### Why no search API?
 
-Because it's not (yet) a client requirement. At the time of writing, the desire is to do all searching client-side because the app feature-set is very much up in the air.
-
-This may be revisited in future.
+The data here is for _retrieval_ only; search is a seperate concern which is implemented at https://github.com/guardian/recipe-search-backend.  This is because the search
+uses a different tech stack to do advanced semantic search wheras the code here is only concerned with pushing the recipe data into a place where it can
+easily be retrieved.
 
 ### Auth
 
@@ -168,6 +168,20 @@ Endpoints which require authentication use [API Gateway API keys](https://eu-wes
 
 This is the lambda function which listens to Kinesis updates from crier. It is responsible for all of the processing and extraction logic, although
 most of the actual logic lives in the library code imported into it
+
+### lambda/facia-responder
+
+This lambda function responds to curation updates from the Fronts Tool (aka Facia) and publishes them for the Feast app as well as updating Facia with the
+publication status
+
+### lambda/publish-todays-curation
+
+This lambda function runs once a day to take that day's curation from the dated folders where it is stored and copy it to the "current" curation.  It's
+also triggered by S3 when a new curation data json is written to dated folders; if the date is todays then it is published immediately
+
+### lambda/profile-cache-rebuild
+
+This lambda function is run hourly to update a mapping cache of {tag-id}->{contributor info} at `v2/contributors.json`
 
 ### lambda/test-indexbuild
 

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -22,6 +22,7 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuScheduledLambda",
+      "GuScheduledLambda",
       "GuLambdaFunction",
       "GuParameter",
     ],
@@ -1484,6 +1485,305 @@ def sort_filter_rules(json_obj):
         },
       },
       "Type": "AWS::ApiGateway::Resource",
+    },
+    "PublishContributors7FDDEA0E": {
+      "DependsOn": [
+        "PublishContributorsServiceRoleDefaultPolicyEEA7218F",
+        "PublishContributorsServiceRole5EFC8614",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "feast/TEST/recipes-publish-contributor-information/profile-cache-rebuild.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "recipes-publish-contributor-information",
+            "BASE_URL": "recipes.guardianapis.com",
+            "CAPI_BASE_URL": "content.guardianapis.com",
+            "FASTLY_API_KEY": {
+              "Ref": "fastlyKey",
+            },
+            "STACK": "feast",
+            "STAGE": "TEST",
+            "STATIC_BUCKET": {
+              "Ref": "staticstaticServing53194089",
+            },
+          },
+        },
+        "FunctionName": "PublishRecipeContributors-TEST",
+        "Handler": "main.handler",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 256,
+        "Role": {
+          "Fn::GetAtt": [
+            "PublishContributorsServiceRole5EFC8614",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "recipes-publish-contributor-information",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "PublishContributorsPublishContributorscron16089AD5627": {
+      "Properties": {
+        "Description": "Update cache of contributor information for Feast at 16 minutes past every hour",
+        "ScheduleExpression": "cron(16 * * * ? *)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "PublishContributors7FDDEA0E",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "PublishContributorsPublishContributorscron160AllowEventRuleRecipesBackendPublishContributorsE21492564767307C": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "PublishContributors7FDDEA0E",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "PublishContributorsPublishContributorscron16089AD5627",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "PublishContributorsServiceRole5EFC8614": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "recipes-publish-contributor-information",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "PublishContributorsServiceRoleDefaultPolicyEEA7218F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "*",
+              "Effect": "Deny",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "staticstaticServing53194089",
+                        "Arn",
+                      ],
+                    },
+                    "/content/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "staticstaticServing53194089",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/feast/TEST/recipes-publish-contributor-information/profile-cache-rebuild.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/feast/recipes-publish-contributor-information",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/feast/recipes-publish-contributor-information/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PublishContributorsServiceRoleDefaultPolicyEEA7218F",
+        "Roles": [
+          {
+            "Ref": "PublishContributorsServiceRole5EFC8614",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "PublishTodaysCuration6EFD9033": {
       "DependsOn": [

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1504,8 +1504,11 @@ def sort_filter_rules(json_obj):
         "Environment": {
           "Variables": {
             "APP": "recipes-publish-contributor-information",
-            "BASE_URL": "recipes.guardianapis.com",
             "CAPI_BASE_URL": "content.guardianapis.com",
+            "CAPI_KEY": {
+              "Ref": "capiKey",
+            },
+            "CONTENT_URL_BASE": "recipes.guardianapis.com",
             "FASTLY_API_KEY": {
               "Ref": "fastlyKey",
             },

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -374,8 +374,9 @@ export class RecipesBackend extends GuStack {
 			environment: {
 				STATIC_BUCKET: serving.staticBucket.bucketName,
 				FASTLY_API_KEY: fastlyKeyParam.valueAsString,
-				BASE_URL: contentUrlBase,
+				CONTENT_URL_BASE: contentUrlBase,
 				CAPI_BASE_URL: capiUrlBase,
+				CAPI_KEY: capiKeyParam.valueAsString,
 			},
 		});
 

--- a/lambda/profile-cache-rebuild/.eslintrc.json
+++ b/lambda/profile-cache-rebuild/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+	"extends": ["../../.eslintrc.json"],
+	"ignorePatterns": ["!**/*"],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}

--- a/lambda/profile-cache-rebuild/.eslintrc.json
+++ b/lambda/profile-cache-rebuild/.eslintrc.json
@@ -1,18 +1,70 @@
 {
-	"extends": ["../../.eslintrc.json"],
-	"ignorePatterns": ["!**/*"],
-	"overrides": [
-		{
-			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-			"rules": {}
-		},
-		{
-			"files": ["*.ts", "*.tsx"],
-			"rules": {}
-		},
-		{
-			"files": ["*.js", "*.jsx"],
-			"rules": {}
-		}
-	]
+  "extends": ["../../.eslintrc.json", "plugin:prettier/recommended"],
+  "ignorePatterns": ["!**/*", "jest.config.ts"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {
+        "prettier/prettier": "error"
+      }
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["lambda/profile-cache-rebuild/tsconfig.app.json"]
+      },
+      "rules": {
+        "prettier/prettier": "error"
+      }
+    },
+    {
+      "files": ["*.test.ts", "*.test.tsx"],
+      "parserOptions": {
+        "project": ["lambda/profile-cache-rebuild/tsconfig.spec.json"]
+      },
+      "rules": {
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/ban-ts-comment": "off",
+        "@typescript-eslint/prefer-ts-expect-error": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "prettier/prettier": "error"
+      }
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["lambda/profile-cache-rebuild/tsconfig.app.json"]
+      },
+      "rules": {}
+    },
+    {
+      "files": ["*.test.ts", "*.test.tsx"],
+      "parserOptions": {
+        "project": ["lambda/profile-cache-rebuild/tsconfig.spec.json"]
+      },
+      "rules": {
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/ban-ts-comment": "off",
+        "@typescript-eslint/prefer-ts-expect-error": "off",
+        "@typescript-eslint/no-unsafe-call": "off"
+      }
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {
+        "prettier/prettier": "error"
+      }
+    }
+  ],
+  "settings": {
+    "import/resolver": {
+      "typescript": {
+        "alwaysTryTypes": true,
+        "project": [
+          "lambda/profile-cache-rebuild/tsconfig.app.json",
+          "lambda/profile-cache-rebuild/tsconfig.spec.json"
+        ]
+      }
+    }
+  }
 }

--- a/lambda/profile-cache-rebuild/jest.config.ts
+++ b/lambda/profile-cache-rebuild/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+	displayName: 'lambda-profile-cache-rebuild',
+	preset: '../../jest.preset.js',
+	testEnvironment: 'node',
+	transform: {
+		'^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+	},
+	moduleFileExtensions: ['ts', 'js', 'html'],
+	coverageDirectory: '../../coverage/lambda/profile-cache-rebuild',
+};

--- a/lambda/profile-cache-rebuild/project.json
+++ b/lambda/profile-cache-rebuild/project.json
@@ -1,0 +1,91 @@
+{
+	"name": "lambda-profile-cache-rebuild",
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "lambda/profile-cache-rebuild/src",
+	"projectType": "application",
+	"targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["zip -r ../profile-cache-rebuild.zip *"],
+        "cwd": "dist/lambda/profile-cache-rebuild"
+      },
+      "dependsOn": [
+        {
+          "projects": "self",
+          "target": "transpile"
+        }
+      ]
+    },
+		"transpile": {
+			"executor": "@nx/esbuild:esbuild",
+			"outputs": ["{options.outputPath}"],
+			"defaultConfiguration": "production",
+			"options": {
+				"platform": "node",
+				"outputPath": "dist/lambda/profile-cache-rebuild",
+				"format": ["cjs"],
+				"bundle": true,
+				"main": "lambda/profile-cache-rebuild/src/main.ts",
+				"tsConfig": "lambda/profile-cache-rebuild/tsconfig.app.json",
+				"assets": [],
+				"generatePackageJson": true,
+        "thirdParty": true,
+				"esbuildOptions": {
+					"sourcemap": true,
+					"outExtension": {
+						".js": ".js"
+					}
+				}
+			},
+			"configurations": {
+				"development": {},
+				"production": {
+					"esbuildOptions": {
+						"sourcemap": false,
+						"outExtension": {
+							".js": ".js"
+						}
+					}
+				}
+			}
+		},
+		"serve": {
+			"executor": "@nx/js:node",
+			"defaultConfiguration": "development",
+			"options": {
+				"buildTarget": "lambda-profile-cache-rebuild:build"
+			},
+			"configurations": {
+				"development": {
+					"buildTarget": "lambda-profile-cache-rebuild:build:development"
+				},
+				"production": {
+					"buildTarget": "lambda-profile-cache-rebuild:build:production"
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": ["lambda/profile-cache-rebuild/**/*.ts"]
+			}
+		},
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "lambda/profile-cache-rebuild/jest.config.ts",
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		}
+	},
+	"tags": []
+}

--- a/lambda/profile-cache-rebuild/src/config.ts
+++ b/lambda/profile-cache-rebuild/src/config.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 
-export const recipes_base_url = process.env['BASE_URL'];
+export const recipes_base_url = process.env['CONTENT_URL_BASE'];
 if (!recipes_base_url) {
 	throw new Error(
 		'Misconfigured - BASE_URL must be set to the base URL of the recipes API',

--- a/lambda/profile-cache-rebuild/src/config.ts
+++ b/lambda/profile-cache-rebuild/src/config.ts
@@ -1,12 +1,16 @@
 import process from 'node:process';
 
-export const recipes_base_url = process.env['CONTENT_URL_BASE'];
+export const recipes_base_url = process.env['CONTENT_URL_BASE']
+	? 'https://' + process.env['CONTENT_URL_BASE']
+	: undefined;
 if (!recipes_base_url) {
 	throw new Error(
 		'Misconfigured - BASE_URL must be set to the base URL of the recipes API',
 	);
 }
-export const capi_base_url = process.env['CAPI_BASE_URL'];
+export const capi_base_url = process.env['CAPI_BASE_URL']
+	? 'https://' + process.env['CAPI_BASE_URL']
+	: undefined;
 if (!capi_base_url) {
 	throw new Error('Misconfigured - CAPI_BASE_URL must be set up');
 }

--- a/lambda/profile-cache-rebuild/src/config.ts
+++ b/lambda/profile-cache-rebuild/src/config.ts
@@ -1,0 +1,16 @@
+import process from 'node:process';
+
+export const recipes_base_url = process.env['BASE_URL'];
+if (!recipes_base_url) {
+	throw new Error(
+		'Misconfigured - BASE_URL must be set to the base URL of the recipes API',
+	);
+}
+export const capi_base_url = process.env['CAPI_BASE_URL'];
+if (!capi_base_url) {
+	throw new Error('Misconfigured - CAPI_BASE_URL must be set up');
+}
+export const capi_key = process.env['CAPI_KEY'];
+if (!capi_key) {
+	throw new Error('Misconfigured - CAPI_KEY must be set');
+}

--- a/lambda/profile-cache-rebuild/src/main.test.ts
+++ b/lambda/profile-cache-rebuild/src/main.test.ts
@@ -3,6 +3,8 @@ import { TagType } from '@guardian/content-api-models/v1/tagType';
 import type { ChefInfoFile } from '@recipes-api/lib/recipes-data';
 import { buildChefInfo } from './main';
 
+jest.mock('./config', () => ({}));
+
 describe('buildChefInfo', () => {
 	it('should build up a simplified structure from the data we provide', () => {
 		const incoming: Tag[] = [

--- a/lambda/profile-cache-rebuild/src/main.test.ts
+++ b/lambda/profile-cache-rebuild/src/main.test.ts
@@ -1,0 +1,51 @@
+import type { Tag } from '@guardian/content-api-models/v1/tag';
+import { TagType } from '@guardian/content-api-models/v1/tagType';
+import type { ChefInfoFile } from '@recipes-api/lib/recipes-data';
+import { buildChefInfo } from './main';
+
+describe('buildChefInfo', () => {
+	it('should build up a simplified structure from the data we provide', () => {
+		const incoming: Tag[] = [
+			{
+				id: 'tag/test1',
+				type: TagType.CONTRIBUTOR,
+				webTitle: 'Test one',
+				webUrl: 'webUrl',
+				apiUrl: 'apiUrl',
+				references: [],
+				bio: 'Some bio here',
+				bylineImageUrl: 'https://some-url',
+			},
+			{
+				id: 'tag/test2',
+				type: TagType.CONTRIBUTOR,
+				webTitle: 'Test two',
+				webUrl: 'webUrl',
+				apiUrl: 'apiUrl',
+				references: [],
+				bio: 'Some other bio here',
+				bylineImageUrl: 'https://some-different-url',
+				bylineLargeImageUrl: 'https://some-different-larger-url',
+			},
+		];
+
+		const expected: ChefInfoFile = {
+			'tag/test1': {
+				webTitle: 'Test one',
+				webUrl: 'webUrl',
+				apiUrl: 'apiUrl',
+				bio: 'Some bio here',
+				bylineImageUrl: 'https://some-url',
+			},
+			'tag/test2': {
+				webTitle: 'Test two',
+				webUrl: 'webUrl',
+				apiUrl: 'apiUrl',
+				bio: 'Some other bio here',
+				bylineImageUrl: 'https://some-different-url',
+				bylineLargeImageUrl: 'https://some-different-larger-url',
+			},
+		};
+		expect(buildChefInfo(incoming)).toEqual(expected);
+	});
+});

--- a/lambda/profile-cache-rebuild/src/main.ts
+++ b/lambda/profile-cache-rebuild/src/main.ts
@@ -1,0 +1,1 @@
+console.log('Hello World');

--- a/lambda/profile-cache-rebuild/src/main.ts
+++ b/lambda/profile-cache-rebuild/src/main.ts
@@ -38,4 +38,19 @@ export async function handler() {
 	console.log(`Chef info file has ${Object.keys(chef_info).length} entries`);
 
 	await writeChefData(chef_info, 'v2/contributors.json');
+
+	if (capi_tag_data.length != profile_tag_ids.length) {
+		console.warn('CAPI tags data does not exactly match recipes api data');
+
+		const capiChefList = Object.keys(chef_info);
+		const missingFromCapi = profile_tag_ids.filter(
+			(id) => !capiChefList.includes(id),
+		);
+
+		console.warn(
+			`CAPI is missing the following tags from the recipes api: ${JSON.stringify(
+				missingFromCapi,
+			)}`,
+		);
+	}
 }

--- a/lambda/profile-cache-rebuild/src/main.ts
+++ b/lambda/profile-cache-rebuild/src/main.ts
@@ -1,7 +1,12 @@
 import type { Tag } from '@guardian/content-api-models/v1/tag';
 import { fetchTagsById } from '@recipes-api/lib/capi';
 import type { ChefInfoFile } from '@recipes-api/lib/recipes-data';
-import { writeChefData } from '@recipes-api/lib/recipes-data';
+import {
+	getContentPrefix,
+	getFastlyApiKey,
+	getStaticBucketName,
+	writeChefData,
+} from '@recipes-api/lib/recipes-data';
 import { capi_base_url, capi_key, recipes_base_url } from './config';
 import { discover_profile_tags } from './recipe-search';
 
@@ -21,6 +26,10 @@ export function buildChefInfo(from: Tag[]): ChefInfoFile {
 }
 
 export async function handler() {
+	const BucketName = getStaticBucketName();
+	const contentPrefix = getContentPrefix();
+	const FastlyApiKey = getFastlyApiKey();
+
 	const profile_tag_ids = await discover_profile_tags(
 		recipes_base_url as string,
 	);
@@ -37,7 +46,13 @@ export async function handler() {
 	const chef_info = buildChefInfo(capi_tag_data);
 	console.log(`Chef info file has ${Object.keys(chef_info).length} entries`);
 
-	await writeChefData(chef_info, 'v2/contributors.json');
+	await writeChefData({
+		chefData: chef_info,
+		Key: 'v2/contributors.json',
+		BucketName,
+		FastlyApiKey,
+		contentPrefix,
+	});
 
 	if (capi_tag_data.length != profile_tag_ids.length) {
 		console.warn('CAPI tags data does not exactly match recipes api data');

--- a/lambda/profile-cache-rebuild/src/main.ts
+++ b/lambda/profile-cache-rebuild/src/main.ts
@@ -1,1 +1,41 @@
-console.log('Hello World');
+import type { Tag } from '@guardian/content-api-models/v1/tag';
+import { fetchTagsById } from '@recipes-api/lib/capi';
+import type { ChefInfoFile } from '@recipes-api/lib/recipes-data';
+import { writeChefData } from '@recipes-api/lib/recipes-data';
+import { capi_base_url, capi_key, recipes_base_url } from './config';
+import { discover_profile_tags } from './recipe-search';
+
+export function buildChefInfo(from: Tag[]): ChefInfoFile {
+	return from.reduce<ChefInfoFile>((prev: ChefInfoFile, current: Tag) => {
+		const id = current.id;
+		prev[id] = {
+			webTitle: current.webTitle,
+			webUrl: current.webUrl,
+			apiUrl: current.apiUrl,
+			bio: current.bio,
+			bylineImageUrl: current.bylineImageUrl,
+			bylineLargeImageUrl: current.bylineLargeImageUrl,
+		};
+		return prev;
+	}, {});
+}
+
+export async function handler() {
+	const profile_tag_ids = await discover_profile_tags(
+		recipes_base_url as string,
+	);
+
+	console.log(`Found ${profile_tag_ids.length} profile tags for chefs`);
+
+	const capi_tag_data = await fetchTagsById(
+		profile_tag_ids,
+		capi_base_url as string,
+		capi_key as string,
+	);
+
+	console.log(`CAPI returned information about ${capi_tag_data.length} tags`);
+	const chef_info = buildChefInfo(capi_tag_data);
+	console.log(`Chef info file has ${Object.keys(chef_info).length} entries`);
+
+	await writeChefData(chef_info, 'v2/contributors.json');
+}

--- a/lambda/profile-cache-rebuild/src/recipe-search.test.ts
+++ b/lambda/profile-cache-rebuild/src/recipe-search.test.ts
@@ -1,0 +1,13 @@
+import { discover_profile_tags } from './recipe-search';
+
+describe('discover_profile_tags', () => {
+	it('should call the recipe search backend and interpret the data', async () => {
+		const results = await discover_profile_tags(
+			'https://recipes.code.dev-guardianapis.com',
+		);
+
+		expect(results.length).toBeGreaterThan(10);
+		expect(results.includes('profile/yotamottolenghi')).toBeTruthy();
+		expect(results.includes('profile/nigelslater')).toBeTruthy();
+	});
+});

--- a/lambda/profile-cache-rebuild/src/recipe-search.ts
+++ b/lambda/profile-cache-rebuild/src/recipe-search.ts
@@ -1,0 +1,24 @@
+import { ContributorsReport } from './search-backend-schema';
+
+/**
+ * Calls the search backend to discover all of the profile tags. Ignores 'byline' type contributors
+ * @param baseUri base URI of the recipe search
+ */
+export async function discover_profile_tags(
+	baseUri: string,
+): Promise<string[]> {
+	const url = baseUri + '/keywords/contributors?limit=1000';
+	const content = await fetch(url);
+	if (content.status != 200) {
+		const contentBody = await content.text();
+		console.error(
+			`Recipe search backend returned ${content.status}: ${contentBody}`,
+		);
+		throw new Error('Unable to retrieve contributors from search backend');
+	}
+
+	const contributorsInfo = ContributorsReport.parse(await content.json());
+	return contributorsInfo.results
+		.filter((c) => c.contributorType === 'Profile')
+		.map((c) => c.nameOrId);
+}

--- a/lambda/profile-cache-rebuild/src/search-backend-schema.ts
+++ b/lambda/profile-cache-rebuild/src/search-backend-schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const ContributorInfo = z.object({
+	contributorType: z.enum(['Profile', 'Byline']),
+	nameOrId: z.string(),
+	docCount: z.number(),
+});
+
+export const ContributorsReport = z.object({
+	hits: z.number(),
+	results: z.array(ContributorInfo),
+});

--- a/lambda/profile-cache-rebuild/tsconfig.app.json
+++ b/lambda/profile-cache-rebuild/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"module": "commonjs",
+		"types": ["node"]
+	},
+	"exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+	"include": ["src/**/*.ts"]
+}

--- a/lambda/profile-cache-rebuild/tsconfig.json
+++ b/lambda/profile-cache-rebuild/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"files": [],
+	"include": [],
+	"references": [
+		{
+			"path": "./tsconfig.app.json"
+		},
+		{
+			"path": "./tsconfig.spec.json"
+		}
+	],
+	"compilerOptions": {
+		"esModuleInterop": true
+	}
+}

--- a/lambda/profile-cache-rebuild/tsconfig.spec.json
+++ b/lambda/profile-cache-rebuild/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"module": "commonjs",
+		"types": ["jest", "node"]
+	},
+	"include": [
+		"jest.config.ts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.ts",
+		"src/**/*.d.ts"
+	]
+}

--- a/lib/capi/src/index.ts
+++ b/lib/capi/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/capi';
 export * from './lib/deserialize';
+export * from './lib/capitags';

--- a/lib/capi/src/lib/capitags.test.ts
+++ b/lib/capi/src/lib/capitags.test.ts
@@ -15,7 +15,7 @@ describe('buildUriList', () => {
 			[],
 		);
 		expect(result).toEqual([
-			'https://content.guardianapis.com/tags?ids=profile%2Fperson-one%2Cprofile%2Fpersontwo%2Cprofile%2Fpersonthree-and-a-half&api-key=some-key',
+			'https://content.guardianapis.com/tags?ids=profile%2Fperson-one%2Cprofile%2Fpersontwo%2Cprofile%2Fpersonthree-and-a-half&api-key=some-key&page-size=50',
 		]);
 	});
 

--- a/lib/capi/src/lib/capitags.test.ts
+++ b/lib/capi/src/lib/capitags.test.ts
@@ -1,0 +1,62 @@
+import { buildUriList, URL_MAX } from './capitags';
+
+describe('buildUriList', () => {
+	it('should just return a shorter list', () => {
+		const list = [
+			'profile/person-one',
+			'profile/persontwo',
+			'profile/personthree-and-a-half',
+		];
+		const result = buildUriList(
+			list,
+			'https://content.guardianapis.com',
+			'some-key',
+			[],
+			[],
+		);
+		expect(result).toEqual([
+			'https://content.guardianapis.com/tags?ids=profile%2Fperson-one%2Cprofile%2Fpersontwo%2Cprofile%2Fpersonthree-and-a-half&api-key=some-key',
+		]);
+	});
+
+	it('should split a longer list into multiple uris', () => {
+		const list: string[] = [];
+		for (let i = 0; i < 2048; i++) {
+			list[i] = i.toString();
+		}
+
+		const result = buildUriList(
+			list,
+			'https://content.guardianapis.com',
+			'some-key',
+			[],
+			[],
+		);
+
+		expect(result.length).toBeGreaterThan(1);
+
+		//Now parse the IDs back out and check that we got the same numbers that went in
+		let sentList: string[] = [];
+		const xtractor = /ids=([^&]+)/;
+		for (const uri of result) {
+			const parts = xtractor.exec(uri);
+			if (parts) {
+				const idList = decodeURIComponent(parts[1]).split(',');
+				sentList = sentList.concat(...idList);
+			}
+		}
+		for (const incomingId of list) {
+			if (!sentList.includes(incomingId)) {
+				console.log(
+					`Should have sent a request for id ${incomingId} but it was not found`,
+				);
+			}
+		}
+
+		expect(sentList.length).toEqual(list.length);
+
+		for (const url of result) {
+			expect(url.length).toBeLessThan(URL_MAX);
+		}
+	});
+});

--- a/lib/capi/src/lib/capitags.ts
+++ b/lib/capi/src/lib/capitags.ts
@@ -1,8 +1,4 @@
 import type { Tag } from '@guardian/content-api-models/v1/tag';
-import {
-	TagsResponse,
-	TagsResponseSerde,
-} from '@guardian/content-api-models/v1/tagsResponse';
 import { deserialzeTagsResponse } from './deserialize';
 
 export const URL_MAX = 2048;

--- a/lib/capi/src/lib/capitags.ts
+++ b/lib/capi/src/lib/capitags.ts
@@ -29,8 +29,11 @@ export function buildUriList(
 	}
 
 	const joinedIdList = encodeURIComponent(tagIdList.join(','));
-	const testUri = `${capiBaseUrl}/tags?ids=${joinedIdList}&api-key=${capiKey}`;
-	if (testUri.length > URL_MAX) {
+	//page-size is 50 because the max tag ids that capi can accept for lookup at once is 50 therefore there cannot be more than that in the output
+	const testUri = `${capiBaseUrl}/tags?ids=${joinedIdList}&api-key=${capiKey}&page-size=50`;
+
+	//CAPI errors if we give it more than 50 tag ids
+	if (testUri.length > URL_MAX || tagIdList.length > 50) {
 		//uri is not usable, try again
 		const midpoint = tagIdList.length / 2;
 		const newTail = tagIdListTail.concat(tagIdList.slice(midpoint));
@@ -81,7 +84,6 @@ export async function fetchTagsById(
 		} else {
 			const rawBytes = await response.arrayBuffer();
 			const contentBody = deserialzeTagsResponse(Buffer.from(rawBytes));
-
 			results = results.concat(...contentBody.results);
 		}
 	}

--- a/lib/capi/src/lib/capitags.ts
+++ b/lib/capi/src/lib/capitags.ts
@@ -1,0 +1,89 @@
+import type { Tag } from '@guardian/content-api-models/v1/tag';
+import {
+	TagsResponse,
+	TagsResponseSerde,
+} from '@guardian/content-api-models/v1/tagsResponse';
+import { deserialzeTagsResponse } from './deserialize';
+
+export const URL_MAX = 2048;
+
+/**
+ * We need to have <2048 chars in the URI or one of the backends objects.
+ * So, we try to bundle all of the tag IDs into one lookup; if that fails, we split in half and try two; etc.
+ * @param tagIdList the list of tag IDs to resolve
+ * @param capiBaseUrl base URL for CAPI
+ * @param capiKey API key for CAPI
+ * @param tagIdListTail remaining tag IDs to process next iteration. Internal use only.
+ * @param prevUrlList URLs already determined. Internal use only.
+ */
+export function buildUriList(
+	tagIdList: string[],
+	capiBaseUrl: string,
+	capiKey: string,
+	tagIdListTail: string[] = [],
+	prevUrlList: string[] = [],
+): string[] {
+	if (tagIdList.length == 0) {
+		//We reached the end!
+		return prevUrlList;
+	}
+
+	const joinedIdList = encodeURIComponent(tagIdList.join(','));
+	const testUri = `${capiBaseUrl}/tags?ids=${joinedIdList}&api-key=${capiKey}`;
+	if (testUri.length > URL_MAX) {
+		//uri is not usable, try again
+		const midpoint = tagIdList.length / 2;
+		const newTail = tagIdListTail.concat(tagIdList.slice(midpoint));
+
+		return buildUriList(
+			tagIdList.slice(0, midpoint),
+			capiBaseUrl,
+			capiKey,
+			newTail,
+			prevUrlList,
+		);
+	} else {
+		//we found a length that works.
+		return buildUriList(
+			tagIdListTail,
+			capiBaseUrl,
+			capiKey,
+			[],
+			prevUrlList.concat(testUri),
+		);
+	}
+}
+
+/**
+ * Given a list of tag IDs (of any length), retrieve the metadata efficiently from CAPI.
+ * Note that success does NOT guarantee that _every_ tag was found, or indeed that _any_ tag was found.
+ * Returns a list of CAPI tag data
+ * @param tagIdList list of tag IDs to look up.
+ * @param capiBaseUrl base URL of CAPI to use
+ * @param capiKey API key valid for the CAPI instance you're targeting. Developer-tier does have access to this data.
+ */
+export async function fetchTagsById(
+	tagIdList: string[],
+	capiBaseUrl: string,
+	capiKey: string,
+): Promise<Tag[]> {
+	const urlList = buildUriList(tagIdList, capiBaseUrl, capiKey);
+	let results: Tag[] = [];
+
+	for (const url of urlList) {
+		const response = await fetch(url + '&format=thrift');
+		if (response.status != 200) {
+			const errorText = await response.text();
+			console.error(
+				`CAPI returned with an error ${response.status}: ${errorText}`,
+			);
+			throw new Error('CAPI returned an error');
+		} else {
+			const rawBytes = await response.arrayBuffer();
+			const contentBody = deserialzeTagsResponse(Buffer.from(rawBytes));
+
+			results = results.concat(...contentBody.results);
+		}
+	}
+	return results;
+}

--- a/lib/capi/src/lib/deserialize.ts
+++ b/lib/capi/src/lib/deserialize.ts
@@ -2,6 +2,8 @@ import type { Event } from '@guardian/content-api-models/crier/event/v1/event';
 import { EventSerde } from '@guardian/content-api-models/crier/event/v1/event';
 import type { ItemResponse } from '@guardian/content-api-models/v1/itemResponse';
 import { ItemResponseSerde } from '@guardian/content-api-models/v1/itemResponse';
+import type { TagsResponse } from '@guardian/content-api-models/v1/tagsResponse';
+import { TagsResponseSerde } from '@guardian/content-api-models/v1/tagsResponse';
 import type { TProtocol } from 'thrift';
 import { TCompactProtocol, TFramedTransport } from 'thrift';
 
@@ -21,4 +23,8 @@ export function deserializeItemResponse(
 	content: string | Buffer,
 ): ItemResponse {
 	return ItemResponseSerde.read(feedToThrift(content));
+}
+
+export function deserialzeTagsResponse(content: string | Buffer): TagsResponse {
+	return TagsResponseSerde.read(feedToThrift(content));
 }

--- a/lib/recipes-data/src/lib/models.ts
+++ b/lib/recipes-data/src/lib/models.ts
@@ -79,6 +79,17 @@ export type Contributor =
 	| { type: 'contributor'; tagId: string }
 	| { type: 'freetext'; text: string };
 
+export interface ChefData {
+	webTitle: string;
+	webUrl: string;
+	apiUrl: string;
+	bio?: string;
+	bylineImageUrl?: string;
+	bylineLargeImageUrl?: string;
+}
+
+export type ChefInfoFile = Record<string, ChefData>;
+
 /**
  * Helper function to un-marshal a raw dynamo record into a RecipeDatabaseEntry structure.
  * Note, this will not throw if the fields are not present; instead, capiArticleId will be an empty string ("")


### PR DESCRIPTION
## What does this change?

- Adds a new static endpoint, `v2/contributors.json`, which contains information about valid "chef" contributors for the app to use.
- This is built hourly by using the recipe search backend to determine all profile tags for which there is at least one recipe, then efficiently resolving them through CAPI and outputting the result as JSON into S3

This is a request from the Feast team in order to move the app to needing less initial data to be downloaded.  At present, they do this resolution client-side and need _every_ recipe downloaded in order to build the list of profile tags to resolve.  By doing this work for them up-front and giving them the data in json format, we can simplify matters considerably so they can simply "download chefs" and have done with it, lazy-loading recipes as required.

## How to test

- Deploy to CODE
- Find the `PublishRecipeContributors-CODE` lambda function in AWS console
- Use the 'Test' panel to manually run it
- Watch the logs - no errors reported. It should report that it found about 15 contributors from the recipe search and resolved 10 of them in CAPI (this is CODE, CAPI does not have anywhere near all the contributors in the CODE environment).
- Use curl, Postman, browser etc. to check https://recipes.code.dev-guardianapis.com/v2/contributors.json.
  - You should see the right amount of data there - including id, name, bio, image, etc.
  - The `Cache-Control` header should indicate a very long `max-age` (`max-age=31557600; stale-while-revalidate=60; stale-if-error=300`)
  - You should probably see the `X-Cache` header to be `HIT` - the cache is only flushed if a real update to the file is made
  - Repeating the request with a request header of `If-Modified-Since` and a recent date (use the same time format as the outgoing `Date` header) should show a response of `304 Not Modified` with no body content

## How can we measure success?

Removing a blocker from the apps lazy-loading data

## Have we considered potential risks?

This does publicly expose information about contributors. However, this information is already publicly exposed through CAPI and the website so there is not actually any change.

