### PR TITLE
Deprecate MiseEnPlace POST endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ most of the actual logic lives in the library code imported into it
 
 A lambda function that rebuilds the index on-demand. This is incorporated from initial testing and will probably be removed.
 
+### lambda/rest-endpoints
+
+A lambda function initially used to POST the curation data for MEP to use it, now exists to support GET endpoint to get the most recent version of a given recipe ID, used by Fronts tool to resolve the recipe unique id to a checksum
+
 ### lib/capi
 
 Library functions to communicate with the Content Application Programmer's Interface. This is imported into the lambda code as `@recipes-api/lib/capi`.

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -554,24 +554,6 @@ def sort_filter_rules(json_obj):
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "s3:PutObject",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Fn::GetAtt": [
-                        "staticstaticServing53194089",
-                        "Arn",
-                      ],
-                    },
-                    "/*/*/curation.json",
-                  ],
-                ],
-              },
-            },
-            {
               "Action": "dynamodb:Query",
               "Effect": "Allow",
               "Resource": [

--- a/cdk/lib/rest-endpoints.ts
+++ b/cdk/lib/rest-endpoints.ts
@@ -49,11 +49,6 @@ export class RestEndpoints extends Construct {
 			initialPolicy: [
 				new PolicyStatement({
 					effect: Effect.ALLOW,
-					actions: ['s3:PutObject'],
-					resources: [`${servingBucket.bucketArn}/*/*/curation.json`],
-				}),
-				new PolicyStatement({
-					effect: Effect.ALLOW,
 					actions: ['dynamodb:Query'],
 					resources: [
 						`${dataStore.table.tableArn}`,

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -3,13 +3,8 @@ import { formatISO } from 'date-fns';
 import { renderFile as ejs } from 'ejs';
 import express, { Router } from 'express';
 import type { Request } from 'express';
-import { FeastAppContainer } from '@recipes-api/lib/facia';
-import { deployCurationData, recipeByUID } from '@recipes-api/lib/recipes-data';
-import {
-	getBodyContentAsJson,
-	recursivelyGetIdList,
-	validateDateParam,
-} from './helpers';
+import { recipeByUID } from '@recipes-api/lib/recipes-data';
+import { recursivelyGetIdList } from './helpers';
 
 export const app = express();
 app.set('view engine', 'ejs');
@@ -21,104 +16,6 @@ router.use(
 	bodyParser.json({
 		limit: '1mb',
 	}),
-);
-
-interface CurationParams {
-	edition: string;
-	front: string;
-}
-
-/**
- * Checks whether the parameters make sense and raises an exception if they don't
- * @param params CurationParams object
- */
-function validateCurationParams(params: CurationParams) {
-	const checker = /[^\\w]+/;
-
-	if (!params.edition.match(checker) || !params.front.match(checker)) {
-		throw new Error('Invalid region parameter');
-	}
-}
-
-router.post(
-	'/api/curation/:edition/:front',
-	(req: Request<CurationParams>, resp) => {
-		if (req.header('Content-Type') != 'application/json') {
-			resp.status(405).json({ status: 'error', detail: 'wrong content type' });
-			return;
-		}
-
-		let dateval: Date | null = null;
-
-		try {
-			dateval = req.query.date
-				? validateDateParam(req.query.date as string)
-				: null;
-		} catch {
-			console.log('Provided querystring ', req.query, ' did not validate');
-			resp.status(400).json({
-				status: 'error',
-				detail:
-					'invalid querystring parameters. date must be specified in YYYY-MM-DD format',
-			});
-			return;
-		}
-
-		try {
-			validateCurationParams(req.params);
-		} catch (err) {
-			console.log('Provided params ', req.params, ' did not validate');
-			resp.status(400).json({
-				status: 'error',
-				detail:
-					'invalid regionalisation parameters. region and variant must be basic strings with no punctuation etc.',
-			});
-			return;
-		}
-
-		try {
-			const textContent = getBodyContentAsJson(req.body);
-			if (textContent.length == 0) {
-				resp
-					.status(400)
-					.json({ status: 'error', detail: 'no content was sent' });
-				return;
-			}
-
-			//For the time being, this check is only advisory as we are not 100% confident that the models represent everything that MEP can send
-			//When we move to Fronts this will be mandatory
-			try {
-				FeastAppContainer.parse(JSON.parse(textContent));
-			} catch (err) {
-				console.warn(`We were sent content that did not validate: `, err);
-				console.warn('Data we got: ');
-				console.warn(textContent);
-			}
-
-			deployCurationData(
-				textContent,
-				req.params.edition,
-				req.params.front,
-				dateval,
-			)
-				.then(() => {
-					return resp.status(200).json({ status: 'ok' });
-				})
-				.catch((err) => {
-					console.error(err);
-
-					return (
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment -- err.toString() is untyped but OK
-						resp.status(500).json({ status: 'error', detail: err.toString() })
-					);
-				});
-		} catch (err) {
-			console.error('Could not parse incoming data as json: ', err);
-			return resp
-				.status(400)
-				.json({ status: 'error', detail: 'invalid content' });
-		}
-	},
 );
 
 interface RecipeIdParams {

--- a/lib/facia/src/lib/facia-models.test.ts
+++ b/lib/facia/src/lib/facia-models.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'path';
 import type { Chef, Recipe } from './facia-models';
-import { FeastCuration, MiseEnPlaceData } from './facia-models';
+import { FeastAppCurationPayload, FeastCuration } from './facia-models';
 
 describe('facia-models', () => {
 	function loadFixture(name: string) {
@@ -64,7 +64,7 @@ describe('facia-models', () => {
 
 	it('should be able to validate real data from MEP', () => {
 		const data = loadFixture('real-curation-data.json');
-		const typedData = MiseEnPlaceData.parse(data);
+		const typedData = FeastAppCurationPayload.parse(data);
 
 		expect(typedData.length).toEqual(13);
 		expect(typedData[11].title).toEqual('Meet our cooks');

--- a/lib/facia/src/lib/facia-models.ts
+++ b/lib/facia/src/lib/facia-models.ts
@@ -91,6 +91,5 @@ export const FeastCuration = z.intersection(
 
 export type FeastCuration = z.infer<typeof FeastCuration>;
 
-//TODO: need to check/test -  if we need removal of refernces of MEP from here as well?
-export const MiseEnPlaceData = z.array(FeastAppContainer);
-export type MiseEnPlaceDataFormat = z.infer<typeof MiseEnPlaceData>;
+export const FeastAppCurationPayload = z.array(FeastAppContainer);
+export type FeastAppCurationPayload = z.infer<typeof FeastAppCurationPayload>;

--- a/lib/facia/src/lib/facia-models.ts
+++ b/lib/facia/src/lib/facia-models.ts
@@ -90,5 +90,7 @@ export const FeastCuration = z.intersection(
 );
 
 export type FeastCuration = z.infer<typeof FeastCuration>;
+
+//TODO: need to check/test -  if we need removal of refernces of MEP from here as well?
 export const MiseEnPlaceData = z.array(FeastAppContainer);
 export type MiseEnPlaceDataFormat = z.infer<typeof MiseEnPlaceData>;


### PR DESCRIPTION
## What does this change?

We don't need to hold `Misenplace` references to curate data because we have `Fronts-tools` fully functioning and working efficiently for the same.
reference of the task: https://trello.com/c/JdzlfTbD/3415-deprecate-mise-en-place-post-endpoints

## How to test

Mentioned in PR below how we tested, 
We tested POST and GET request to see if they are working as expected and it seems they are.


## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
