### PR TITLE
Refactor configuration getters

### DIFF
--- a/lambda/facia-responder/src/config.ts
+++ b/lambda/facia-responder/src/config.ts
@@ -1,8 +1,9 @@
-import { mandatoryParameter } from 'lib/recipes-data/src/lib/parameters';
+import { createGetMandatoryParameter } from 'lib/recipes-data/src/lib/parameters';
 
-export const faciaPublicationStatusTopicArn = mandatoryParameter(
+export const getFaciaPublicationStatusTopicArn = createGetMandatoryParameter(
 	'FACIA_PUBLISH_STATUS_TOPIC_ARN',
 );
-export const faciaPublicationStatusRoleArn = mandatoryParameter(
+
+export const getFaciaPublicationStatusRoleArn = createGetMandatoryParameter(
 	'FACIA_PUBLISH_STATUS_ROLE_ARN',
 );

--- a/lambda/facia-responder/src/facia-notifications.ts
+++ b/lambda/facia-responder/src/facia-notifications.ts
@@ -1,9 +1,5 @@
 import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
 import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
-import {
-	faciaPublicationStatusRoleArn,
-	faciaPublicationStatusTopicArn,
-} from './config';
 import { getErrorMessage } from './util';
 
 // The publication status event we send over SNS.
@@ -29,6 +25,8 @@ export type PublicationStatusEvent = {
 
 export async function notifyFaciaTool(
 	event: PublicationStatusEvent,
+	faciaPublicationStatusTopicArn: string,
+	faciaPublicationStatusRoleArn: string,
 ): Promise<void> {
 	const payload = JSON.stringify({ event } as PublicationStatusEventEnvelope);
 

--- a/lambda/facia-responder/src/main.test.ts
+++ b/lambda/facia-responder/src/main.test.ts
@@ -10,11 +10,13 @@ import { handler } from './main';
 
 jest.mock('@recipes-api/lib/recipes-data', () => ({
 	deployCurationData: jest.fn(),
+	getStaticBucketName: () => 'static-bucket-name',
+	getFastlyApiKey: () => 'fastly-api-key',
 }));
 
 jest.mock('./config', () => ({
-	faciaPublicationStatusTopicArn: 'config-param',
-	faciaPublicationStatusRoleArn: 'config-param',
+	getFaciaPublicationStatusTopicArn: () => 'config-param',
+	getFaciaPublicationStatusRoleArn: () => 'config-param',
 }));
 
 jest.mock('./facia-notifications', () => ({

--- a/lambda/facia-responder/src/main.test.ts
+++ b/lambda/facia-responder/src/main.test.ts
@@ -12,6 +12,7 @@ jest.mock('@recipes-api/lib/recipes-data', () => ({
 	deployCurationData: jest.fn(),
 	getStaticBucketName: () => 'static-bucket-name',
 	getFastlyApiKey: () => 'fastly-api-key',
+	getContentPrefix: () => 'cdn.content.location',
 }));
 
 jest.mock('./config', () => ({

--- a/lambda/publish-todays-curation/src/config.ts
+++ b/lambda/publish-todays-curation/src/config.ts
@@ -1,5 +1,1 @@
-export const Bucket = process.env['STATIC_BUCKET'];
-
 export const Today = new Date();
-
-export const FastlyApiKey = process.env['FASTLY_API_KEY'];

--- a/lambda/publish-todays-curation/src/curation.ts
+++ b/lambda/publish-todays-curation/src/curation.ts
@@ -179,9 +179,9 @@ export async function activateCuration(
 	console.log(
 		`Done, new Etag is ${response.CopyObjectResult?.ETag ?? '(unknown)'}`,
 	);
-	await sendFastlyPurgeRequestWithRetries(
-		targetPath,
-		fastlyApiKey,
+	await sendFastlyPurgeRequestWithRetries({
+		contentPath: targetPath,
+		apiKey: fastlyApiKey,
 		contentPrefix,
-	);
+	});
 }

--- a/lambda/publish-todays-curation/src/curation.ts
+++ b/lambda/publish-todays-curation/src/curation.ts
@@ -6,7 +6,6 @@ import {
 } from '@aws-sdk/client-s3';
 import { format, formatISO } from 'date-fns';
 import { sendFastlyPurgeRequestWithRetries } from '@recipes-api/lib/recipes-data';
-import { Bucket, FastlyApiKey } from './config';
 
 const s3Client = new S3Client({ region: process.env['AWS_REGION'] });
 
@@ -27,10 +26,16 @@ const DateFormat = 'yyyy-MM-dd';
 export async function validateAllCuration(
 	date: Date,
 	throwOnAbsent: boolean,
+	staticBucketName: string,
 ): Promise<CurationPath[]> {
 	const promises = KnownEditions.flatMap((region) =>
 		KnownFronts.map(async (variant) => {
-			const maybeInfo = await validateCurationData(region, variant, date);
+			const maybeInfo = await validateCurationData(
+				region,
+				variant,
+				date,
+				staticBucketName,
+			);
 			if (!maybeInfo) {
 				console.warn(
 					`No curation was present for region ${region} variant ${variant} on date ${format(
@@ -118,10 +123,11 @@ export async function validateCurationData(
 	region: string,
 	variant: string,
 	date: Date,
+	staticBucketName: string,
 ): Promise<CurationPath | null> {
 	console.debug(`Checking path `, generatePath(region, variant, date));
 	const req = new HeadObjectCommand({
-		Bucket,
+		Bucket: staticBucketName,
 		Key: generatePath(region, variant, date),
 	});
 
@@ -152,15 +158,20 @@ export async function validateCurationData(
 	}
 }
 
-export async function activateCuration(info: CurationPath): Promise<void> {
+export async function activateCuration(
+	info: CurationPath,
+	contentPrefix: string,
+	staticBucketName: string,
+	fastlyApiKey: string,
+): Promise<void> {
 	const targetPath = generateActivePath(info.edition, info.front);
 	console.log(
 		`Deploying config ${generatePathFromCuration(info)} to ${targetPath}`,
 	);
 
 	const req = new CopyObjectCommand({
-		Bucket,
-		CopySource: (Bucket ?? '') + '/' + generatePathFromCuration(info),
+		Bucket: staticBucketName,
+		CopySource: staticBucketName + '/' + generatePathFromCuration(info),
 		Key: targetPath,
 	});
 
@@ -168,5 +179,9 @@ export async function activateCuration(info: CurationPath): Promise<void> {
 	console.log(
 		`Done, new Etag is ${response.CopyObjectResult?.ETag ?? '(unknown)'}`,
 	);
-	await sendFastlyPurgeRequestWithRetries(targetPath, FastlyApiKey as string);
+	await sendFastlyPurgeRequestWithRetries(
+		targetPath,
+		fastlyApiKey,
+		contentPrefix,
+	);
 }

--- a/lambda/publish-todays-curation/src/main.test.ts
+++ b/lambda/publish-todays-curation/src/main.test.ts
@@ -8,7 +8,6 @@ import { handler } from './main';
 mockClient(S3Client);
 
 jest.mock('./config', () => ({
-	Bucket: 'TestBucket',
 	Today: new Date(2024, 1, 3, 11, 26, 19),
 }));
 
@@ -26,6 +25,14 @@ jest.mock('./curation', () => {
 
 jest.mock('@recipes-api/lib/recipes-data', () => ({
 	sendFastlyPurgeRequestWithRetries: jest.fn(),
+}));
+
+const staticBucketName = 'static-bucket';
+
+jest.mock('lib/recipes-data/src/lib/config', () => ({
+	getContentPrefix: () => 'cdn.content',
+	getFastlyApiKey: () => 'fastly-api-key',
+	getStaticBucketName: () => staticBucketName,
 }));
 
 describe('main.handler', () => {
@@ -99,7 +106,7 @@ describe('main.handler', () => {
 						s3SchemaVersion: '1.0',
 						configurationId: 'testConfigRule',
 						bucket: {
-							name: 'TestBucket',
+							name: staticBucketName,
 							ownerIdentity: {
 								principalId: 'EXAMPLE',
 							},
@@ -155,7 +162,7 @@ describe('main.handler', () => {
 						s3SchemaVersion: '1.0',
 						configurationId: 'testConfigRule',
 						bucket: {
-							name: 'TestBucket',
+							name: staticBucketName,
 							ownerIdentity: {
 								principalId: 'EXAMPLE',
 							},
@@ -204,7 +211,7 @@ describe('main.handler', () => {
 						s3SchemaVersion: '1.0',
 						configurationId: 'testConfigRule',
 						bucket: {
-							name: 'TestBucket',
+							name: staticBucketName,
 							ownerIdentity: {
 								principalId: 'EXAMPLE',
 							},

--- a/lambda/publish-todays-curation/src/main.ts
+++ b/lambda/publish-todays-curation/src/main.ts
@@ -1,6 +1,11 @@
 import type { S3Event } from 'aws-lambda';
 import { formatISO } from 'date-fns';
-import { Bucket, Today } from './config';
+import {
+	getContentPrefix,
+	getFastlyApiKey,
+	getStaticBucketName,
+} from 'lib/recipes-data/src/lib/config';
+import { Today } from './config';
 import {
 	activateCuration,
 	checkCurationPath,
@@ -13,9 +18,14 @@ import {
  * immediately.
  * @param event
  */
-async function handleS3Event(event: S3Event): Promise<void> {
+async function handleS3Event(
+	event: S3Event,
+	contentPrefix: string,
+	staticBucketName: string,
+	fastlyApiKey: string,
+): Promise<void> {
 	const toWaitFor = event.Records.map((rec) => {
-		if (rec.s3.bucket.name != Bucket) {
+		if (rec.s3.bucket.name !== staticBucketName) {
 			console.log(`Event was for bucket ${rec.s3.bucket.name}, ignoring`);
 			return;
 		}
@@ -34,7 +44,12 @@ async function handleS3Event(event: S3Event): Promise<void> {
 				console.log(
 					`Detected an update of today's curation data for ${info.edition}/${info.front}, redeploying`,
 				);
-				return activateCuration(info);
+				return activateCuration(
+					info,
+					contentPrefix,
+					staticBucketName,
+					fastlyApiKey,
+				);
 			} else {
 				console.log(
 					`Detected an update of curation data for ${info.edition}/${info.front} on ${info.year}-${info.month}-${info.day}`,
@@ -52,26 +67,53 @@ async function handleS3Event(event: S3Event): Promise<void> {
  * Activate the fronts for a given date
  * @param date Date to activate
  */
-async function handleTimerEvent(date: Date): Promise<void> {
+async function handleTimerEvent(
+	date: Date,
+	contentPrefix: string,
+	staticBucketName: string,
+	fastlyApiKey: string,
+): Promise<void> {
 	console.log(`Checking we have curation for ${formatISO(date)}...`);
 	//Check if we have curation available for the new date
-	const curations = await validateAllCuration(date, false);
+	const curations = await validateAllCuration(date, false, staticBucketName);
 	if (curations.length == 0) {
 		console.error(`No curation data was available for date ${formatISO(date)}`);
 	} else {
 		console.log(`Activating ${curations.length} fronts...`);
-		await Promise.all(curations.map(activateCuration));
+		await Promise.all(
+			curations.map((curation) =>
+				activateCuration(
+					curation,
+					contentPrefix,
+					staticBucketName,
+					fastlyApiKey,
+				),
+			),
+		);
 		console.log('Done.');
 	}
 }
 
 export async function handler(event: S3Event | unknown) {
+	const staticBucketName = getStaticBucketName();
+	const contentPrefix = getContentPrefix();
+	const fastlyApiKey = getFastlyApiKey();
 	// eslint-disable-next-line no-prototype-builtins -- hasOwnProperty is valid here
 	if ((event as NonNullable<unknown>).hasOwnProperty('Records')) {
 		console.log('Invoked from S3');
-		return handleS3Event(event as S3Event);
+		return handleS3Event(
+			event as S3Event,
+			contentPrefix,
+			staticBucketName,
+			fastlyApiKey,
+		);
 	} else {
 		console.log('Did not receive an S3 record, assuming invoked from timer');
-		return handleTimerEvent(Today);
+		return handleTimerEvent(
+			Today,
+			contentPrefix,
+			staticBucketName,
+			fastlyApiKey,
+		);
 	}
 }

--- a/lambda/recipes-reindex/src/config.ts
+++ b/lambda/recipes-reindex/src/config.ts
@@ -1,0 +1,11 @@
+import {
+	createGetMandatoryNumberParameter,
+	createGetMandatoryParameter,
+} from 'lib/recipes-data/src/lib/parameters';
+
+export const getRecipeIndexSnapshotBucket = createGetMandatoryParameter(
+	'RECIPE_INDEX_SNAPSHOT_BUCKET',
+);
+
+export const getReindexBatchSize =
+	createGetMandatoryNumberParameter('REINDEX_BATCH_SIZE');

--- a/lambda/recipes-reindex/src/sharedConfig.ts
+++ b/lambda/recipes-reindex/src/sharedConfig.ts
@@ -1,5 +1,0 @@
-import { mandatoryParameter } from 'lib/recipes-data/src/lib/parameters';
-
-export const RecipeIndexSnapshotBucket = mandatoryParameter(
-	'RECIPE_INDEX_SNAPSHOT_BUCKET',
-);

--- a/lambda/recipes-reindex/src/snapshotRecipeReindex/config.ts
+++ b/lambda/recipes-reindex/src/snapshotRecipeReindex/config.ts
@@ -1,9 +1,0 @@
-import { mandatoryParameter } from 'lib/recipes-data/src/lib/parameters';
-import { RecipeIndexSnapshotBucket } from '../sharedConfig';
-
-export const getConfig = () => {
-	return {
-		RecipeIndexSnapshotBucket,
-		ContentUrlBase: mandatoryParameter('CONTENT_URL_BASE'),
-	};
-};

--- a/lambda/recipes-reindex/src/snapshotRecipeReindex/index.ts
+++ b/lambda/recipes-reindex/src/snapshotRecipeReindex/index.ts
@@ -1,13 +1,14 @@
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import type { Handler } from 'aws-lambda';
+import { getContentUrlBase } from 'lib/recipes-data/src/lib/config';
 import { INDEX_JSON } from 'lib/recipes-data/src/lib/constants';
 import type { RecipeIndex } from 'lib/recipes-data/src/lib/models';
+import { getRecipeIndexSnapshotBucket } from '../config';
 import { recipeIndexSnapshotKey } from '../constants';
 import type {
 	SnapshotRecipeIndexInput,
 	SnapshotRecipeIndexOutput,
 } from '../types';
-import { getConfig } from './config';
 
 const s3Client = new S3Client({ region: process.env['AWS_REGION'] });
 
@@ -15,10 +16,11 @@ export const snapshotRecipeIndexHandler: Handler<
 	SnapshotRecipeIndexInput,
 	SnapshotRecipeIndexOutput
 > = async (state) => {
-	const { ContentUrlBase, RecipeIndexSnapshotBucket } = getConfig();
+	const reindexSnapshotBucket = getRecipeIndexSnapshotBucket();
+	const contentUrlBase = getContentUrlBase();
 	const { executionId } = state;
 
-	const recipeIndexUrl = `https://${ContentUrlBase}/${INDEX_JSON}`;
+	const recipeIndexUrl = `https://${contentUrlBase}/${INDEX_JSON}`;
 	console.log(`Fetching recipe index from ${recipeIndexUrl}`);
 	const recipeIndexSnapshotResponse = await fetch(recipeIndexUrl);
 
@@ -29,20 +31,20 @@ export const snapshotRecipeIndexHandler: Handler<
 	const Key = `${executionId}/${recipeIndexSnapshotKey}`;
 
 	const req = new PutObjectCommand({
-		Bucket: RecipeIndexSnapshotBucket,
+		Bucket: reindexSnapshotBucket,
 		Key,
 		Body: JSON.stringify(recipeIndexSnapshotJson),
 		ContentType: 'application/json',
 	});
 
 	console.log(
-		`Writing recipe index for execution with ID ${executionId} to S3 at path ${RecipeIndexSnapshotBucket}/${Key}`,
+		`Writing recipe index for execution with ID ${executionId} to S3 at path ${reindexSnapshotBucket}/${Key}`,
 	);
 
 	await s3Client.send(req);
 
 	console.log(
-		`Written recipe index for execution with ID ${executionId} to S3 at path ${RecipeIndexSnapshotBucket}/${Key}`,
+		`Written recipe index for execution with ID ${executionId} to S3 at path ${reindexSnapshotBucket}/${Key}`,
 	);
 
 	return {

--- a/lambda/recipes-reindex/src/writeBatchToReindexQueue/config.ts
+++ b/lambda/recipes-reindex/src/writeBatchToReindexQueue/config.ts
@@ -1,7 +1,0 @@
-import { mandatoryParameter } from 'lib/recipes-data/src/lib/parameters';
-import { RecipeIndexSnapshotBucket } from '../sharedConfig';
-
-export const getConfig = () => ({
-	RecipeIndexSnapshotBucket,
-	ReindexBatchSize: parseInt(mandatoryParameter('REINDEX_BATCH_SIZE')),
-});

--- a/lambda/recipes-reindex/src/writeBatchToReindexQueue/index.test.ts
+++ b/lambda/recipes-reindex/src/writeBatchToReindexQueue/index.test.ts
@@ -7,18 +7,9 @@ import { writeBatchToReindexQueueHandler } from './index';
 const RecipeIndexSnapshotBucket = 'example-reindex-bucket';
 const ReindexBatchSize = 10;
 
-jest.mock('./config', () => ({
-	getConfig: () => ({
-		RecipeIndexSnapshotBucket,
-		ReindexBatchSize,
-	}),
-}));
-
-jest.mock('../sharedConfig', () => ({
-	getConfig: () => ({
-		RecipeIndexSnapshotBucket,
-		ReindexBatchSize: 10,
-	}),
+jest.mock('../config', () => ({
+	getRecipeIndexSnapshotBucket: () => RecipeIndexSnapshotBucket,
+	getReindexBatchSize: () => ReindexBatchSize,
 }));
 
 const s3Mock = mockClient(S3Client);

--- a/lambda/recipes-responder/src/main.test.ts
+++ b/lambda/recipes-responder/src/main.test.ts
@@ -35,7 +35,11 @@ jest.mock('./update_retrievable_processor', () => ({
 	handleContentUpdateRetrievable: jest.fn(),
 }));
 
-jest.mock('@recipes-api/lib/recipes-data', () => ({}));
+jest.mock('lib/recipes-data/src/lib/config', () => ({
+	getContentPrefix: () => 'cdn.content',
+	getFastlyApiKey: () => 'fastly-api-key',
+	getStaticBucketName: () => 'static-bucket',
+}));
 
 jest.mock('@recipes-api/cwmetrics', () => ({
 	registerMetric: jest.fn(),

--- a/lambda/recipes-responder/src/main.test.ts
+++ b/lambda/recipes-responder/src/main.test.ts
@@ -161,10 +161,12 @@ describe('main.processRecord', () => {
 		//@ts-ignore
 		expect(handleContentUpdateRetrievable.mock.calls.length).toEqual(1);
 		//@ts-ignore
-		expect(handleContentUpdateRetrievable.mock.calls[0][0].retrievable).toEqual({
-			id: 'test',
-			capiUrl: '/path/to/test',
-		});
+		expect(handleContentUpdateRetrievable.mock.calls[0][0].retrievable).toEqual(
+			{
+				id: 'test',
+				capiUrl: '/path/to/test',
+			},
+		);
 		//@ts-ignore
 		expect(handleDeletedContent.mock.calls.length).toEqual(0);
 	});

--- a/lambda/recipes-responder/src/main.test.ts
+++ b/lambda/recipes-responder/src/main.test.ts
@@ -88,11 +88,11 @@ describe('main.processRecord', () => {
 		//@ts-ignore
 		deserializeEvent.mockReturnValue(testEvent);
 		//@ts-ignore
-		await processRecord(testReq);
+		await processRecord({ eventDetail: testReq });
 		//@ts-ignore
 		expect(handleTakedown.mock.calls.length).toEqual(1);
 		//@ts-ignore
-		expect(handleTakedown.mock.calls[0][0]).toEqual(testEvent);
+		expect(handleTakedown.mock.calls[0][0].event).toEqual(testEvent);
 		//@ts-ignore
 		expect(handleContentUpdate.mock.calls.length).toEqual(0);
 		//@ts-ignore
@@ -119,13 +119,13 @@ describe('main.processRecord', () => {
 		//@ts-ignore
 		deserializeEvent.mockReturnValue(testEvent);
 		//@ts-ignore
-		await processRecord(testReq);
+		await processRecord({ eventDetail: testReq });
 		//@ts-ignore
 		expect(handleTakedown.mock.calls.length).toEqual(0);
 		//@ts-ignore
 		expect(handleContentUpdate.mock.calls.length).toEqual(1);
 		//@ts-ignore
-		expect(handleContentUpdate.mock.calls[0][0]).toEqual(testContent);
+		expect(handleContentUpdate.mock.calls[0][0].content).toEqual(testContent);
 		//@ts-ignore
 		expect(handleContentUpdateRetrievable.mock.calls.length).toEqual(0);
 		//@ts-ignore
@@ -153,7 +153,7 @@ describe('main.processRecord', () => {
 		//@ts-ignore
 		deserializeEvent.mockReturnValue(testEvent);
 		//@ts-ignore
-		await processRecord(testReq);
+		await processRecord({ eventDetail: testReq });
 		//@ts-ignore
 		expect(handleTakedown.mock.calls.length).toEqual(0);
 		//@ts-ignore
@@ -161,7 +161,7 @@ describe('main.processRecord', () => {
 		//@ts-ignore
 		expect(handleContentUpdateRetrievable.mock.calls.length).toEqual(1);
 		//@ts-ignore
-		expect(handleContentUpdateRetrievable.mock.calls[0][0]).toEqual({
+		expect(handleContentUpdateRetrievable.mock.calls[0][0].retrievable).toEqual({
 			id: 'test',
 			capiUrl: '/path/to/test',
 		});
@@ -198,7 +198,7 @@ describe('main.processRecord', () => {
 		//@ts-ignore
 		deserializeEvent.mockReturnValue(testEvent);
 		//@ts-ignore
-		await processRecord(testReq);
+		await processRecord({ eventDetail: testReq });
 		//@ts-ignore
 		expect(handleTakedown.mock.calls.length).toEqual(0);
 		//@ts-ignore
@@ -240,11 +240,11 @@ describe('main.processRecord', () => {
 		//@ts-ignore
 		deserializeEvent.mockReturnValue(testEvent);
 		//@ts-ignore
-		await processRecord(testReq);
+		await processRecord({ eventDetail: testReq });
 		//@ts-ignore
 		expect(handleTakedown.mock.calls.length).toEqual(1);
 		//@ts-ignore
-		expect(handleTakedown.mock.calls[0][0]).toEqual(testEvent);
+		expect(handleTakedown.mock.calls[0][0].event).toEqual(testEvent);
 		//@ts-ignore
 		expect(handleContentUpdate.mock.calls.length).toEqual(0);
 		//@ts-ignore
@@ -271,7 +271,7 @@ describe('main.processRecord', () => {
 		//@ts-ignore
 		deserializeEvent.mockReturnValue(testEvent);
 		//@ts-ignore
-		const result = await processRecord(testReq);
+		const result = await processRecord({ eventDetail: testReq });
 		expect(result).toEqual(0);
 		//@ts-ignore
 		expect(handleTakedown.mock.calls.length).toEqual(0);

--- a/lambda/recipes-responder/src/takedown_processor.test.ts
+++ b/lambda/recipes-responder/src/takedown_processor.test.ts
@@ -19,6 +19,7 @@ jest.mock('../../../lib/recipes-data/src/lib/eventbus', () => ({
 
 const staticBucketName = 'static-bucket-name';
 const fastlyApiKey = 'fastly-api-key';
+const contentPrefix = 'cdn.content.location';
 
 describe('takedown_processor.handleTakedown', () => {
 	beforeEach(() => {
@@ -36,15 +37,20 @@ describe('takedown_processor.handleTakedown', () => {
 			dateTime: new Int64(Date.now()),
 		};
 
-		const count = await handleTakedown(testEvt, staticBucketName, fastlyApiKey);
+		const count = await handleTakedown({
+			event: testEvt,
+			staticBucketName,
+			fastlyApiKey,
+			contentPrefix,
+		});
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeAllRecipesForArticle.mock.calls.length).toEqual(1);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(awaitableDelay.mock.calls.length).toEqual(0);
-		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeAllRecipesForArticle.mock.calls[0][0]).toEqual(
-			'path/to/article/id',
-		);
+		expect(
+			// @ts-ignore -- Typescript doesn't know that this is a mock
+			removeAllRecipesForArticle.mock.calls[0][0].canonicalArticleId,
+		).toEqual('path/to/article/id');
 		expect(count).toEqual(1);
 	});
 
@@ -56,7 +62,12 @@ describe('takedown_processor.handleTakedown', () => {
 			dateTime: new Int64(Date.now()),
 		};
 
-		const count = await handleTakedown(testEvt, staticBucketName, fastlyApiKey);
+		const count = await handleTakedown({
+			event: testEvt,
+			staticBucketName,
+			fastlyApiKey,
+			contentPrefix,
+		});
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeAllRecipesForArticle.mock.calls.length).toEqual(0);
 		// @ts-ignore -- Typescript doesn't know that this is a mock

--- a/lambda/recipes-responder/src/takedown_processor.test.ts
+++ b/lambda/recipes-responder/src/takedown_processor.test.ts
@@ -17,6 +17,9 @@ jest.mock('../../../lib/recipes-data/src/lib/eventbus', () => ({
 	announce_new_recipe: jest.fn(),
 }));
 
+const staticBucketName = 'static-bucket-name';
+const fastlyApiKey = 'fastly-api-key';
+
 describe('takedown_processor.handleTakedown', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
@@ -33,7 +36,7 @@ describe('takedown_processor.handleTakedown', () => {
 			dateTime: new Int64(Date.now()),
 		};
 
-		const count = await handleTakedown(testEvt);
+		const count = await handleTakedown(testEvt, staticBucketName, fastlyApiKey);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeAllRecipesForArticle.mock.calls.length).toEqual(1);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
@@ -53,7 +56,7 @@ describe('takedown_processor.handleTakedown', () => {
 			dateTime: new Int64(Date.now()),
 		};
 
-		const count = await handleTakedown(testEvt);
+		const count = await handleTakedown(testEvt, staticBucketName, fastlyApiKey);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeAllRecipesForArticle.mock.calls.length).toEqual(0);
 		// @ts-ignore -- Typescript doesn't know that this is a mock

--- a/lambda/recipes-responder/src/takedown_processor.ts
+++ b/lambda/recipes-responder/src/takedown_processor.ts
@@ -3,20 +3,27 @@ import type { Event } from '@guardian/content-api-models/crier/event/v1/event';
 import { ItemType } from '@guardian/content-api-models/crier/event/v1/itemType';
 import { removeAllRecipesForArticle } from '@recipes-api/lib/recipes-data';
 
-export async function handleTakedown(
-	evt: Event,
-	staticBucketName: string,
-	fastlyApiKey: string,
-): Promise<number> {
-	console.log('takedown payload: ', JSON.stringify(evt));
+export async function handleTakedown({
+	event,
+	staticBucketName,
+	fastlyApiKey,
+	contentPrefix,
+}: {
+	event: Event;
+	staticBucketName: string;
+	fastlyApiKey: string;
+	contentPrefix: string;
+}): Promise<number> {
+	console.log('takedown payload: ', JSON.stringify(event));
 
-	if (evt.itemType == ItemType.CONTENT) {
+	if (event.itemType == ItemType.CONTENT) {
 		//there's no payload in the takedown message!
-		return removeAllRecipesForArticle(
-			evt.payloadId,
+		return removeAllRecipesForArticle({
+			canonicalArticleId: event.payloadId,
 			staticBucketName,
 			fastlyApiKey,
-		); //evt.payloadId is the canonical article ref that was taken down
+			contentPrefix,
+		}); //event.payloadId is the canonical article ref that was taken down
 	} else {
 		return 0;
 	}

--- a/lambda/recipes-responder/src/takedown_processor.ts
+++ b/lambda/recipes-responder/src/takedown_processor.ts
@@ -3,12 +3,20 @@ import type { Event } from '@guardian/content-api-models/crier/event/v1/event';
 import { ItemType } from '@guardian/content-api-models/crier/event/v1/itemType';
 import { removeAllRecipesForArticle } from '@recipes-api/lib/recipes-data';
 
-export async function handleTakedown(evt: Event): Promise<number> {
+export async function handleTakedown(
+	evt: Event,
+	staticBucketName: string,
+	fastlyApiKey: string,
+): Promise<number> {
 	console.log('takedown payload: ', JSON.stringify(evt));
 
 	if (evt.itemType == ItemType.CONTENT) {
 		//there's no payload in the takedown message!
-		return removeAllRecipesForArticle(evt.payloadId); //evt.payloadId is the canonical article ref that was taken down
+		return removeAllRecipesForArticle(
+			evt.payloadId,
+			staticBucketName,
+			fastlyApiKey,
+		); //evt.payloadId is the canonical article ref that was taken down
 	} else {
 		return 0;
 	}

--- a/lambda/recipes-responder/src/update_processor.test.ts
+++ b/lambda/recipes-responder/src/update_processor.test.ts
@@ -171,7 +171,9 @@ describe('update_processor.handleContentUpdate', () => {
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipeVersion.mock.calls.length).toEqual(2);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeVersion.mock.calls[0][0].canonicalArticleId).toEqual('path/to/content');
+		expect(removeRecipeVersion.mock.calls[0][0].canonicalArticleId).toEqual(
+			'path/to/content',
+		);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipeVersion.mock.calls[0][0].recipe).toEqual({
 			checksum: 'xxxyyyzzz',
@@ -180,7 +182,9 @@ describe('update_processor.handleContentUpdate', () => {
 			sponsorshipCount: 0,
 		});
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeVersion.mock.calls[1][0].canonicalArticleId).toEqual('path/to/content');
+		expect(removeRecipeVersion.mock.calls[1][0].canonicalArticleId).toEqual(
+			'path/to/content',
+		);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipeVersion.mock.calls[1][0].recipe).toEqual({
 			checksum: 'zzzyyyqqq',

--- a/lambda/recipes-responder/src/update_processor.test.ts
+++ b/lambda/recipes-responder/src/update_processor.test.ts
@@ -19,6 +19,7 @@ import Mock = jest.Mock;
 
 const staticBucketName = 'static-bucket';
 const fastlyApiKey = 'fastly-api-key';
+const contentPrefix = 'cdn.content.location';
 
 jest.mock('@recipes-api/lib/recipes-data', () => ({
 	calculateChecksum: jest.fn(),
@@ -101,7 +102,12 @@ describe('update_processor.handleContentUpdate', () => {
 				sponsorshipCount: 0,
 			});
 
-		await handleContentUpdate(fakeContent, staticBucketName, fastlyApiKey);
+		await handleContentUpdate({
+			content: fakeContent,
+			staticBucketName,
+			fastlyApiKey,
+			contentPrefix,
+		});
 
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(extractAllRecipesFromArticle.mock.calls.length).toEqual(1);
@@ -141,21 +147,21 @@ describe('update_processor.handleContentUpdate', () => {
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(publishRecipeContent.mock.calls.length).toEqual(3);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(publishRecipeContent.mock.calls[0][0]).toEqual({
+		expect(publishRecipeContent.mock.calls[0][0].recipe).toEqual({
 			recipeUID: 'uid-recep-1',
 			checksum: 'abcd1',
 			jsonBlob: '',
 			sponsorshipCount: 0,
 		});
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(publishRecipeContent.mock.calls[1][0]).toEqual({
+		expect(publishRecipeContent.mock.calls[1][0].recipe).toEqual({
 			recipeUID: 'uid-recep-2',
 			checksum: 'efgh',
 			jsonBlob: '',
 			sponsorshipCount: 0,
 		});
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(publishRecipeContent.mock.calls[2][0]).toEqual({
+		expect(publishRecipeContent.mock.calls[2][0].recipe).toEqual({
 			recipeUID: 'uid-recep-3',
 			checksum: 'xyzp',
 			jsonBlob: '',
@@ -165,18 +171,18 @@ describe('update_processor.handleContentUpdate', () => {
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipeVersion.mock.calls.length).toEqual(2);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeVersion.mock.calls[0][0]).toEqual('path/to/content');
+		expect(removeRecipeVersion.mock.calls[0][0].canonicalArticleId).toEqual('path/to/content');
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeVersion.mock.calls[0][1]).toEqual({
+		expect(removeRecipeVersion.mock.calls[0][0].recipe).toEqual({
 			checksum: 'xxxyyyzzz',
 			recipeUID: 'uid-recep-2',
 			capiArticleId: 'path/to/article',
 			sponsorshipCount: 0,
 		});
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeVersion.mock.calls[1][0]).toEqual('path/to/content');
+		expect(removeRecipeVersion.mock.calls[1][0].canonicalArticleId).toEqual('path/to/content');
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeVersion.mock.calls[1][1]).toEqual({
+		expect(removeRecipeVersion.mock.calls[1][0].recipe).toEqual({
 			checksum: 'zzzyyyqqq',
 			recipeUID: 'uid-recep-4',
 			capiArticleId: 'path/to/article',
@@ -244,11 +250,12 @@ describe('update_processor.handleContentUpdate', () => {
 				sponsorshipCount: 0,
 			});
 
-		await handleContentUpdate(
-			{ ...fakeContent, type: ContentType.GALLERY },
+		await handleContentUpdate({
+			content: { ...fakeContent, type: ContentType.GALLERY },
 			staticBucketName,
 			fastlyApiKey,
-		);
+			contentPrefix,
+		});
 
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(extractAllRecipesFromArticle.mock.calls.length).toEqual(0);
@@ -282,7 +289,12 @@ describe('update_processor.handleContentUpdate', () => {
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		recipesToTakeDown.mockReturnValue(refsToRemove);
 
-		await handleContentUpdate(fakeContent, staticBucketName, fastlyApiKey);
+		await handleContentUpdate({
+			content: fakeContent,
+			staticBucketName,
+			fastlyApiKey,
+			contentPrefix,
+		});
 
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(extractAllRecipesFromArticle.mock.calls.length).toEqual(1);
@@ -361,7 +373,12 @@ describe('update_processor.handleContentUpdate', () => {
 				sponsorshipCount: 0,
 			});
 
-		await handleContentUpdate(fakeContent, staticBucketName, fastlyApiKey);
+		await handleContentUpdate({
+			content: fakeContent,
+			staticBucketName,
+			fastlyApiKey,
+			contentPrefix,
+		});
 
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(extractAllRecipesFromArticle.mock.calls.length).toEqual(1);
@@ -401,21 +418,21 @@ describe('update_processor.handleContentUpdate', () => {
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(publishRecipeContent.mock.calls.length).toEqual(3);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(publishRecipeContent.mock.calls[0][0]).toEqual({
+		expect(publishRecipeContent.mock.calls[0][0].recipe).toEqual({
 			recipeUID: 'uid-recep-1',
 			checksum: 'abcd1',
 			jsonBlob: '',
 			sponsorshipCount: 0,
 		});
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(publishRecipeContent.mock.calls[1][0]).toEqual({
+		expect(publishRecipeContent.mock.calls[1][0].recipe).toEqual({
 			recipeUID: 'uid-recep-2',
 			checksum: 'efgh',
 			jsonBlob: '',
 			sponsorshipCount: 0,
 		});
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(publishRecipeContent.mock.calls[2][0]).toEqual({
+		expect(publishRecipeContent.mock.calls[2][0].recipe).toEqual({
 			recipeUID: 'uid-recep-3',
 			checksum: 'xyzp',
 			jsonBlob: '',
@@ -425,18 +442,22 @@ describe('update_processor.handleContentUpdate', () => {
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipeVersion.mock.calls.length).toEqual(2);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeVersion.mock.calls[0][0]).toEqual('path/to/content');
+		expect(removeRecipeVersion.mock.calls[0][0].canonicalArticleId).toEqual(
+			'path/to/content',
+		);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeVersion.mock.calls[0][1]).toEqual({
+		expect(removeRecipeVersion.mock.calls[0][0].recipe).toEqual({
 			checksum: 'xxxyyyzzz',
 			recipeUID: 'uid-recep-2',
 			capiArticleId: 'path/to/article',
 			sponsorshipCount: 0,
 		});
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeVersion.mock.calls[1][0]).toEqual('path/to/content');
+		expect(removeRecipeVersion.mock.calls[1][0].canonicalArticleId).toEqual(
+			'path/to/content',
+		);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeVersion.mock.calls[1][1]).toEqual({
+		expect(removeRecipeVersion.mock.calls[1][0].recipe).toEqual({
 			checksum: 'zzzyyyqqq',
 			recipeUID: 'uid-recep-4',
 			capiArticleId: 'path/to/article',

--- a/lambda/recipes-responder/src/update_processor.test.ts
+++ b/lambda/recipes-responder/src/update_processor.test.ts
@@ -17,6 +17,9 @@ import {
 import { handleContentUpdate } from './update_processor';
 import Mock = jest.Mock;
 
+const staticBucketName = 'static-bucket';
+const fastlyApiKey = 'fastly-api-key';
+
 jest.mock('@recipes-api/lib/recipes-data', () => ({
 	calculateChecksum: jest.fn(),
 	extractAllRecipesFromArticle: jest.fn(),
@@ -98,7 +101,7 @@ describe('update_processor.handleContentUpdate', () => {
 				sponsorshipCount: 0,
 			});
 
-		await handleContentUpdate(fakeContent);
+		await handleContentUpdate(fakeContent, staticBucketName, fastlyApiKey);
 
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(extractAllRecipesFromArticle.mock.calls.length).toEqual(1);
@@ -241,7 +244,11 @@ describe('update_processor.handleContentUpdate', () => {
 				sponsorshipCount: 0,
 			});
 
-		await handleContentUpdate({ ...fakeContent, type: ContentType.GALLERY });
+		await handleContentUpdate(
+			{ ...fakeContent, type: ContentType.GALLERY },
+			staticBucketName,
+			fastlyApiKey,
+		);
 
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(extractAllRecipesFromArticle.mock.calls.length).toEqual(0);
@@ -275,7 +282,7 @@ describe('update_processor.handleContentUpdate', () => {
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		recipesToTakeDown.mockReturnValue(refsToRemove);
 
-		await handleContentUpdate(fakeContent);
+		await handleContentUpdate(fakeContent, staticBucketName, fastlyApiKey);
 
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(extractAllRecipesFromArticle.mock.calls.length).toEqual(1);
@@ -354,7 +361,7 @@ describe('update_processor.handleContentUpdate', () => {
 				sponsorshipCount: 0,
 			});
 
-		await handleContentUpdate(fakeContent);
+		await handleContentUpdate(fakeContent, staticBucketName, fastlyApiKey);
 
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(extractAllRecipesFromArticle.mock.calls.length).toEqual(1);

--- a/lambda/recipes-responder/src/update_processor.ts
+++ b/lambda/recipes-responder/src/update_processor.ts
@@ -20,6 +20,8 @@ import {
 async function publishRecipe(
 	canonicalArticleId: string,
 	recep: RecipeReference,
+	staticBucketName: string,
+	fastlyApiKey: string,
 ): Promise<void> {
 	try {
 		await sendTelemetryEvent('PublishedData', recep.recipeUID, recep.jsonBlob);
@@ -29,7 +31,7 @@ async function publishRecipe(
 	console.log(
 		`INFO [${canonicalArticleId}] - pushing ${recep.recipeUID} @ ${recep.checksum} to S3...`,
 	);
-	await publishRecipeContent(recep);
+	await publishRecipeContent(recep, staticBucketName, fastlyApiKey);
 	console.log(`INFO [${canonicalArticleId}] - updating index table...`);
 	await insertNewRecipe(canonicalArticleId, {
 		recipeUID: recep.recipeUID,
@@ -45,7 +47,11 @@ async function publishRecipe(
  * @returns a number, representing the number of recipes that were added plus the number that were deleted (i.e., an
  * update counts as 1 add and 1 delete)
  */
-export async function handleContentUpdate(content: Content): Promise<number> {
+export async function handleContentUpdate(
+	content: Content,
+	staticBucketName: string,
+	fastlyApiKey: string,
+): Promise<number> {
 	try {
 		if (content.type != ContentType.ARTICLE) return 0; //no point processing live-blogs etc.
 
@@ -62,7 +68,9 @@ export async function handleContentUpdate(content: Content): Promise<number> {
 		);
 		if (allRecipes.length == 0 && entriesToRemove.length == 0) return 0; //no point hanging around and noising up the logs
 		await Promise.all(
-			entriesToRemove.map((recep) => removeRecipeVersion(content.id, recep)),
+			entriesToRemove.map((recep) =>
+				removeRecipeVersion(content.id, recep, staticBucketName, fastlyApiKey),
+			),
 		);
 		console.log(
 			`INFO [${content.id}] - ${entriesToRemove.length} removed/superceded recipes have been removed from the store`,
@@ -72,7 +80,9 @@ export async function handleContentUpdate(content: Content): Promise<number> {
 			`INFO [${content.id}] - publishing ${allRecipes.length} new/updated recipes to the service`,
 		);
 		await Promise.all(
-			allRecipes.map((recep) => publishRecipe(content.id, recep)),
+			allRecipes.map((recep) =>
+				publishRecipe(content.id, recep, staticBucketName, fastlyApiKey),
+			),
 		);
 
 		console.log(

--- a/lambda/recipes-responder/src/update_retrievable_processor.test.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.test.ts
@@ -36,6 +36,7 @@ const fakeContent: Content = {
 
 const staticBucketName = 'static-bucket';
 const fastlyApiKey = 'fastly-api-key';
+const contentPrefix = 'cdn.content.location';
 
 describe('handleContentUpdateRetrievable', () => {
 	beforeEach(() => {
@@ -50,11 +51,12 @@ describe('handleContentUpdateRetrievable', () => {
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		handleContentUpdate.mockReturnValue(Promise.resolve(3));
 
-		const recordCount = await handleContentUpdateRetrievable(
-			fakeUpdate,
+		const recordCount = await handleContentUpdateRetrievable({
+			retrievable: fakeUpdate,
 			staticBucketName,
 			fastlyApiKey,
-		);
+			contentPrefix,
+		});
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(callCAPI.mock.calls.length).toEqual(1);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
@@ -68,7 +70,7 @@ describe('handleContentUpdateRetrievable', () => {
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(handleContentUpdate.mock.calls.length).toEqual(1);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
-		expect(handleContentUpdate.mock.calls[0][0]).toEqual(fakeContent);
+		expect(handleContentUpdate.mock.calls[0][0].content).toEqual(fakeContent);
 		expect(recordCount).toEqual(3); //it should pass back the value returned by handleContentUpdate
 	});
 
@@ -78,14 +80,15 @@ describe('handleContentUpdateRetrievable', () => {
 			Promise.resolve({ action: 0, content: fakeContent }),
 		);
 
-		const recordCount = await handleContentUpdateRetrievable(
-			{
+		const recordCount = await handleContentUpdateRetrievable({
+			retrievable: {
 				...fakeUpdate,
 				contentType: ContentType.GALLERY,
 			},
 			staticBucketName,
 			fastlyApiKey,
-		);
+			contentPrefix,
+		});
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(callCAPI.mock.calls.length).toEqual(0);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
@@ -100,11 +103,12 @@ describe('handleContentUpdateRetrievable', () => {
 		);
 
 		await expect(
-			handleContentUpdateRetrievable(
-				fakeUpdate,
+			handleContentUpdateRetrievable({
+				retrievable: fakeUpdate,
 				staticBucketName,
 				fastlyApiKey,
-			),
+				contentPrefix,
+			}),
 		).rejects.toEqual(
 			new Error(
 				'Could not handle retrievable update from CAPI: PollingAction code was 4. Allowing the lambda runtime to retry or DLQ.',
@@ -123,11 +127,12 @@ describe('handleContentUpdateRetrievable', () => {
 			Promise.resolve({ action: 1, content: fakeContent }),
 		);
 
-		const recordCount = await handleContentUpdateRetrievable(
-			fakeUpdate,
+		const recordCount = await handleContentUpdateRetrievable({
+			retrievable: fakeUpdate,
 			staticBucketName,
 			fastlyApiKey,
-		);
+			contentPrefix,
+		});
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(callCAPI.mock.calls.length).toEqual(1);
 		// @ts-ignore -- Typescript doesn't know that this is a mock

--- a/lambda/recipes-responder/src/update_retrievable_processor.test.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.test.ts
@@ -34,6 +34,9 @@ const fakeContent: Content = {
 	webUrl: 'web://path/to/content',
 };
 
+const staticBucketName = 'static-bucket';
+const fastlyApiKey = 'fastly-api-key';
+
 describe('handleContentUpdateRetrievable', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
@@ -47,7 +50,11 @@ describe('handleContentUpdateRetrievable', () => {
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		handleContentUpdate.mockReturnValue(Promise.resolve(3));
 
-		const recordCount = await handleContentUpdateRetrievable(fakeUpdate);
+		const recordCount = await handleContentUpdateRetrievable(
+			fakeUpdate,
+			staticBucketName,
+			fastlyApiKey,
+		);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(callCAPI.mock.calls.length).toEqual(1);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
@@ -71,10 +78,14 @@ describe('handleContentUpdateRetrievable', () => {
 			Promise.resolve({ action: 0, content: fakeContent }),
 		);
 
-		const recordCount = await handleContentUpdateRetrievable({
-			...fakeUpdate,
-			contentType: ContentType.GALLERY,
-		});
+		const recordCount = await handleContentUpdateRetrievable(
+			{
+				...fakeUpdate,
+				contentType: ContentType.GALLERY,
+			},
+			staticBucketName,
+			fastlyApiKey,
+		);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(callCAPI.mock.calls.length).toEqual(0);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
@@ -88,7 +99,13 @@ describe('handleContentUpdateRetrievable', () => {
 			Promise.resolve({ action: 4, content: fakeContent }),
 		);
 
-		await expect(handleContentUpdateRetrievable(fakeUpdate)).rejects.toEqual(
+		await expect(
+			handleContentUpdateRetrievable(
+				fakeUpdate,
+				staticBucketName,
+				fastlyApiKey,
+			),
+		).rejects.toEqual(
 			new Error(
 				'Could not handle retrievable update from CAPI: PollingAction code was 4. Allowing the lambda runtime to retry or DLQ.',
 			),
@@ -106,7 +123,11 @@ describe('handleContentUpdateRetrievable', () => {
 			Promise.resolve({ action: 1, content: fakeContent }),
 		);
 
-		const recordCount = await handleContentUpdateRetrievable(fakeUpdate);
+		const recordCount = await handleContentUpdateRetrievable(
+			fakeUpdate,
+			staticBucketName,
+			fastlyApiKey,
+		);
 		// @ts-ignore -- Typescript doesn't know that this is a mock
 		expect(callCAPI.mock.calls.length).toEqual(1);
 		// @ts-ignore -- Typescript doesn't know that this is a mock

--- a/lambda/recipes-responder/src/update_retrievable_processor.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.ts
@@ -41,11 +41,17 @@ export async function retrieveContent(capiUrl: string): Promise<PollingResult> {
 	return callCAPI(`${capiUrl}?${params}`);
 }
 
-export async function handleContentUpdateRetrievable(
-	retrievable: RetrievableContent,
-	staticBucketName: string,
-	fastlyApiKey: string,
-): Promise<number> {
+export async function handleContentUpdateRetrievable({
+	retrievable,
+	staticBucketName,
+	fastlyApiKey,
+	contentPrefix,
+}: {
+	retrievable: RetrievableContent;
+	staticBucketName: string;
+	fastlyApiKey: string;
+	contentPrefix: string;
+}): Promise<number> {
 	if (retrievable.contentType != ContentType.ARTICLE) return 0; //no point processing live-blogs etc.
 
 	// TO FIX UPSTREAM – Crier returns a path that does not include channelled content, giving a 404
@@ -69,11 +75,12 @@ export async function handleContentUpdateRetrievable(
 					`INFO Retrievable update was superceded - we expected to see ${retrievable.internalRevision} but got ${capiResponse.content.fields.internalRevision}`,
 				);
 			} else if (capiResponse.content) {
-				return handleContentUpdate(
-					capiResponse.content,
+				return handleContentUpdate({
+					content: capiResponse.content,
 					staticBucketName,
 					fastlyApiKey,
-				);
+					contentPrefix,
+				});
 			} else {
 				console.error(
 					"Content existed but was empty, this shouldn't happen :(",

--- a/lambda/recipes-responder/src/update_retrievable_processor.ts
+++ b/lambda/recipes-responder/src/update_retrievable_processor.ts
@@ -43,6 +43,8 @@ export async function retrieveContent(capiUrl: string): Promise<PollingResult> {
 
 export async function handleContentUpdateRetrievable(
 	retrievable: RetrievableContent,
+	staticBucketName: string,
+	fastlyApiKey: string,
 ): Promise<number> {
 	if (retrievable.contentType != ContentType.ARTICLE) return 0; //no point processing live-blogs etc.
 
@@ -67,7 +69,11 @@ export async function handleContentUpdateRetrievable(
 					`INFO Retrievable update was superceded - we expected to see ${retrievable.internalRevision} but got ${capiResponse.content.fields.internalRevision}`,
 				);
 			} else if (capiResponse.content) {
-				return handleContentUpdate(capiResponse.content);
+				return handleContentUpdate(
+					capiResponse.content,
+					staticBucketName,
+					fastlyApiKey,
+				);
 			} else {
 				console.error(
 					"Content existed but was empty, this shouldn't happen :(",

--- a/lambda/test-indexbuild/src/config.ts
+++ b/lambda/test-indexbuild/src/config.ts
@@ -1,1 +1,0 @@
-export const StaticBucketName = process.env['STATIC_BUCKET'];

--- a/lambda/test-indexbuild/src/main.ts
+++ b/lambda/test-indexbuild/src/main.ts
@@ -5,8 +5,17 @@ import {
 	V2_INDEX_JSON,
 	writeIndexData,
 } from '@recipes-api/lib/recipes-data';
+import {
+	getContentPrefix,
+	getFastlyApiKey,
+	getStaticBucketName,
+} from 'lib/recipes-data/src/lib/config';
 
 export const handler: Handler = async () => {
+	const staticBucketName = getStaticBucketName();
+	const contentPrefix = getContentPrefix();
+	const fastlyApiKey = getFastlyApiKey();
+
 	console.log('Index test starting up');
 
 	console.log('Retrieving index data...');
@@ -35,7 +44,19 @@ export const handler: Handler = async () => {
 	}
 
 	console.log('Done.');
-	await writeIndexData(indexDataForUnSponsoredRecipes, INDEX_JSON);
-	await writeIndexData(indexDataForAllRecipes, V2_INDEX_JSON);
+	await writeIndexData(
+		indexDataForUnSponsoredRecipes,
+		INDEX_JSON,
+		staticBucketName,
+		contentPrefix,
+		fastlyApiKey,
+	);
+	await writeIndexData(
+		indexDataForAllRecipes,
+		V2_INDEX_JSON,
+		staticBucketName,
+		contentPrefix,
+		fastlyApiKey,
+	);
 	console.log('All completed.');
 };

--- a/lambda/test-indexbuild/src/main.ts
+++ b/lambda/test-indexbuild/src/main.ts
@@ -44,19 +44,19 @@ export const handler: Handler = async () => {
 	}
 
 	console.log('Done.');
-	await writeIndexData(
-		indexDataForUnSponsoredRecipes,
-		INDEX_JSON,
+	await writeIndexData({
+		indexData: indexDataForUnSponsoredRecipes,
+		Key: INDEX_JSON,
 		staticBucketName,
 		contentPrefix,
 		fastlyApiKey,
-	);
-	await writeIndexData(
-		indexDataForAllRecipes,
-		V2_INDEX_JSON,
+	});
+	await writeIndexData({
+		indexData: indexDataForAllRecipes,
+		Key: V2_INDEX_JSON,
 		staticBucketName,
 		contentPrefix,
 		fastlyApiKey,
-	);
+	});
 	console.log('All completed.');
 };

--- a/lib/recipes-data/src/index.ts
+++ b/lib/recipes-data/src/index.ts
@@ -7,6 +7,7 @@ export * from './lib/telemetry';
 export * from './lib/curation';
 export * from './lib/constants';
 export * from './lib/eventbus';
+export * from './lib/config';
 
 export { sendFastlyPurgeRequestWithRetries } from './lib/fastly';
 export {

--- a/lib/recipes-data/src/lib/config.ts
+++ b/lib/recipes-data/src/lib/config.ts
@@ -1,6 +1,6 @@
 //Used by dynamo.ts
 import * as process from 'process';
-import { mandatoryParameter } from './parameters';
+import { createGetMandatoryParameter } from './parameters';
 
 export const AwsRegion = process.env['AWS_REGION'];
 export const indexTableName = process.env['INDEX_TABLE'];
@@ -8,10 +8,18 @@ export const lastUpdatedIndex = process.env['LAST_UPDATED_INDEX'];
 
 //Used by fastly.ts
 const UrlPrefix = /^http(s)?:\/\//;
-export const ContentUrlBase = mandatoryParameter('CONTENT_URL_BASE');
-export const ContentPrefix = ContentUrlBase
-	? ContentUrlBase.replace(UrlPrefix, '')
-	: undefined;
+export const getContentUrlBase =
+	createGetMandatoryParameter('CONTENT_URL_BASE');
+export const getContentPrefix = () => {
+	const contentUrlBase = getContentUrlBase();
+
+	if (contentUrlBase === '') {
+		throw new Error(
+			'Attempted to create content prefix, but CONTENT_URL_BASE is an empty string.',
+		);
+	}
+	return contentUrlBase.replace(UrlPrefix, '');
+};
 export const DebugLogsEnabled = process.env['DEBUG_LOGS']
 	? process.env['DEBUG_LOGS'].toLowerCase() === 'true'
 	: false;
@@ -21,10 +29,10 @@ export const MaximumRetries = process.env['MAX_RETRIES']
 export const RetryDelaySeconds = process.env['RETRY_DELAY']
 	? parseInt(process.env['RETRY_DELAY'])
 	: 1;
-export const FastlyApiKey = process.env['FASTLY_API_KEY'];
+export const getFastlyApiKey = createGetMandatoryParameter('FASTLY_API_KEY');
 
 //Used by s3.ts
-export const StaticBucketName = mandatoryParameter('STATIC_BUCKET');
+export const getStaticBucketName = createGetMandatoryParameter('STATIC_BUCKET');
 
 //Used by telemetry
 export const TelemetryXAR = process.env['TELEMETRY_XAR'];

--- a/lib/recipes-data/src/lib/curation.test.ts
+++ b/lib/recipes-data/src/lib/curation.test.ts
@@ -13,6 +13,7 @@ jest.mock('./config', () => ({
 
 const staticBucketName = 'static-bucket';
 const fastlyApiKey = 'fastly-api-key';
+const contentPrefix = 'cdn.content.location';
 
 jest.mock('./fastly', () => ({
 	sendFastlyPurgeRequestWithRetries: jest.fn(),
@@ -30,8 +31,7 @@ describe('importNewData', () => {
 			'some-region',
 			'some-variant',
 			null,
-			staticBucketName,
-			fastlyApiKey,
+			{ staticBucketName, fastlyApiKey, contentPrefix },
 		);
 
 		expect(s3Mock.calls().length).toEqual(1);
@@ -45,24 +45,21 @@ describe('importNewData', () => {
 		const fastlyPurgeMock = sendFastlyPurgeRequestWithRetries as MockedFn<
 			typeof sendFastlyPurgeRequestWithRetries
 		>;
-		expect(fastlyPurgeMock.mock.calls[0][0]).toEqual(
+		expect(fastlyPurgeMock.mock.calls[0][0].contentPath).toEqual(
 			`some-region/some-variant/curation.json`,
 		);
-		expect(fastlyPurgeMock.mock.calls[0][1]).toEqual(fastlyApiKey);
-		expect(fastlyPurgeMock.mock.calls[0][2]).toEqual('hard');
+		expect(fastlyPurgeMock.mock.calls[0][0].apiKey).toEqual(fastlyApiKey);
+		expect(fastlyPurgeMock.mock.calls[0][0].purgeType).toEqual('hard');
 	});
 
 	it('should respect the date parameter if given', async () => {
 		const d = new Date(2021, 5, 5); //Note - actually 5th Jun - due to Date() constructor weirdness
 
-		await deployCurationData(
-			'test-content',
-			'some-region',
-			'some-variant',
-			d,
+		await deployCurationData('test-content', 'some-region', 'some-variant', d, {
 			staticBucketName,
 			fastlyApiKey,
-		);
+			contentPrefix,
+		});
 
 		expect(s3Mock.calls().length).toEqual(1);
 		const uploadArgs = s3Mock.call(0).firstArg as PutObjectCommand;
@@ -75,10 +72,10 @@ describe('importNewData', () => {
 		const fastlyPurgeMock = sendFastlyPurgeRequestWithRetries as MockedFn<
 			typeof sendFastlyPurgeRequestWithRetries
 		>;
-		expect(fastlyPurgeMock.mock.calls[0][0]).toEqual(
+		expect(fastlyPurgeMock.mock.calls[0][0].contentPath).toEqual(
 			`some-region/some-variant/2021-06-05/curation.json`,
 		);
-		expect(fastlyPurgeMock.mock.calls[0][1]).toEqual(fastlyApiKey);
-		expect(fastlyPurgeMock.mock.calls[0][2]).toEqual('hard');
+		expect(fastlyPurgeMock.mock.calls[0][0].apiKey).toEqual(fastlyApiKey);
+		expect(fastlyPurgeMock.mock.calls[0][0].purgeType).toEqual('hard');
 	});
 });

--- a/lib/recipes-data/src/lib/curation.ts
+++ b/lib/recipes-data/src/lib/curation.ts
@@ -1,6 +1,6 @@
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import format from 'date-fns/format';
-import { AwsRegion, StaticBucketName as Bucket, FastlyApiKey } from './config';
+import { AwsRegion } from './config';
 import { sendFastlyPurgeRequestWithRetries } from './fastly';
 
 const s3client = new S3Client({ region: AwsRegion });
@@ -10,6 +10,8 @@ export async function deployCurationData(
 	region: string,
 	variant: string,
 	maybeDate: Date | null,
+	Bucket: string,
+	fastlyApiKey: string,
 ): Promise<void> {
 	const Key = maybeDate
 		? `${region}/${variant}/${format(maybeDate, 'yyyy-MM-dd')}/curation.json`
@@ -26,5 +28,5 @@ export async function deployCurationData(
 	console.log(`Uploading new curation data to ${Bucket}/${Key}`);
 	await s3client.send(req);
 	console.log('Done. Flushing CDN cache...');
-	await sendFastlyPurgeRequestWithRetries(Key, FastlyApiKey as string, 'hard');
+	await sendFastlyPurgeRequestWithRetries(Key, fastlyApiKey, 'hard');
 }

--- a/lib/recipes-data/src/lib/extract-recipes.ts
+++ b/lib/recipes-data/src/lib/extract-recipes.ts
@@ -59,8 +59,9 @@ export function extractRecipeData(
 	sponsorship: Sponsorship[],
 ): Array<RecipeReferenceWithoutChecksum | null> {
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- to fix error when elements are undefined , example if main block does not have any elements.
-	if (!block?.elements) return [];
-	else {
+	if (!block?.elements) {
+		return [];
+	} else {
 		const recipeDates: RecipeDates = {
 			lastModifiedDate: capiDateTimeToDate(block.lastModifiedDate),
 			firstPublishedDate: getFirstPublishedDate(block, content),

--- a/lib/recipes-data/src/lib/fastly.test.ts
+++ b/lib/recipes-data/src/lib/fastly.test.ts
@@ -1,8 +1,6 @@
 import { FastlyError, sendFastlyPurgeRequest } from './fastly';
 
-jest.mock('./config', () => ({
-	ContentPrefix: 'cdn.content.location',
-}));
+const contentPrefix = 'cdn.content.location';
 
 describe('sendFastlyPurgeRequest', () => {
 	beforeEach(() => {
@@ -18,7 +16,7 @@ describe('sendFastlyPurgeRequest', () => {
 				status: 200,
 			} as Response),
 		);
-		await sendFastlyPurgeRequest('/path/to/content', 'fake-key');
+		await sendFastlyPurgeRequest('/path/to/content', 'fake-key', contentPrefix);
 
 		//@ts-ignore
 		expect(fetch.mock.calls.length).toEqual(1);
@@ -46,7 +44,12 @@ describe('sendFastlyPurgeRequest', () => {
 				status: 200,
 			}),
 		);
-		await sendFastlyPurgeRequest('/path/to/content', 'fake-key', 'hard');
+		await sendFastlyPurgeRequest(
+			'/path/to/content',
+			'fake-key',
+			contentPrefix,
+			'hard',
+		);
 
 		//@ts-ignore
 		expect(fetch.mock.calls.length).toEqual(1);
@@ -75,7 +78,7 @@ describe('sendFastlyPurgeRequest', () => {
 		);
 
 		await expect(
-			sendFastlyPurgeRequest('/path/to/content', 'fake-key'),
+			sendFastlyPurgeRequest('/path/to/content', 'fake-key', contentPrefix),
 		).rejects.toEqual(new FastlyError('Fastly returned 502'));
 
 		//@ts-ignore

--- a/lib/recipes-data/src/lib/fastly.test.ts
+++ b/lib/recipes-data/src/lib/fastly.test.ts
@@ -16,7 +16,11 @@ describe('sendFastlyPurgeRequest', () => {
 				status: 200,
 			} as Response),
 		);
-		await sendFastlyPurgeRequest('/path/to/content', 'fake-key', contentPrefix);
+		await sendFastlyPurgeRequest({
+			contentPath: '/path/to/content',
+			apiKey: 'fake-key',
+			contentPrefix,
+		});
 
 		//@ts-ignore
 		expect(fetch.mock.calls.length).toEqual(1);
@@ -44,12 +48,12 @@ describe('sendFastlyPurgeRequest', () => {
 				status: 200,
 			}),
 		);
-		await sendFastlyPurgeRequest(
-			'/path/to/content',
-			'fake-key',
+		await sendFastlyPurgeRequest({
+			contentPath: '/path/to/content',
+			apiKey: 'fake-key',
 			contentPrefix,
-			'hard',
-		);
+			purgeType: 'hard',
+		});
 
 		//@ts-ignore
 		expect(fetch.mock.calls.length).toEqual(1);
@@ -78,7 +82,11 @@ describe('sendFastlyPurgeRequest', () => {
 		);
 
 		await expect(
-			sendFastlyPurgeRequest('/path/to/content', 'fake-key', contentPrefix),
+			sendFastlyPurgeRequest({
+				contentPath: '/path/to/content',
+				apiKey: 'fake-key',
+				contentPrefix,
+			}),
 		).rejects.toEqual(new FastlyError('Fastly returned 502'));
 
 		//@ts-ignore

--- a/lib/recipes-data/src/lib/fastly.ts
+++ b/lib/recipes-data/src/lib/fastly.ts
@@ -35,12 +35,17 @@ function removeLeadingAndTrailingSlash(from: string): string {
  * @param apiKey Fastly API key to authenticate the request.  The function will throw if this is undefined or empty.
  * @param purgeType Whether to execute a soft or hard purge (default soft). See the docs on PurgeType for more information.
  */
-export async function sendFastlyPurgeRequest(
-	contentPath: string,
-	apiKey: string,
-	contentPrefix: string,
-	purgeType?: PurgeType,
-) {
+export async function sendFastlyPurgeRequest({
+	contentPath,
+	apiKey,
+	contentPrefix,
+	purgeType,
+}: {
+	contentPath: string;
+	apiKey: string;
+	contentPrefix: string;
+	purgeType?: PurgeType;
+}) {
 	if (!apiKey || apiKey == '') {
 		throw new Error('Cannot purge because Fastly API key is not set');
 	}
@@ -98,20 +103,26 @@ export async function sendFastlyPurgeRequest(
  * @param purgeType Whether to execute a soft or hard purge (default soft). See the docs on PurgeType for more information.
  * @param retryCount don't specify this, it's used internally.
  */
-export async function sendFastlyPurgeRequestWithRetries(
-	contentPath: string,
-	apiKey: string,
-	contentPrefix: string,
-	purgeType?: PurgeType,
-	retryCount?: number,
-): Promise<void> {
+export async function sendFastlyPurgeRequestWithRetries({
+	contentPath,
+	apiKey,
+	contentPrefix,
+	purgeType,
+	retryCount,
+}: {
+	contentPath: string;
+	apiKey: string;
+	contentPrefix: string;
+	purgeType?: PurgeType;
+	retryCount?: number;
+}): Promise<void> {
 	try {
-		return sendFastlyPurgeRequest(
+		return sendFastlyPurgeRequest({
 			contentPath,
 			apiKey,
 			contentPrefix,
 			purgeType,
-		);
+		});
 	} catch (err) {
 		if (err instanceof FastlyError) {
 			const nextRetry = retryCount ? retryCount + 1 : 1;
@@ -123,13 +134,13 @@ export async function sendFastlyPurgeRequestWithRetries(
 				throw err; //we give up! it ain't gonna work.
 			}
 			await awaitableDelay();
-			return sendFastlyPurgeRequestWithRetries(
+			return sendFastlyPurgeRequestWithRetries({
 				contentPath,
 				apiKey,
 				contentPrefix,
 				purgeType,
-				nextRetry,
-			);
+				retryCount: nextRetry,
+			});
 		} else {
 			throw err;
 		}

--- a/lib/recipes-data/src/lib/fastly.ts
+++ b/lib/recipes-data/src/lib/fastly.ts
@@ -31,9 +31,11 @@ function removeLeadingAndTrailingSlash(from: string): string {
  *
  * Note, the CONTENT_URL_BASE parameter must be configured (either in environment variables or via a mock when testing).
  * The function will throw if it is not defined.
- * @param contentPath URL to purge. This is relative to the configured CONTENT_URL_BASE
- * @param apiKey Fastly API key to authenticate the request.  The function will throw if this is undefined or empty.
- * @param purgeType Whether to execute a soft or hard purge (default soft). See the docs on PurgeType for more information.
+ * @param options
+ * @param options.contentPath URL to purge. This is relative to the configured CONTENT_URL_BASE
+ * @param options.apiKey Fastly API key to authenticate the request.  The function will throw if this is undefined or empty.
+ * @param options.contentPrefix CDN hostname
+ * @param options.purgeType Whether to execute a soft or hard purge (default soft). See the docs on PurgeType for more information.
  */
 export async function sendFastlyPurgeRequest({
 	contentPath,
@@ -98,10 +100,11 @@ export async function sendFastlyPurgeRequest({
 /**
  * calls `sendFastlyPurgeRequest` with the given parameters.  If Fastly returns an error, this will delay by the
  * number of seconds given in RETRY_DELAY and then retry, up to a maximum of MAX_RETRIES attempts.
- * @param contentPath URL to purge. This is relative to the configured CONTENT_URL_BASE
- * @param apiKey Fastly API key to authenticate the request.  The function will throw if this is undefined or empty.
- * @param purgeType Whether to execute a soft or hard purge (default soft). See the docs on PurgeType for more information.
- * @param retryCount don't specify this, it's used internally.
+ * @param options
+ * @param options.contentPath URL to purge. This is relative to the configured CONTENT_URL_BASE
+ * @param options.apiKey Fastly API key to authenticate the request.  The function will throw if this is undefined or empty.
+ * @param options.purgeType Whether to execute a soft or hard purge (default soft). See the docs on PurgeType for more information.
+ * @param options.retryCount don't specify this, it's used internally.
  */
 export async function sendFastlyPurgeRequestWithRetries({
 	contentPath,

--- a/lib/recipes-data/src/lib/parameters.ts
+++ b/lib/recipes-data/src/lib/parameters.ts
@@ -1,13 +1,31 @@
-export function mandatoryParameter(name: string): string {
-	if (process.env[name]) {
-		return process.env[name] as string;
-	} else {
-		if (process.env['CI']) {
-			return 'test';
+export function createGetMandatoryParameter<AliasType extends string>(
+	name: string,
+): () => AliasType {
+	return () => {
+		if (process.env[name]) {
+			return process.env[name] as AliasType;
 		} else {
+			if (process.env['CI']) {
+				return 'test' as AliasType;
+			} else {
+				throw new Error(
+					`You need to define the environment variable ${name} in the lambda config`,
+				);
+			}
+		}
+	};
+}
+
+export function createGetMandatoryNumberParameter(name: string) {
+	const getMandatoryParam = createGetMandatoryParameter(name);
+	return () => {
+		const param = getMandatoryParam();
+		try {
+			return parseInt(param);
+		} catch (e) {
 			throw new Error(
-				`You need to define the environment variable ${name} in the lambda config`,
+				`Could not parse param ${name} with value ${param} as integer`,
 			);
 		}
-	}
+	};
 }

--- a/lib/recipes-data/src/lib/parameters.ts
+++ b/lib/recipes-data/src/lib/parameters.ts
@@ -1,18 +1,14 @@
-export function createGetMandatoryParameter<AliasType extends string>(
-	name: string,
-): () => AliasType {
-	return () => {
+export function createGetMandatoryParameter(name: string): () => string {
+	return (): string => {
 		if (process.env[name]) {
-			return process.env[name] as AliasType;
-		} else {
-			if (process.env['CI']) {
-				return 'test' as AliasType;
-			} else {
-				throw new Error(
-					`You need to define the environment variable ${name} in the lambda config`,
-				);
-			}
+			return process.env[name] as string;
 		}
+		if (process.env['CI']) {
+			return 'test';
+		}
+		throw new Error(
+			`You need to define the environment variable ${name} in the lambda config`,
+		);
 	};
 }
 

--- a/lib/recipes-data/src/lib/s3.ts
+++ b/lib/recipes-data/src/lib/s3.ts
@@ -126,9 +126,6 @@ export async function removeRecipeContent({
 	const realAttempt = attempt ?? 1;
 
 	const Key = `content/${recipeSHA}`;
-	console.debug(
-		`DEBUG: removeRecipeContent path is s3://${staticBucketName}/${Key}`,
-	);
 
 	const req = new DeleteObjectCommand({
 		Bucket: staticBucketName,

--- a/lib/recipes-data/src/lib/takedown.test.ts
+++ b/lib/recipes-data/src/lib/takedown.test.ts
@@ -40,6 +40,9 @@ jest.mock('./telemetry', () => ({
 	sendTelemetryEvent: jest.fn(),
 }));
 
+const fastlyApiKey = 'fastly-api-key';
+const staticBucketName = 'static-bucket';
+
 describe('takedown', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
@@ -50,12 +53,17 @@ describe('takedown', () => {
 	});
 
 	it('removeRecipePermanently should delete the given recipe from the index and from the content bucket', async () => {
-		await removeRecipePermanently('path/to/some/article', {
-			recipeUID: 'some-uid',
-			checksum: 'xxxyyyzzz',
-			capiArticleId: 'path/to/some/article',
-			sponsorshipCount: 0,
-		});
+		await removeRecipePermanently(
+			'path/to/some/article',
+			{
+				recipeUID: 'some-uid',
+				checksum: 'xxxyyyzzz',
+				capiArticleId: 'path/to/some/article',
+				sponsorshipCount: 0,
+			},
+			staticBucketName,
+			fastlyApiKey,
+		);
 
 		//@ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipe.mock.calls.length).toEqual(1);
@@ -85,12 +93,17 @@ describe('takedown', () => {
 	});
 
 	it('removeRecipeVersion should delete the given recipe from the content bucket but not the index', async () => {
-		await removeRecipeVersion('path/to/some/article', {
-			recipeUID: 'some-uid',
-			checksum: 'xxxyyyzzz',
-			capiArticleId: 'path/to/some/article',
-			sponsorshipCount: 0,
-		});
+		await removeRecipeVersion(
+			'path/to/some/article',
+			{
+				recipeUID: 'some-uid',
+				checksum: 'xxxyyyzzz',
+				capiArticleId: 'path/to/some/article',
+				sponsorshipCount: 0,
+			},
+			staticBucketName,
+			fastlyApiKey,
+		);
 
 		//@ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipe.mock.calls.length).toEqual(1);
@@ -137,7 +150,11 @@ describe('takedown', () => {
 			Promise.resolve(knownArticles),
 		);
 
-		await removeAllRecipesForArticle('path/to/some/article');
+		await removeAllRecipesForArticle(
+			'path/to/some/article',
+			staticBucketName,
+			fastlyApiKey,
+		);
 
 		//@ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeAllRecipeIndexEntriesForArticle.mock.calls.length).toEqual(1);
@@ -148,11 +165,26 @@ describe('takedown', () => {
 		//@ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipeContent.mock.calls.length).toEqual(3);
 		//@ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeContent.mock.calls[0]).toEqual(['abcd', 'hard']);
+		expect(removeRecipeContent.mock.calls[0]).toEqual([
+			'abcd',
+			'static-bucket',
+			'fastly-api-key',
+			'hard',
+		]);
 		//@ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeContent.mock.calls[1]).toEqual(['efg', 'hard']);
+		expect(removeRecipeContent.mock.calls[1]).toEqual([
+			'efg',
+			'static-bucket',
+			'fastly-api-key',
+			'hard',
+		]);
 		//@ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeContent.mock.calls[2]).toEqual(['hij', 'hard']);
+		expect(removeRecipeContent.mock.calls[2]).toEqual([
+			'hij',
+			'static-bucket',
+			'fastly-api-key',
+			'hard',
+		]);
 
 		expect((sendTelemetryEvent as jest.Mock).mock.calls.length).toEqual(3);
 	});

--- a/lib/recipes-data/src/lib/takedown.test.ts
+++ b/lib/recipes-data/src/lib/takedown.test.ts
@@ -42,6 +42,7 @@ jest.mock('./telemetry', () => ({
 
 const fastlyApiKey = 'fastly-api-key';
 const staticBucketName = 'static-bucket';
+const contentPrefix = 'content-prefix';
 
 describe('takedown', () => {
 	beforeEach(() => {
@@ -53,9 +54,9 @@ describe('takedown', () => {
 	});
 
 	it('removeRecipePermanently should delete the given recipe from the index and from the content bucket', async () => {
-		await removeRecipePermanently(
-			'path/to/some/article',
-			{
+		await removeRecipePermanently({
+			canonicalArticleId: 'path/to/some/article',
+			recipe: {
 				recipeUID: 'some-uid',
 				checksum: 'xxxyyyzzz',
 				capiArticleId: 'path/to/some/article',
@@ -63,7 +64,8 @@ describe('takedown', () => {
 			},
 			staticBucketName,
 			fastlyApiKey,
-		);
+			contentPrefix,
+		});
 
 		//@ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipe.mock.calls.length).toEqual(1);
@@ -81,7 +83,7 @@ describe('takedown', () => {
 		//@ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipe.mock.calls[0][1]).toEqual('some-uid');
 		//@ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeContent.mock.calls[0][0]).toEqual('xxxyyyzzz');
+		expect(removeRecipeContent.mock.calls[0][0].recipeSHA).toEqual('xxxyyyzzz');
 
 		expect((sendTelemetryEvent as jest.Mock).mock.calls.length).toEqual(1);
 		expect((sendTelemetryEvent as jest.Mock).mock.calls[0][0]).toEqual(
@@ -93,9 +95,9 @@ describe('takedown', () => {
 	});
 
 	it('removeRecipeVersion should delete the given recipe from the content bucket but not the index', async () => {
-		await removeRecipeVersion(
-			'path/to/some/article',
-			{
+		await removeRecipeVersion({
+			canonicalArticleId: 'path/to/some/article',
+			recipe: {
 				recipeUID: 'some-uid',
 				checksum: 'xxxyyyzzz',
 				capiArticleId: 'path/to/some/article',
@@ -103,7 +105,8 @@ describe('takedown', () => {
 			},
 			staticBucketName,
 			fastlyApiKey,
-		);
+			contentPrefix,
+		});
 
 		//@ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipe.mock.calls.length).toEqual(1);
@@ -118,7 +121,7 @@ describe('takedown', () => {
 		expect(removeRecipeContent.mock.calls.length).toEqual(1);
 
 		//@ts-ignore -- Typescript doesn't know that this is a mock
-		expect(removeRecipeContent.mock.calls[0][0]).toEqual('xxxyyyzzz');
+		expect(removeRecipeContent.mock.calls[0][0].recipeSHA).toEqual('xxxyyyzzz');
 
 		expect((sendTelemetryEvent as jest.Mock).mock.calls.length).toEqual(0); //this is not a take-down
 	});
@@ -150,11 +153,12 @@ describe('takedown', () => {
 			Promise.resolve(knownArticles),
 		);
 
-		await removeAllRecipesForArticle(
-			'path/to/some/article',
+		await removeAllRecipesForArticle({
+			canonicalArticleId: 'path/to/some/article',
 			staticBucketName,
 			fastlyApiKey,
-		);
+			contentPrefix,
+		});
 
 		//@ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeAllRecipeIndexEntriesForArticle.mock.calls.length).toEqual(1);
@@ -166,24 +170,33 @@ describe('takedown', () => {
 		expect(removeRecipeContent.mock.calls.length).toEqual(3);
 		//@ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipeContent.mock.calls[0]).toEqual([
-			'abcd',
-			'static-bucket',
-			'fastly-api-key',
-			'hard',
+			{
+				recipeSHA: 'abcd',
+				staticBucketName: 'static-bucket',
+				fastlyApiKey: 'fastly-api-key',
+				purgeType: 'hard',
+				contentPrefix: 'content-prefix',
+			},
 		]);
 		//@ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipeContent.mock.calls[1]).toEqual([
-			'efg',
-			'static-bucket',
-			'fastly-api-key',
-			'hard',
+			{
+				recipeSHA: 'efg',
+				staticBucketName: 'static-bucket',
+				fastlyApiKey: 'fastly-api-key',
+				purgeType: 'hard',
+				contentPrefix: 'content-prefix',
+			},
 		]);
 		//@ts-ignore -- Typescript doesn't know that this is a mock
 		expect(removeRecipeContent.mock.calls[2]).toEqual([
-			'hij',
-			'static-bucket',
-			'fastly-api-key',
-			'hard',
+			{
+				recipeSHA: 'hij',
+				staticBucketName: 'static-bucket',
+				fastlyApiKey: 'fastly-api-key',
+				purgeType: 'hard',
+				contentPrefix: 'content-prefix',
+			},
 		]);
 
 		expect((sendTelemetryEvent as jest.Mock).mock.calls.length).toEqual(3);

--- a/lib/recipes-data/src/lib/utils.test.ts
+++ b/lib/recipes-data/src/lib/utils.test.ts
@@ -7,8 +7,6 @@ import {
 	extractCropDataFromGuimUrl,
 } from './utils';
 
-jest.mock('./config', () => ({}));
-
 describe('calculateChecksum', () => {
 	it('should checksum the content into base64', () => {
 		const input: RecipeReferenceWithoutChecksum = {

--- a/tools/manual-takedown/src/main.ts
+++ b/tools/manual-takedown/src/main.ts
@@ -1,5 +1,6 @@
 import * as process from 'process';
 import {
+	getContentPrefix,
 	getFastlyApiKey,
 	getStaticBucketName,
 	removeAllRecipesForArticle,
@@ -19,9 +20,15 @@ async function main() {
 	const articleId = process.env['ARTICLE_ID'] as string; //checkArgs ensures that this is valid
 	const staticBucketName = getStaticBucketName();
 	const fastlyApiKey = getFastlyApiKey();
+	const contentPrefix = getContentPrefix();
 
 	console.log('Attempting takedown on ', articleId);
-	await removeAllRecipesForArticle(articleId, staticBucketName, fastlyApiKey);
+	await removeAllRecipesForArticle({
+		canonicalArticleId: articleId,
+		staticBucketName,
+		fastlyApiKey,
+		contentPrefix,
+	});
 }
 
 main()

--- a/tools/manual-takedown/src/main.ts
+++ b/tools/manual-takedown/src/main.ts
@@ -1,5 +1,9 @@
 import * as process from 'process';
-import { removeAllRecipesForArticle } from '@recipes-api/lib/recipes-data';
+import {
+	getFastlyApiKey,
+	getStaticBucketName,
+	removeAllRecipesForArticle,
+} from '@recipes-api/lib/recipes-data';
 
 function checkArgs(args: string[]) {
 	args.forEach((arg) => {
@@ -11,11 +15,13 @@ function checkArgs(args: string[]) {
 }
 
 async function main() {
-	checkArgs(['ARTICLE_ID', 'INDEX_TABLE', 'STATIC_BUCKET', 'CONTENT_URL_BASE']);
+	checkArgs(['ARTICLE_ID', 'INDEX_TABLE']);
 	const articleId = process.env['ARTICLE_ID'] as string; //checkArgs ensures that this is valid
+	const staticBucketName = getStaticBucketName();
+	const fastlyApiKey = getFastlyApiKey();
 
 	console.log('Attempting takedown on ', articleId);
-	await removeAllRecipesForArticle(articleId);
+	await removeAllRecipesForArticle(articleId, staticBucketName, fastlyApiKey);
 }
 
 main()


### PR DESCRIPTION
## What does this change?

Refactors our config in recipes-backend to ensure that importing utilities does not accidentally pull in mandatory parameters. 

This is a side-quest as I attempted to include dynamoDB helpers into the reindex lambda. At the moment, importing these helpers also pulls in a host of exported vars that call getMandatoryParam and fail fast, but are not required in a reindex context.

The solution in this PR is that all mandatory configuration variables become getters that must be called.

Each lambda handler invokes these functions at its beginning, and passes values explicitly in named object fields. Tests provide the appropriate values explicitly.

This is

- boring 😀 
- slightly more verbose
- harder to get wrong (by naming arguments: having functions with large arities and many arguments of type `string` means argument order matters, and neither the compiler nor common sense can warn us when we are passing arguments in an incorrect order at the point of invocation)
- significantly less complicated to debug at runtime.

If we want smaller function arities, we could refactor our fns to receive objects (the JS equivalent of 'named parameters'.)

## How to test

- The tests should pass.
- Deploy to CODE, and exercise publication and curation paths. They should work as expected.

Testing on CODE, verifying that behaviour is correct and Fastly is purging for the following operations:

- [x] publish new recipe
- [x] update recipe
- [x] take down 
- [x] update curation
- [x] manual reindex

## How can we measure success?

No surprises when importing configuration from libraries into lambda projects.
