### PR TITLE
Retrievable tag bugfix

### DIFF
--- a/lambda/recipes-responder/src/commandline-reindex.ts
+++ b/lambda/recipes-responder/src/commandline-reindex.ts
@@ -166,6 +166,7 @@ async function main() {
 		else console.log(msg);
 		console.log('------------------------------------------------------\n');
 	}
+	const failedArticleIds: string[] = [];
 
 	if (all && !indexOnly) {
 		const index = await retrieveIndexData();
@@ -191,7 +192,14 @@ async function main() {
 				console.log('------------------------------------------------------');
 				console.log(`Article ${i} / ${total}...\n`);
 				const queryUri = await getQueryUri(articleId, undefined, undefined);
-				await reindex(queryUri);
+				try {
+					await reindex(queryUri);
+				} catch (e) {
+					console.error(
+						`Error reindexing ${queryUri}: ${(e as Error).toString()}`,
+					);
+					failedArticleIds.push(queryUri);
+				}
 				console.log('------------------------------------------------------\n');
 				i++;
 			}
@@ -217,6 +225,11 @@ async function main() {
 	};
 	await writeIndexData(indexWithoutSponsored, INDEX_JSON);
 	console.log('Finished rebuilding index');
+
+	if (failedArticleIds.length > 0) {
+		console.warn(`${failedArticleIds.length} failed to reindex:`);
+		failedArticleIds.forEach((capiId) => console.warn(`\t${capiId}`));
+	}
 }
 
 main()

--- a/lambda/recipes-responder/src/update_retrievable_processor.test.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.test.ts
@@ -56,7 +56,7 @@ describe('handleContentUpdateRetrievable', () => {
 				'/path/to/article',
 				'/channel/feast/item/path/to/article',
 			) +
-				'?show-fields=internalRevision,lastModifiedDate,firstPublishedDate,publishedDate&show-blocks=all&show-channels=all&api-key=fake-api-key&format=thrift',
+				'?show-fields=internalRevision,lastModifiedDate,firstPublishedDate,publishedDate&show-blocks=all&show-channels=all&show-tags=all&api-key=fake-api-key&format=thrift',
 		);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(handleContentUpdate.mock.calls.length).toEqual(1);

--- a/lambda/recipes-responder/src/update_retrievable_processor.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.ts
@@ -31,6 +31,7 @@ export async function retrieveContent(capiUrl: string): Promise<PollingResult> {
 		`show-fields=internalRevision,lastModifiedDate,firstPublishedDate,publishedDate`,
 		`show-blocks=all`,
 		`show-channels=all`,
+		`show-tags=all`,
 		`api-key=${CapiKey}`,
 		`format=thrift`,
 	]


### PR DESCRIPTION
## What does this change?

- Fixes a nasty bug where the "retrievable update" code (also used in the reindexing process) was not requesting tag data from CAPI resulting in a loss of sponsorship information
- Slight improvement to the reindex script code so we log failures at the end rather than interrupting partway through

## How to test

- Deploy to CODE
- Perform a reindex on e.g. da5442fb9ed648df95c5b5bd592bef3b
```bash
npm run commandline-reindex -- --recipeUid=da5442fb9ed648df95c5b5bd592bef3b
```
- Request https://recipes.code.dev-guardianapis.com/v2/index.json
- Request it again (the first one is usually served stale content while the CDN refreshes in the background)
- Find that recipe in the index, it should still have `"sponsorshipCount": 1`
- Request https://recipes.code.dev-guardianapis.com/content/da5442fb9ed648df95c5b5bd592bef3b
- This should have the sponsorship data that was there before

## How can we measure success?

Don't accidentally lose data!

## Have we considered potential risks?

n/a
