### PR TITLE
Bump express to fix a vuln in path-to-regexp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "aws-lambda": "^1.0.7",
         "body-parser": "^1.20.2",
         "date-fns": "^2.30.0",
-        "express": "^4.21.1",
+        "express": "^4.21.2",
         "express-async-handler": "^1.2.0",
         "tslib": "^2.3.0",
         "uuid": "^9.0.1",
@@ -10098,9 +10098,10 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -10121,7 +10122,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -10136,6 +10137,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express-async-handler": {
@@ -10157,9 +10162,10 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "aws-lambda": "^1.0.7",
     "body-parser": "^1.20.2",
     "date-fns": "^2.30.0",
-    "express": "^4.21.1",
+    "express": "^4.21.2",
     "express-async-handler": "^1.2.0",
     "tslib": "^2.3.0",
     "uuid": "^9.0.1",


### PR DESCRIPTION
## What does this change?

Bump express to fix a vuln in path-to-regexp.

## How to test

- Tests should pass.
- Deploy to CODE. Routing for paths handled by express, e.g. `/api/content/by-uid/:recipeUID`, should work.

✅  tested in CODE with a cache purge, the above endpoint (e.g. https://recipes.code.dev-guardianapis.com/api/content/by-uid/3f3410b0edae470abb76f5f48c02e8f4) works fine.
