### PR TITLE
Mock config object, not process object, intests

### DIFF
--- a/lib/recipes-data/src/lib/config.ts
+++ b/lib/recipes-data/src/lib/config.ts
@@ -1,6 +1,8 @@
 //Used by dynamo.ts
 import * as process from 'process';
 
+export const AwsRegion = process.env['AWS_REGION'];
+
 export const indexTableName = process.env['INDEX_TABLE'];
 export const lastUpdatedIndex = process.env['LAST_UPDATED_INDEX'];
 

--- a/lib/recipes-data/src/lib/curation.test.ts
+++ b/lib/recipes-data/src/lib/curation.test.ts
@@ -7,21 +7,12 @@ import MockedFn = jest.MockedFn;
 
 const s3Mock = mockClient(S3Client);
 
-jest.mock('process', () => {
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- typescript doesn't like 'any' value
-	const originalModule = jest.requireActual('process');
-
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-return -- doesn't like 'any' value
-	return {
-		...originalModule,
-		env: {
-			CONTENT_URL_BASE: 'not-used',
-			STATIC_BUCKET: 'static-content-bucket',
-			AWS_REGION: 'some-aws-region',
-			FASTLY_API_KEY: 'blahblahblah',
-		},
-	};
-});
+jest.mock('./config', () => ({
+	ContentUrlBase: 'not-used',
+	StaticBucketName: 'static-content-bucket',
+	FastlyApiKey: 'blahblahblah',
+	AwsRegion: 'eu-west-1',
+}));
 
 jest.mock('./fastly', () => ({
 	sendFastlyPurgeRequestWithRetries: jest.fn(),

--- a/lib/recipes-data/src/lib/curation.ts
+++ b/lib/recipes-data/src/lib/curation.ts
@@ -1,9 +1,9 @@
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import format from 'date-fns/format';
-import { StaticBucketName as Bucket, FastlyApiKey } from './config';
+import { AwsRegion, StaticBucketName as Bucket, FastlyApiKey } from './config';
 import { sendFastlyPurgeRequestWithRetries } from './fastly';
 
-const s3client = new S3Client({ region: process.env['AWS_REGION'] });
+const s3client = new S3Client({ region: AwsRegion });
 
 export async function deployCurationData(
 	content: string | Buffer,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "update-cdk": "nx run cdk:update",
     "build": "nx run-many --target=build --skip-nx-cache",
-    "test": "CONTENT_URL_BASE=fake-base STATIC_BUCKET=fake-bucket nx run-many --target=test",
+    "test": "nx run-many --target=test",
     "lint": "nx run-many --target=lint",
     "manual-takedown": "nx run tools-manual-takedown:run",
     "commandline-reindex": "nx run lambda-recipes-responder:commandline-reindex -- ",


### PR DESCRIPTION
## What does this change?

Mock config object, not process object, in tests, to prevent the order of execution affecting test output.

This caused an odd issue while I was working on https://github.com/guardian/recipes-backend/pull/79, which I think was caused by files executing out of order — if the file pulling values from `process.env` is evaluated before the file mocking `process.env`, the values will be pulled from the command line, not the mock.

Mocking `./config` is in any case consistent with the way the majority of tests work in this repo.

## How to test

This is a no-op — if the tests pass, this is working as expected.
