### PR TITLE
Add a new transform to temporarily fix `celebration(s)Ids`

### DIFF
--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -17,6 +17,7 @@ import {
 	handleFreeTextContribs,
 	replaceCanonicalArticle,
 	replaceImageUrlsWithFastly,
+	temporaryCelebrationIdsFix,
 } from './transform';
 import type {
 	RecipeTransformationFunction,
@@ -142,6 +143,7 @@ function parseJsonBlob(
 			addSponsorsTransform(sponsorship),
 			addRecipeDatesTransform(recipeDates),
 			replaceCanonicalArticle(canonicalId),
+			temporaryCelebrationIdsFix,
 		];
 
 		const updatedRecipe = transforms.reduce(

--- a/lib/recipes-data/src/lib/transform.test.ts
+++ b/lib/recipes-data/src/lib/transform.test.ts
@@ -4,6 +4,7 @@ import { recipes } from './recipe-fixtures';
 import {
 	handleFreeTextContribs,
 	replaceImageUrlsWithFastly,
+	temporaryCelebrationIdsFix,
 } from './transform';
 
 jest.mock('./config', () => ({
@@ -242,6 +243,39 @@ describe('Recipe transforms', () => {
 				'https://cdn.road.cc/sites/default/files/styles/main_width/public/Wat-duck.png',
 				undefined,
 			);
+		});
+	});
+
+	describe('temporaryCelebrationIdsFix', () => {
+		it('should not change anything if celebrationIds is not present', () => {
+			const recipe = recipes[0];
+			recipe.celebrationIds = undefined;
+
+			const transformed = temporaryCelebrationIdsFix(recipe);
+			expect(transformed).toEqual(recipe);
+			expect(transformed.celebrationsIds).toBeUndefined();
+		});
+
+		it('should not change anything if celebrationIds is empty', () => {
+			const recipe = recipes[0];
+
+			const transformed = temporaryCelebrationIdsFix(recipe);
+			expect(transformed).toEqual(recipe);
+			expect(transformed.celebrationsIds).toBeUndefined();
+		});
+
+		it('should copy a non-empty celebrationIds to celebrationsIds', () => {
+			const recipe = recipes[0];
+			recipe.celebrationIds = ['christmas', 'new_year'];
+
+			const transformed = temporaryCelebrationIdsFix(recipe);
+			expect(transformed).not.toEqual(recipe);
+			expect(transformed.celebrationIds).toEqual(['christmas', 'new_year']);
+			expect(transformed.celebrationsIds).toEqual(['christmas', 'new_year']);
+
+			for (const k of Object.keys(recipe)) {
+				expect(transformed[k]).toEqual(recipe[k]);
+			}
 		});
 	});
 });

--- a/lib/recipes-data/src/lib/transform.ts
+++ b/lib/recipes-data/src/lib/transform.ts
@@ -215,3 +215,25 @@ export function handleFreeTextContribs<
 
 	return { ...parsedRecipe, contributors: contributorTags, byline: freetexts };
 }
+
+/**
+ * Due to a snafu, older app versions want a field called `celebrationsIds` rather than `celebrationIds`.
+ * This transform copies the data from `celebrationIds`, only in the case where there is at least one member of the array.
+ * By avoiding changing recipes which do not have anything there, we avoid forcing the users to redownload the lot.
+ * @param recipeData
+ */
+export const temporaryCelebrationIdsFix: RecipeTransformationFunction = (
+	recipeData,
+) => {
+	const celebrationIds = recipeData['celebrationIds'] as string[] | undefined;
+
+	if (celebrationIds && celebrationIds.length > 0) {
+		console.debug(`Got ${celebrationIds.length} celebrationIds`);
+		return {
+			...recipeData,
+			celebrationsIds: celebrationIds,
+		};
+	} else {
+		return recipeData;
+	}
+};


### PR DESCRIPTION
## What does this change?

- Duplicates the contents of `celebrationIds` to `celebrationsIds`, if the former array exists and has at least one member.
- This is to allow older versions of the app to correctly read the data, this can be removed once enough app users have updated
- Since this is on ingest, a re-index will be required

## How to test

- Transformation code is tested in CI

- Use the recipe search API on CODE to see how many recipes have celebrationIds on them
- Re-index recipes on CODE
- Re-index search on CODE
- Check some of the recipes - ones that had `celebrationIds` should now have both `celebrationIds` and `celebrationsIds` and have their checksum updated. Ones that did not have any `celebrationIds` should be unchanged

_I have already carried this out on CODE_

## How can we measure success?

App is able to search for christmas recipes!

## Have we considered potential risks?

Since this involves re-indexing we need to be aware of forcing users to re-download a large delta.  We've checked the stats and it only looks like we'll be updating 600-700 recipes out of 5000 and this is considered acceptable.
