### PR TITLE
Write article ids for reindex

### DIFF
--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -2413,6 +2413,10 @@ def sort_filter_rules(json_obj):
           "Variables": {
             "APP": "recipes-reindex-snapshot-recipe-index",
             "CONTENT_URL_BASE": "recipes.guardianapis.com",
+            "INDEX_TABLE": {
+              "Ref": "storeRecipeTableC3AD84B7",
+            },
+            "LAST_UPDATED_INDEX": "idxArticleLastUpdated",
             "RECIPE_INDEX_SNAPSHOT_BUCKET": {
               "Ref": "RecipeReindexreindexSnapshotBucketB9E1DA96",
             },

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -2536,6 +2536,35 @@ def sort_filter_rules(json_obj):
             },
             {
               "Action": [
+                "dynamodb:Scan",
+                "dynamodb:Query",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "storeRecipeTableC3AD84B7",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "storeRecipeTableC3AD84B7",
+                          "Arn",
+                        ],
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -249,6 +249,7 @@ export class RecipesBackend extends GuStack {
 		});
 
 		new RecipesReindex(this, 'RecipeReindex', {
+			dataStore: store,
 			contentUrlBase,
 			reindexBatchSize: reindexBatchSizeParam.valueAsNumber,
 			reindexWaitTime: reindexWaitTimeParam.valueAsNumber,

--- a/cdk/lib/recipes-reindex.ts
+++ b/cdk/lib/recipes-reindex.ts
@@ -18,8 +18,10 @@ import {
 } from 'aws-cdk-lib/aws-stepfunctions';
 import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
 import { Construct } from 'constructs';
+import type { DataStore } from './datastore';
 
 type RecipesReindexProps = {
+	dataStore: DataStore;
 	contentUrlBase: string;
 	reindexBatchSize: number;
 	reindexWaitTime: number;
@@ -29,7 +31,12 @@ export class RecipesReindex extends Construct {
 	constructor(
 		scope: GuStack,
 		id: string,
-		{ contentUrlBase, reindexBatchSize, reindexWaitTime }: RecipesReindexProps,
+		{
+			dataStore,
+			contentUrlBase,
+			reindexBatchSize,
+			reindexWaitTime,
+		}: RecipesReindexProps,
 	) {
 		super(scope, id);
 
@@ -57,6 +64,14 @@ export class RecipesReindex extends Construct {
 						effect: Effect.ALLOW,
 						actions: ['s3:PutObject'],
 						resources: [snapshotBucket.bucketArn + '/*'],
+					}),
+					new PolicyStatement({
+						effect: Effect.ALLOW,
+						actions: ['dynamodb:Scan', 'dynamodb:Query'],
+						resources: [
+							dataStore.table.tableArn,
+							dataStore.table.tableArn + '/index/*',
+						],
 					}),
 				],
 				environment: {

--- a/cdk/lib/recipes-reindex.ts
+++ b/cdk/lib/recipes-reindex.ts
@@ -77,6 +77,8 @@ export class RecipesReindex extends Construct {
 				environment: {
 					CONTENT_URL_BASE: contentUrlBase,
 					RECIPE_INDEX_SNAPSHOT_BUCKET: snapshotBucket.bucketName,
+					INDEX_TABLE: dataStore.table.tableName,
+					LAST_UPDATED_INDEX: dataStore.lastUpdatedIndexName,
 				},
 				architecture: Architecture.ARM_64,
 				timeout: Duration.seconds(30),

--- a/lambda/recipes-reindex/src/types.ts
+++ b/lambda/recipes-reindex/src/types.ts
@@ -16,3 +16,5 @@ export type WriteBatchToReindexQueueInput = SnapshotRecipeIndexOutput;
 export type WriteBatchToReindexQueueOutput = SnapshotRecipeIndexOutput & {
 	lastIndex: number;
 };
+
+export type RecipeArticlesSnapshot = string[];

--- a/lambda/recipes-reindex/src/writeBatchToReindexQueue/fixtures/index.json
+++ b/lambda/recipes-reindex/src/writeBatchToReindexQueue/fixtures/index.json
@@ -1,1062 +1,178 @@
-{
-	"schemaVersion": 1,
-	"recipes": [
-		{
-			"checksum": "yWlWasS7rL3V8Df0IXg708G9Nk9stVBj8IqdwAS0kZc",
-			"recipeUID": "3f3410b0edae470abb76f5f48c02e8f4",
-			"capiArticleId": "food/2021/aug/23/thomasina-miers-recipe-summer-tomato-tagliatelle-toasted-walnut-nduja-pesto",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "0IIWDePWjgUYAiOZGA4MPodLe6sGZCe9ehasceY4Pjk",
-			"recipeUID": "d90776464018f0515e6cf979790e446d14588413",
-			"capiArticleId": "lifeandstyle/wordofmouth/2011/jan/20/how-make-perfect-orange-marmalade",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "3CWmtPxpDtaiDEnjq0zEWiZnlWCbQ7zjZYJR9n_ASlg",
-			"recipeUID": "37f0b96a9e8f2be46c5b70a2e58425b17c6f0a89",
-			"capiArticleId": "lifeandstyle/2017/dec/08/christmas-cocktail-recipes-hawksmoor-hot-doddy-shaky-pete-gin-sherry",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "MuUuuE3xUMOL-HAPhAFTqjCpgkIzsZAJ5rBOEYXKvBI",
-			"recipeUID": "b2ad0e94024d9304c4f7fcc68756e0c4116fffaf",
-			"capiArticleId": "lifeandstyle/2017/dec/08/christmas-cocktail-recipes-hawksmoor-hot-doddy-shaky-pete-gin-sherry",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "PE7SqU2sUMEBk3TB56Yq25L9wCSGQaPnP-NlUVFK_Ks",
-			"recipeUID": "946dccf0b335f6a73fd6444358cf7acbf79d19f3",
-			"capiArticleId": "lifeandstyle/2011/jan/16/stir-fried-beef-noodles-recipe-hugh-fearnley-whittingstall",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "K53Fw3PZXWmkS3jsddDhnChz8HMlcE8ifBP9RSVWt8s",
-			"recipeUID": "5e88a82fe4ac197507b3ff45171f0cedfc423d6e",
-			"capiArticleId": "lifeandstyle/2014/jan/15/jack-monroe-pearl-barley-risotto",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "WJcw96K12pOlC9O4gFPqw2pIvkzZ3ZDXaYJFqaFJoXo",
-			"recipeUID": "5cb2b9fe9ffb0d89543feb2f49d3cb7a8e8f1886",
-			"capiArticleId": "lifeandstyle/allotment/2007/apr/26/siennasseabass",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "2dafhpIZOyZtUUv4aoQ-IxC8oqrxOVRag7xfzH7Sc6U",
-			"recipeUID": "99ea87d53eb3dc2f2f445b38919d9b9cbda4b7b1",
-			"capiArticleId": "lifeandstyle/2017/oct/14/lemon-tart-recipe-jeremy-lee-king-of-puddings",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "SyyoyJm6DhxEaoDjwQdQISRnfigaWEcey3y0Rd_WBnQ",
-			"recipeUID": "1ee17958309dc4eba3456979adc4313025c4e8be",
-			"capiArticleId": "lifeandstyle/2009/dec/05/northeast-winter-warmer-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "TU-YnK3Nl9j3Vmc05QqRui6Lj1aPRUHqZ3OmoMhmXOc",
-			"recipeUID": "b5c2307c7b7cd4ea8918c66c9a2e647072b5daed",
-			"capiArticleId": "lifeandstyle/2009/dec/05/northeast-winter-warmer-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "2aBIBAnT0t6GTXSiBS0UbQ4IFxdUsXg-gURNbIKOVPA",
-			"recipeUID": "f6e75336f4f6a49d21eacd4d3b63e9de902175b1",
-			"capiArticleId": "lifeandstyle/2009/dec/05/northeast-winter-warmer-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "mC79YhHk6amFapB7_7BXTRgHq6FIwn6C4832bRSQ6SM",
-			"recipeUID": "745fe7651142d396290c7e08a35206eb9f97df77",
-			"capiArticleId": "lifeandstyle/2013/nov/22/irish-salmon-supper-christmas-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "kMFv48AXf4Qp6h_Gxw0OwiWUpplDrwSMhi6RARGZNLk",
-			"recipeUID": "1875096b7bdfe04209c2d4c66ce87c4a9fd33d2d",
-			"capiArticleId": "lifeandstyle/2015/jul/24/henry-dimbleby-jane-baxter-vegan-italian-recipes-puglia-pasta-chickpeas",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "HvoJ-A6Ca2CKZhdDzGzCA9ZxIdxxqOyaojdQL0P9p4s",
-			"recipeUID": "ab4be9fadaae80edbdffd0894be5e43b167ce6cf",
-			"capiArticleId": "lifeandstyle/2015/jul/24/henry-dimbleby-jane-baxter-vegan-italian-recipes-puglia-pasta-chickpeas",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Rt5fr7FjbOJAMdvPATddIH8tmenEY2nWLMwxN3118Rk",
-			"recipeUID": "e2596ffb42abda66c0b931502e9a52d2de3a9521",
-			"capiArticleId": "lifeandstyle/2015/jul/24/henry-dimbleby-jane-baxter-vegan-italian-recipes-puglia-pasta-chickpeas",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "AbZbmnCBWRtJ2__xbrUIWAAHymtt10_on55fzLELDoU",
-			"recipeUID": "be342980c669c441de28458d78e2301fa1c09ad4",
-			"capiArticleId": "lifeandstyle/2017/oct/21/chilli-tofu-recipe-vegan-meera-sodha",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "oZAQJz0tGnUtwi6xZqeJKJ7uzxAWQypNppfdy3p5xYc",
-			"recipeUID": "0c6cd324be5325e462b128f7992936827c25b09e",
-			"capiArticleId": "lifeandstyle/2008/oct/18/cooking-treats-for-kids",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "TO-dyrMCsdzr74oJSeXu3xj5ChGnXn3qH7OMLWDAuzM",
-			"recipeUID": "1df70e7fd58b17576190dae31d218aca0d5645a9",
-			"capiArticleId": "lifeandstyle/2008/oct/18/cooking-treats-for-kids",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "P8r5WkhCUAkFNOk61_sBY7lMpsiIWhPkBOij0sF6L8w",
-			"recipeUID": "dcbc228b56ad3471db91c3629a2d98b19566316a",
-			"capiArticleId": "lifeandstyle/2013/nov/25/why-free-range-milk-is-good-for-you",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "sT2fwDhRBn5ioaYN6269BnR6g5nLH5Tf-sl716COrEA",
-			"recipeUID": "d7ad2969206ab0299ac9bf1429fda6b9a05aff2e",
-			"capiArticleId": "lifeandstyle/2015/jul/11/get-ahead-one-batch-creme-patissiere-custard-four-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "g3N91pck9BQH-LJWE5787K4DvtpvB618k8lkSCTwIsY",
-			"recipeUID": "9cb8e9f22219b1ddfbd0fbca558b289287a60f88",
-			"capiArticleId": "lifeandstyle/2015/jul/11/get-ahead-one-batch-creme-patissiere-custard-four-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "jNqLin3y5MNeC01wmMHL7ZXkum5SBzCXwTJ58aarcxY",
-			"recipeUID": "e63560c7b3520f3e3c399297f69644321dbb2c4f",
-			"capiArticleId": "lifeandstyle/2015/jul/11/get-ahead-one-batch-creme-patissiere-custard-four-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "aNFyM5GFgOUYlI13cQmEjmQMdln0V4qHU4b8FjQ3xIY",
-			"recipeUID": "4ef3eb907d560f26b7eda8203bdeb7173d162533",
-			"capiArticleId": "theobserver/2008/jul/20/foodanddrink.alcohol",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "EeAWHC7a3DPavNQ9__xzUC4DATjZKWLZ9rEyGvScNOc",
-			"recipeUID": "689987d6d6dedfd769536cb15696750d78f65559",
-			"capiArticleId": "lifeandstyle/2010/aug/10/50-best-cookbooks-edouard-pomiane",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "uINDLiBri17CFaeEbEvCZTXD6xslUrAGV95DYHdD7HI",
-			"recipeUID": "cd05709ed8a1526ee69b0e8aafd57c16839c3d7c",
-			"capiArticleId": "lifeandstyle/2010/aug/10/50-best-cookbooks-edouard-pomiane",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "M_ugIx-_e_pB6-qtq8QA6ETtkB4HjlC001pgp4Gxeec",
-			"recipeUID": "f107103ea0ba625b5b9bbc73bebf2d7397e9b99b",
-			"capiArticleId": "lifeandstyle/2010/aug/10/50-best-cookbooks-edouard-pomiane",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "G2TnybcMMl8phZ8jijDr8yetaRoHUr7tXmFQP0pZejo",
-			"recipeUID": "963efd5625dc42a8bfe2fc19c7988276",
-			"capiArticleId": "food/2024/mar/16/how-to-cook-the-perfect-guinness-soda-bread-recipe-felicity-cloake",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "fkIL2uOkpyE6AMXi89DbUc2dWhC_i3kPdmVx-2ATOho",
-			"recipeUID": "f83c34a3487649f47077554e3bff298744d8061a",
-			"capiArticleId": "lifeandstyle/2011/jan/15/sweetcorn-cakes-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "aGSOWzE8JdnwE2kJzJPpjXJ_p1MuqwDSE_HRgfAYGl4",
-			"recipeUID": "a7adc3c97943df4aaf34ee89493608992047bf87",
-			"capiArticleId": "lifeandstyle/2013/nov/29/angela-hartnett-simple-party-food-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "fl4T_rq7tJjpyu0Ah3GKBPmvC-pk2ELh0sW4HvNnrAo",
-			"recipeUID": "7891ec25d90fff675a48efa94de07ae21baea1c8",
-			"capiArticleId": "lifeandstyle/2013/nov/29/angela-hartnett-simple-party-food-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "z_8VwuoYYali8Uxk-_mLfYRlZrODtQxee6Q4Hdz9Vlk",
-			"recipeUID": "72de6f7428d9cecf4d6c8d89f1121e151b1d67a4",
-			"capiArticleId": "lifeandstyle/2013/nov/29/angela-hartnett-simple-party-food-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Wb7wSA1JRWqMY6ATukfEaiueqcRnPJeC6POjUXbASEM",
-			"recipeUID": "014192e0f53a914087e6bbb033848da1f8fc4899",
-			"capiArticleId": "lifeandstyle/2015/dec/05/preserved-lemon-recipes-batch-cooking-get-ahead-rosie-birkett",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "XJjmMPXLTyRo5Kw7wiX26QHIec23-38gKsaFpZgAtYo",
-			"recipeUID": "fbbefbb0cb5f88dc360ca57aa3dbbaad5937c31b",
-			"capiArticleId": "lifeandstyle/2015/dec/05/preserved-lemon-recipes-batch-cooking-get-ahead-rosie-birkett",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "3fNz8iwNe4zpimpyPa2kYGupPnZobGHBU8qgIR95OIs",
-			"recipeUID": "c24aed1e74352006473e907a5b55f8becfaa9a6d",
-			"capiArticleId": "lifeandstyle/2015/dec/05/preserved-lemon-recipes-batch-cooking-get-ahead-rosie-birkett",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "OO_3LIKh6iHLFPgKfv3Z4uP6SRqPMHt6KuPyzLGTAQ0",
-			"recipeUID": "a6debe8d217d354ca8ae65d0892f4f70f9804ff0",
-			"capiArticleId": "lifeandstyle/2015/dec/05/preserved-lemon-recipes-batch-cooking-get-ahead-rosie-birkett",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "2Tky0jxnxYhxhKxkSBufAE4o6HiiJPqijwzL78Wj6NY",
-			"recipeUID": "2ec3eabfe324ae75c4b0f34646d0c22eea862524",
-			"capiArticleId": "lifeandstyle/2016/jan/30/seville-orange-marmalade-recipe-get-ahead-rob-andrew-breakfast-sald-ste-ice-cream",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "imsCjtc0Z-xabnFGkHea3ILG5LjgwbQQ_IV1Ei3KnaI",
-			"recipeUID": "7a83593cf702615f890e4b198ad945a2f84eb0a7",
-			"capiArticleId": "lifeandstyle/2016/jan/30/seville-orange-marmalade-recipe-get-ahead-rob-andrew-breakfast-sald-ste-ice-cream",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "ON8yWeDS00dZOEh7JTdxKoTQMXAGKHq4rHdcJA8oq6c",
-			"recipeUID": "5dbbf1026a7401426103516da7ba2111a5d41dcd",
-			"capiArticleId": "lifeandstyle/2016/jan/30/seville-orange-marmalade-recipe-get-ahead-rob-andrew-breakfast-sald-ste-ice-cream",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "WH0LOKib5RPkvlfHS0ZBGsyPDEmT_zO7VzDr9oGLOUc",
-			"recipeUID": "2228f7b82c32fbfd0f6fd872a2e450ef2be7cc06",
-			"capiArticleId": "lifeandstyle/2016/jan/30/seville-orange-marmalade-recipe-get-ahead-rob-andrew-breakfast-sald-ste-ice-cream",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "rjoxpg1PKUnj0p5CMQE_HvhJUhugYIihQLgom5K7Fu8",
-			"recipeUID": "9ab6b7c2abb8873d882afd941d1197b801501726",
-			"capiArticleId": "lifeandstyle/2016/jan/30/seville-orange-marmalade-recipe-get-ahead-rob-andrew-breakfast-sald-ste-ice-cream",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "XCtt4c2kvztmlnINW7CjuefICIWqL6yhLI9qgenr27k",
-			"recipeUID": "57ef41f96d94f8cf371e97a80ef152f7c34dfa26",
-			"capiArticleId": "lifeandstyle/2014/feb/08/make-your-own-bacon-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "YQI-_4M4c_Mct-QhGAFXQFHGySDd_E5xMX31kB57zB8",
-			"recipeUID": "df0f5d8bce786fe6cd9be09f4d50c4c11dd5e8cd",
-			"capiArticleId": "lifeandstyle/2017/oct/27/aztec-baked-eggs-quick-recipe-day-of-dead-mexican-thomasina-miers",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "4NFozwSp0QWWwyU7Xx878-aEQcGXdvqD49vhg9hi2TI",
-			"recipeUID": "f25dd89d59da73f33c5927a9a2dd3e1fc29dfaec",
-			"capiArticleId": "lifeandstyle/2012/nov/27/bruno-loubet-chia-chocolate-cake-caramel-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "mjSJza3Bzib9wnNx9txkM1Coj8A1s1IdOxJjbJaUxNc",
-			"recipeUID": "2a111e4011e0cccb843f85cd3fbb567c92dce1ec",
-			"capiArticleId": "lifeandstyle/2014/nov/14/welsh-lamb-snowdon-pudding-cheese-onion-pie-recipes-tom-kerridge",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "QeBMeo6aAx1TDEU2lBTXrCgP5vGoWgqDfKli39ncEJQ",
-			"recipeUID": "ba4874227b7d7950a468aeb37d87cfc888b0dc44",
-			"capiArticleId": "lifeandstyle/2014/nov/14/welsh-lamb-snowdon-pudding-cheese-onion-pie-recipes-tom-kerridge",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Y0-W_5xd6pRccxCIm7-Juz_FjN5x469lT4eT5ORFxsY",
-			"recipeUID": "e50e90549e7d90aed0594c4b966cd9dbda423fe7",
-			"capiArticleId": "lifeandstyle/2014/nov/14/welsh-lamb-snowdon-pudding-cheese-onion-pie-recipes-tom-kerridge",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Qs061l_OghDsGSkR6zqLLfwdSk08rMUrOnn9qoBK-vU",
-			"recipeUID": "6cc12accba8e47dfa8c81cb4db8f9a04b3f09244",
-			"capiArticleId": "lifeandstyle/2011/jan/20/baked-apples-recipe-angela-hartnett",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "IzDEr9o2tBJXEkHZRU7Gub14TFS32P7GU1-pfxQSI5s",
-			"recipeUID": "633c7b7934e36362a546e247bdc20221ac5da51a",
-			"capiArticleId": "lifeandstyle/wordofmouth/2010/dec/02/how-make-perfect-sausage-rolls",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "YpYfSDS84IebHyPyTwTPTnsRM87UlnOcigAU_8zWBv0",
-			"recipeUID": "5bdab0ad54a409f2293a2565ca074a7d2677fbbc",
-			"capiArticleId": "lifeandstyle/wordofmouth/2010/dec/02/how-make-perfect-sausage-rolls",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "TazVTdJf5wTqctRbQgv65fOxtJsa875e6JYrz-RqhRc",
-			"recipeUID": "cff31ea9bd5c64f28bde6f1f305a31eea46985ab",
-			"capiArticleId": "lifeandstyle/2012/sep/07/chicory-peaches-black-pudding-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "CqSPsoI4aZ2rLR1yKtppOZAuuypoLdjHsr3wi3eeQQA",
-			"recipeUID": "4d8c34168af4f19dbae3f07077d80d690e28c9f4",
-			"capiArticleId": "lifeandstyle/2013/aug/29/gazpacho-shooter-drinks-make-your-own",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "VvNhECHOzwvDBnBd9ghRBQSShEcRZQVNFNTByHpyvqo",
-			"recipeUID": "9659a42a229382e65cda6612983f61f068fec79e",
-			"capiArticleId": "lifeandstyle/2014/feb/19/jack-monroe-cauliflower-garlic-fennel-soup-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "RNxVO4LkbKJEWn7Sq2djFmgC91_4ILiavXk18N83ifg",
-			"recipeUID": "f51a5f293e7f5619c77f9f6135f8323f3686998c",
-			"capiArticleId": "lifeandstyle/2010/nov/15/french-onion-soup",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "FEHElJ8zOvgF7rvUEFCo46DChcwwry_ZdrDM_aDrb6Q",
-			"recipeUID": "25c033b25f3ce7d0730cd946a3c51dcef927c5c0",
-			"capiArticleId": "lifeandstyle/2017/nov/25/lentil-recipes-curried-coconut-soup-aubergine-stew-sweet-potato-croquettes-fritters-yotam-ottolenghi",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "nWcQR2g6UmsN6ydrVSwIlFMWI2mER0OA-zuq7qCTGQk",
-			"recipeUID": "9a759e43ba075d8eb87ff871b63c272dfb5b5e1a",
-			"capiArticleId": "lifeandstyle/2017/nov/25/lentil-recipes-curried-coconut-soup-aubergine-stew-sweet-potato-croquettes-fritters-yotam-ottolenghi",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "6hRLKpPoWFFBWrUE5lWFJRYnh-CfyQu0jbT3QSmoIIk",
-			"recipeUID": "300850c925a9bd0f43d2fe8c315c6df460d521f6",
-			"capiArticleId": "lifeandstyle/2017/nov/25/lentil-recipes-curried-coconut-soup-aubergine-stew-sweet-potato-croquettes-fritters-yotam-ottolenghi",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "5OOjiduWuGao5PXtJln7WfzLdrltAiuBtA5gKlXlS-E",
-			"recipeUID": "fac87c9f7141cc5c9b53741788eb75f43b6a6f57",
-			"capiArticleId": "lifeandstyle/2014/feb/12/bush-food-marron",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "UL2G2xnbia-2YWJIpLSW0m7qDAVtnwM-APF8EhDzYbU",
-			"recipeUID": "cf59b3c5608abcea8760e9785ff9edf71520216c",
-			"capiArticleId": "lifeandstyle/2008/oct/18/baking-cakes-bread-muffins",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "QJNXHre4uPQd2Ch-Mc2KY_fQ2Blz1Cs8gCWmE6JgmJc",
-			"recipeUID": "6228dc1acc4eafee4ffa9239f3e7708462bed6fd",
-			"capiArticleId": "lifeandstyle/2008/oct/18/baking-cakes-bread-muffins",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "tQ8SjZQcz8Q-hN4A0sDirEHpfDA7EzFEQ0vHm4qt56E",
-			"recipeUID": "923617e86eb4983399d90604e10cabf11670fbe5",
-			"capiArticleId": "lifeandstyle/2015/nov/06/the-chicken-and-the-egg-french-bourride-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "uBLIkruegE6vKGHIzdmxW8x7fBOqakRjWJ04dSE_v0k",
-			"recipeUID": "e0aea7ec747cf7a993e165efaa9c2d323a1014be",
-			"capiArticleId": "lifeandstyle/2015/nov/06/the-chicken-and-the-egg-french-bourride-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "4mVCBfeULfAyY9Bf20-r5rz7c563OY7m7ilzTeQJqow",
-			"recipeUID": "9c19b182498fdb8ad05aee5c518d4a13e25d453a",
-			"capiArticleId": "lifeandstyle/2015/nov/06/the-chicken-and-the-egg-french-bourride-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "EV3CWvXGbNmsV7AIxUMDPqY82Pg8niqf_NGYqlnk_Pk",
-			"recipeUID": "bdddad39e72740f190d2617c89db61f4",
-			"capiArticleId": "food/2024/sep/23/quick-easy-chicken-lime-coriander-quesadillas-recipe-carrot-beetroot-slaw-rukmini-iyer",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "fZ1tCEtVEHR-3nFsy18bNPPgwk_VRWeAYn6uRJCtF1Q",
-			"recipeUID": "88a1144dbc1207c8c3c759d4d36738f99fb9853a",
-			"capiArticleId": "lifeandstyle/2010/aug/11/ofm-50-bold-knife-fork",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "cS1NfqpygMVExJatKg8QiTzYJVZ3hdxbNH3dp-lQvk0",
-			"recipeUID": "d371d6505e6cc8fd67c03525bea717eb9d92d551",
-			"capiArticleId": "lifeandstyle/2013/oct/18/sachertorte-gluten-egg-dairy-free-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "fXKET5cbmMbHPSHT49ftp0N6iEWTglgtqsEEuqbSU-s",
-			"recipeUID": "56a42246d0e2ebbdfd7275705d10bac2560354b9",
-			"capiArticleId": "lifeandstyle/2010/dec/12/christmas-recipes-cake-fruit-baking",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Z-FkgMHd_gpqyCTtrPDrZlseUSC7JF1Or-KqRrgLGGM",
-			"recipeUID": "e96e3bdb1738ca53dbe923af7794d4aa6ceb2f37",
-			"capiArticleId": "lifeandstyle/2010/dec/12/christmas-recipes-cake-fruit-baking",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "7EZMtcQx3EfWYzjkIgDZynSA0ucRtUXy3B2zzJf4mGo",
-			"recipeUID": "eed9c26a1c86e3c82c3cfe8e623526c64ce49c48",
-			"capiArticleId": "lifeandstyle/2010/dec/12/christmas-recipes-cake-fruit-baking",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "brvPDvM_MUbu4G8Ltdo9rS7x339SyB1bqvIUzwxvtWQ",
-			"recipeUID": "ee21bb07191a39f3825cfbb15787f82e3fdb2e11",
-			"capiArticleId": "lifeandstyle/2010/dec/12/christmas-recipes-cake-fruit-baking",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Awt4LQrofDbgOtdL3AccDOf-j-7eF66vMtm7Yi1zSlM",
-			"recipeUID": "12a504ee2fb34f0ab67124406140dcce",
-			"capiArticleId": "food/2024/apr/21/sticky-aubergine-tart-sea-bass-pistachio-pesto-baklava-cheesecake-greekish-recipes-georgina-hayden",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "6EU5lO0e9XSyolw9_VqTw8Uq2ke1LWHe7EgogsvNe94",
-			"recipeUID": "6e1a24d8c5c1495592e10cf8427fa3d9",
-			"capiArticleId": "food/2024/apr/21/sticky-aubergine-tart-sea-bass-pistachio-pesto-baklava-cheesecake-greekish-recipes-georgina-hayden",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "dYyuOjdFzgefJOqEE4Qk9CXEmZXpIgDAYTlY3UNZwnE",
-			"recipeUID": "a49bed6c8f1842809c6f4776611adc0c",
-			"capiArticleId": "food/2024/apr/21/sticky-aubergine-tart-sea-bass-pistachio-pesto-baklava-cheesecake-greekish-recipes-georgina-hayden",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "W5eBiD3Zv597lpP5dSGtOpU05MtTQcttZYuPY4rUY4U",
-			"recipeUID": "70265dd004fc4b03a5cb50f972fe13f5",
-			"capiArticleId": "food/2024/apr/21/sticky-aubergine-tart-sea-bass-pistachio-pesto-baklava-cheesecake-greekish-recipes-georgina-hayden",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "YBHTPKRsKzkqfa7vvBB_zlGNFTZi7718sEsiefM98gU",
-			"recipeUID": "36cf0c87ba4341aca5b3bcfc26f2364a",
-			"capiArticleId": "food/2024/apr/21/sticky-aubergine-tart-sea-bass-pistachio-pesto-baklava-cheesecake-greekish-recipes-georgina-hayden",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "uebc5y-rNos7fqdd1dkq8QRuqPNPXJTNKqw-N3OwLcE",
-			"recipeUID": "72603cd9828849729fd50bc4b3dd6f1b",
-			"capiArticleId": "food/2024/apr/21/sticky-aubergine-tart-sea-bass-pistachio-pesto-baklava-cheesecake-greekish-recipes-georgina-hayden",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "dOrj1a91HQSM-XqND8ht_JBu94r6Gc9ciOnco8cTWUg",
-			"recipeUID": "a0b8f93f734e6d72b157a3511c0c7cceeb8f437d",
-			"capiArticleId": "lifeandstyle/2014/jan/04/guardian-home-cook-of-the-year-readers-recipe-swap",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "yz2cz1gFvX6zCffzO417zs0-1b8rdl_9yiLYB0_Vd5A",
-			"recipeUID": "23e40d016f33ffa9b2ea09e42fe2b374702f6504",
-			"capiArticleId": "lifeandstyle/2014/jan/04/guardian-home-cook-of-the-year-readers-recipe-swap",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "ldi2rqh5wBnEH89eCsAl0M0vz1u8zbNgSFm6MiuCDFA",
-			"recipeUID": "772577d9e19896ea86cae4457da0b185d2baba5b",
-			"capiArticleId": "lifeandstyle/2014/jan/04/guardian-home-cook-of-the-year-readers-recipe-swap",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "yk8_np7U4lIiP69co1yvg7T2Sxr1M83cn7yNNXcjTHg",
-			"recipeUID": "452af6b486bf3e2448486d3ddc9d9a162086d047",
-			"capiArticleId": "lifeandstyle/2014/jan/04/guardian-home-cook-of-the-year-readers-recipe-swap",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "vMcYpzVUwlBUuzQux4fCHIR04rCfjhAXRN0ly-GnFiI",
-			"recipeUID": "3f9b3b76757fb157a0d694e1876e759e818cf90e",
-			"capiArticleId": "lifeandstyle/2014/jan/04/guardian-home-cook-of-the-year-readers-recipe-swap",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "bLnbTu7kyr5ekyofm9SiLJqufl4ix_1h31iGkwqCc8g",
-			"recipeUID": "e546e4fd74bc5aee0583bd6398e8a083c3de5a21",
-			"capiArticleId": "lifeandstyle/wordofmouth/2013/may/16/how-bake-perfect-victoria-sponge-cake",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "KKTYz97lE6jGsGU0P43Lsir89uO92SDr-YsY7f6i6yc",
-			"recipeUID": "f2aa929b3d47486e158558833b150d9276ef2631",
-			"capiArticleId": "lifeandstyle/wordofmouth/2011/feb/10/how-cook-perfect-chocolate-fondants",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Vck8deBfS1cyDhvo64nfn_sreEH_yOA_0TgSJ7rCjHo",
-			"recipeUID": "6d1fbd5b33927af6adc27f1f0e5c7a05a55c8f05",
-			"capiArticleId": "lifeandstyle/wordofmouth/2011/sep/14/how-to-make-cider",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "0P55XeTk4b7LqP5Hm9HZZZWYSOPahYuTTZ4Dhqp0eDk",
-			"recipeUID": "22bd8a213b389d25f189b69e31635948bfa892b5",
-			"capiArticleId": "lifeandstyle/2011/jan/23/monica-galetti-venison-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "cuWcHEvP_jr4cF-Mqps2OXchd3NqqCUi2-3LSbromRg",
-			"recipeUID": "b94331e352af825d33466c3422b230ef877b6d20",
-			"capiArticleId": "lifeandstyle/2017/aug/18/moroccan-chicken-tray-bake-easy-recipe-thomasina-miers-apricots-fennel-spice",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "3pUfbFNrnUIPuRxJzS4DU17i2woCgAICMEHUBAQHs8o",
-			"recipeUID": "72fe68f49f38fd61bfb4d207d2c15732ed299c5a",
-			"capiArticleId": "lifeandstyle/2010/aug/13/ofm-50-platter-of-figs",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "sY8IC8jNf3ptAZTmmPzfLqL1iJ0v9HgFQxe4WHUMnco",
-			"recipeUID": "73bdb6f8e4b863604f5c978bbeb1a8c1812f5af9",
-			"capiArticleId": "lifeandstyle/2010/aug/13/ofm-50-platter-of-figs",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "dvoHMrEUBk6IAgzc6EP_RS0olXGkEjM61IPCi5JHYQE",
-			"recipeUID": "785b80efbb7207699ba3b86d51c072184432f295",
-			"capiArticleId": "lifeandstyle/2010/aug/13/ofm-50-platter-of-figs",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Jsjv8X00Ih9PQNcrxRH0bBwT0XuVbawWVoc1AmQrWwY",
-			"recipeUID": "66a537905740217f5245b1b14191d0c610002362",
-			"capiArticleId": "lifeandstyle/2010/aug/13/ofm-50-platter-of-figs",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "k4dtryWwQ3msSBoBsw4ufwpTBDIuWelfwxCT4Q0YfbU",
-			"recipeUID": "fe735df895848bf728636f1d820354f6751c875a",
-			"capiArticleId": "lifeandstyle/2012/dec/02/lamb-apricots-cinnamon-nigel-slater",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Gtu4WX4s4BnB0nHo56Nm3HUX6yXT6o_npwVheIdtGuw",
-			"recipeUID": "fa17eb1b6681b909bac2f0b1f9222a15c662fa0f",
-			"capiArticleId": "lifeandstyle/2015/mar/04/jack-monroe-tom-kha-gai-thai-coconut-soup-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "LnaLK3u9AlpX-p44Vb0yQn6WCEKkGDy9Z8uQdnJr0dg",
-			"recipeUID": "915cac2b5002aaf0a817978a19c50741c0e0f4db",
-			"capiArticleId": "lifeandstyle/2013/jul/31/summer-recipes-salads-fish-veg",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "HtbvRBBd6JsBk6m_yvmA3u0BtB89qsZYXXMfsFbiN_4",
-			"recipeUID": "f7c7d8f4d84f8792fb3db7e8a8d01dd0d0f5f44e",
-			"capiArticleId": "lifeandstyle/2013/jul/31/summer-recipes-salads-fish-veg",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "-HKy0GsYBtNMyEuVoEoHHYYpkqlh1U2KsjtE3zGb0JA",
-			"recipeUID": "974ad0638a2130ca05eec4a61819939a5fca51ea",
-			"capiArticleId": "lifeandstyle/wordofmouth/2011/may/12/cook-perfect-chilli-con-carne",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "GnBIZWIS-bQbuxPQYDrXmJGAlZF93r3uoXx-tS3yRLs",
-			"recipeUID": "ce750b0d06897be636a3cbf730d2b440d5f1f6e3",
-			"capiArticleId": "lifeandstyle/2007/apr/01/foodanddrink.shopping1",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "t5j9KiLFlPBQWYwl2ZswB7ALbrGsXGiSR5I5aTpNsAk",
-			"recipeUID": "1afc0f2c628e8c122fe0a2fe7ff35585a7e2c255",
-			"capiArticleId": "lifeandstyle/2007/apr/01/foodanddrink.shopping1",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "jslrPv61PDnvkXoMJyRd6cOyvz5SUnAXMod_yWQD_FQ",
-			"recipeUID": "6e91d1246a5babeb242e44b11a881049f1af7a4f",
-			"capiArticleId": "lifeandstyle/2010/jul/19/italian-farro-salad-pesto",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "E326TuDk_Ys6JbilVbuFhH1YeWFgH0ar7mB-Vs5urAE",
-			"recipeUID": "6b4d5df10ff811a6d33bf9a74f8fbf783a4cff47",
-			"capiArticleId": "lifeandstyle/2010/sep/04/organic-pork-recipes-fearnley-whittingstall",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "tlCNflEWDm_NrClChURwSvY-WKz3E03cyNEwZS_fTjw",
-			"recipeUID": "0b1070a4270133b6227dd988339cf0a5b91bf5b9",
-			"capiArticleId": "lifeandstyle/2010/sep/04/organic-pork-recipes-fearnley-whittingstall",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "YVCDEyAnlwE5te_KYTQSMJ9S_QuxajR0umXAAQy-v0M",
-			"recipeUID": "83e474a17743d7a6c1d0a59fe3cb13463044a765",
-			"capiArticleId": "lifeandstyle/2016/jun/02/elderflower-fritter-zabaglione-recipe-claire-ptak-baking-the-seasons",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "NqOilNGndQwPFuurqx3O7hWXZLIiFtXZfm04qgOAWLU",
-			"recipeUID": "4d5021f563e77b6873f1ad50c980742fe611e732",
-			"capiArticleId": "lifeandstyle/2016/jun/02/elderflower-fritter-zabaglione-recipe-claire-ptak-baking-the-seasons",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "P04axj3KKOu5TU4XUqscp3NqXlCJCKSg8hfTd_FdYls",
-			"recipeUID": "edd933a5ecb520cf4b9569c8e28db6cb7000ec60",
-			"capiArticleId": "lifeandstyle/2015/sep/21/make-a-meal-with-any-number-of-eggs-cook",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "CV_t-jnEgOYN_-4mMVbaUMr-dNHrrkQ06R3aP3YNGTw",
-			"recipeUID": "c389c8ab38a3f5d3c2d5027efba3500e2b9b7d66",
-			"capiArticleId": "lifeandstyle/2014/mar/05/jack-monroe-tanzanian-sprats-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "BGlk3US1e8RdQkwUcMAlexJ9HSyVbousmNqjkzoCY8Y",
-			"recipeUID": "103f4ca038d108f1eaee363a81714beb97b0b715",
-			"capiArticleId": "lifeandstyle/2012/apr/20/spring-greens-recipes-hugh-fearnley-whittingstall",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "XyyWKu7DVWVebOhrAdgIiGDeDb6CiA0v59M0dDvYMo0",
-			"recipeUID": "118572af073586eb1689de8792a68b494ecc6c7c",
-			"capiArticleId": "lifeandstyle/2012/apr/20/spring-greens-recipes-hugh-fearnley-whittingstall",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Y1jej-GI7zSDPBRQ08MikV02BOQmLp6fYg5JCM-MlWY",
-			"recipeUID": "e195576c09a4925db2412aee8c5c3611edac8165",
-			"capiArticleId": "lifeandstyle/2012/apr/20/spring-greens-recipes-hugh-fearnley-whittingstall",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "-7m_gyvapwpmdwXWMH1WD6xaQfDVxzLzXzPBSjKLeDY",
-			"recipeUID": "ed56e791842456b00c2eef1c2493de9fb2058e16",
-			"capiArticleId": "lifeandstyle/2011/jul/15/summer-chicken-citrus-stew-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "xpFeBvDZB5Mr2BDK8baKrheDTCGarVkSdjPoYWFhKdk",
-			"recipeUID": "b3ad175cacf3cc5b686759df4ad19d23f7562eaf",
-			"capiArticleId": "lifeandstyle/2011/may/15/turbot-recipe-pierre-koffmann",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "BSi13vc3_IaBumCL8hFxfrmbnQ0aQRt9P4PHE5cmfrw",
-			"recipeUID": "52a18672e6cac0f57eac0f91a9c7fd903e07759b",
-			"capiArticleId": "lifeandstyle/2008/oct/18/healthy-fast-food",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "18lOX-jDgIbI2LATMBgNldfKniuyPAAA_Y8EE3BLbnQ",
-			"recipeUID": "2a0e9aa5f5ca71164459175e5ee98d9fc50e9645",
-			"capiArticleId": "lifeandstyle/2008/oct/18/healthy-fast-food",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "euIYK4VZQFUYACXwgzOKtf7p2Fc34Mf-JH06YJ9eh_4",
-			"recipeUID": "3514ae438a1357e6e173c54726e9321ca576a1eb",
-			"capiArticleId": "lifeandstyle/2008/oct/18/healthy-fast-food",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "rwtQJ097_rU-lgER2nKUIgqlwyQ0CKYyIIy3i9DLgto",
-			"recipeUID": "279330f9ff17e4dd0abda8020993e91f6d7721f9",
-			"capiArticleId": "lifeandstyle/2008/oct/18/healthy-fast-food",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "MK2bzK_wDhBN9fMH7Bc9AvjygF4dGu4VTP3aRaNcN5k",
-			"recipeUID": "9f4172b41ade931a9f08077776cb2f75d517b69a",
-			"capiArticleId": "lifeandstyle/2008/oct/18/healthy-fast-food",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "5K25WPPWOGducJF9ztJ_0Kna1tB8fgwNRLxsd-SmQMI",
-			"recipeUID": "6336ee6697d7e712ddaafb2219df7b50c13c5d79",
-			"capiArticleId": "lifeandstyle/2013/dec/04/jack-monroe-budget-christmas",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "sVifW7zijlctTNkCghnGBXU-q2mxD1uXrA9XEKWfvDo",
-			"recipeUID": "a4a6166bf2d2d6a21f088946888d2d812025a2ed",
-			"capiArticleId": "lifeandstyle/2013/dec/04/jack-monroe-budget-christmas",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "5BQhVnefQdD6-Ovvco_2whbnBSwmtyTSIEN6Wml6hPY",
-			"recipeUID": "ace5ff9097bfd43e91e5bd4ca639af9f38be5fb9",
-			"capiArticleId": "lifeandstyle/2013/dec/04/jack-monroe-budget-christmas",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "9ndmI49i-Sfa_BjeTpVkKWBP9hiCzEvgFC3xj3t9-yE",
-			"recipeUID": "a2f17e12717d22e27b8b5303357e77216bf8b3c5",
-			"capiArticleId": "lifeandstyle/2013/oct/30/nigel-slater-20-recipes-veg",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "rdRZsSVTxdb8BhO95Uv79EgTNQV7jC-GQjWtQ-f20rM",
-			"recipeUID": "253882f53d1b268c9cd1b30684867eb292dfdaee",
-			"capiArticleId": "lifeandstyle/2013/oct/30/nigel-slater-20-recipes-veg",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "NhEIS633hGcbRdAzHIyywb5PqdY_4BjaJKFl3f-CRBQ",
-			"recipeUID": "9f10d8ff4a933f87ae8e7144d44c214bfa22f3e3",
-			"capiArticleId": "lifeandstyle/2013/oct/30/nigel-slater-20-recipes-veg",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "umjpXaiAOg-wXP9V_yJuGWZttXS2al5gREt0_sfRLpQ",
-			"recipeUID": "013440b5e83ac2eb66295f993d775d59a8987c9b",
-			"capiArticleId": "lifeandstyle/2013/oct/30/nigel-slater-20-recipes-veg",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "fuJ6OyntdCEwkQ0QlnfiQ6NIRpqjDI3UwJv5mWQNbkQ",
-			"recipeUID": "63978d51c1720d0172ac0b3a91e7889e7da0aee2",
-			"capiArticleId": "lifeandstyle/2012/sep/07/trout-watercress-spelt-recipe-whittingstall",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "qDuAnYwK6KTtLvWY8LavY25faP2WPU7DQv10KWDIWZM",
-			"recipeUID": "d1af0a019472fb65b5f8f1cde07961bea1b192dd",
-			"capiArticleId": "lifeandstyle/2015/oct/16/sri-lankan-breakfast-feast-recipe-egg-hoppers-henry-dimbleby-jane-baxter-feasting",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "LufbgkYFE_2gpEkK_1gwQJKdep3NbqbiIN781UFD8Vc",
-			"recipeUID": "0e82ad1dca35638036c205be9adbbcc6749e2646",
-			"capiArticleId": "lifeandstyle/2015/oct/16/sri-lankan-breakfast-feast-recipe-egg-hoppers-henry-dimbleby-jane-baxter-feasting",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "qlCVLyZ7ZMiZkg8pSxg4L6FecQBzJlhnkpR3n8BfGSs",
-			"recipeUID": "7679f4fd3530c0679b460ef63dd79f3e60211563",
-			"capiArticleId": "lifeandstyle/2015/oct/16/sri-lankan-breakfast-feast-recipe-egg-hoppers-henry-dimbleby-jane-baxter-feasting",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "0spW2_--r52Kyn31rn21MiaPmg0CgROkOkvZ_urVzGM",
-			"recipeUID": "f4cc9311188c25906cbb428fdb2276980db23439",
-			"capiArticleId": "lifeandstyle/2015/aug/15/roasted-pepper-recipes-get-ahead-kitchen-cooperative",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "fa8bh-5304ylpntlKRb9KBy4AMomMYA6huSSW4br8lQ",
-			"recipeUID": "6d1b9e2473c3ad50e04305d726be9f9b32e7cce1",
-			"capiArticleId": "lifeandstyle/2015/aug/15/roasted-pepper-recipes-get-ahead-kitchen-cooperative",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "A8Abhcb5uYrL-wmOzyUf6RMzO5uXPosCp4tjL0JwxPw",
-			"recipeUID": "b48fe05779acb745ce988c736045461400d6167d",
-			"capiArticleId": "lifeandstyle/2015/aug/15/roasted-pepper-recipes-get-ahead-kitchen-cooperative",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "sXRLC0R7a5x1ELmVcYZV7WCZltxlPUORG_EGX6MCvvw",
-			"recipeUID": "28eb7a13582fef7df15ff25d0fdb3edbaca3e404",
-			"capiArticleId": "lifeandstyle/2015/aug/15/roasted-pepper-recipes-get-ahead-kitchen-cooperative",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "WLos-rRSZ9I2eSMyIgtlzmGDoSAy8jy-8tzeJu9fgmE",
-			"recipeUID": "8a2d98235c874c08ad71f1f7cfff76fde6dac47b",
-			"capiArticleId": "lifeandstyle/2010/jul/19/salad-nicoise-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "h2iPxt2IYL6nj7ND33rACdL7-V1_Tmh8JF0CxNIT4Kw",
-			"recipeUID": "9815d7d5c7563d07319ebe92a2ef2f93554e98ea",
-			"capiArticleId": "lifeandstyle/2016/mar/05/roast-lamb-shoulder-recipes-batch-cooking-ben-tish",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "yEMWcwgWf4_RD6Iw-eIkAxqklpmeP8hSdRxmT5XilaQ",
-			"recipeUID": "e25214c7e1282c621e8d8b03e643836139f86179",
-			"capiArticleId": "lifeandstyle/2016/mar/05/roast-lamb-shoulder-recipes-batch-cooking-ben-tish",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "2R3-gcIzXkuatrwOnIcfJN5097hhKSIGbWZsxmggvoo",
-			"recipeUID": "2d9215a37cbf684901dbdb39d6074b1fddf30ed4",
-			"capiArticleId": "lifeandstyle/2016/mar/05/roast-lamb-shoulder-recipes-batch-cooking-ben-tish",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "w_DgY0if_yVJoIP2dNwJ7CkuVpeJcPK7hdZbSX51jkw",
-			"recipeUID": "a8fbdf8e5fa5530b4c05f6cc699c1da3fbf527ac",
-			"capiArticleId": "lifeandstyle/2016/mar/05/roast-lamb-shoulder-recipes-batch-cooking-ben-tish",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "W4wg2NhPhzHuQigyLckWiZg49BFRRwOdj923r2cj7Mc",
-			"recipeUID": "d41d9603818d8cfd5a71382a7b6257cbadd13375",
-			"capiArticleId": "lifeandstyle/2012/nov/30/dan-lepard-edible-christmas-gift-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "HVhIYZAongAWN7MrO39jLeDGPoS5iNXozIQyjv-qp94",
-			"recipeUID": "9590a3d7f68275760914b97ea77b78b4b0a8b949",
-			"capiArticleId": "lifeandstyle/2012/nov/30/dan-lepard-edible-christmas-gift-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Rf0TqVOtAotWWyDVUQQOkr1Fjl2L20be1dGEkFfWaLA",
-			"recipeUID": "a9426667f06ece1358540e673fb603540140e9c2",
-			"capiArticleId": "lifeandstyle/2012/nov/30/dan-lepard-edible-christmas-gift-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "f3nvdvjXez--GoYfS2Yn6N39f5dzfdYnY7vRDC3VHm4",
-			"recipeUID": "cfb36878f4c2e46200b6267b277d06f3b87639fc",
-			"capiArticleId": "lifeandstyle/2012/nov/30/dan-lepard-edible-christmas-gift-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "QRrw330S00OOvuNkh5vRP9kjujL5u2jEY2LCbgAfzGc",
-			"recipeUID": "3f8230628dcd340adb0bad0894cc3786ad8d23b7",
-			"capiArticleId": "lifeandstyle/2017/jun/24/french-chocolate-cake-recipe-jeremy-lee-king-of-puddings",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "wwaTP_bBgMoeMUpwEkrLfGz8JVO1aDo-OOlQcOMxNTY",
-			"recipeUID": "501bf18b352a5eb54531400d861eb3f424cf93d7",
-			"capiArticleId": "lifeandstyle/wordofmouth/2016/oct/06/how-to-make-the-perfect-cheese-scones",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "P6TWNeiK3-fZCZWP-grwwm0LKOnZCROahCDhLouaTUs",
-			"recipeUID": "557e861f168e807b2c4d49d713ed92d99bed403a",
-			"capiArticleId": "lifeandstyle/2014/may/21/jack-monroe-broad-bean-salad-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "K-DeJ1GCBFB_VgCRL53Dq5xaibEPbWrHpQhBrUwqbwI",
-			"recipeUID": "6a199fa19a79c48b7f824896f9508621c1848ec0",
-			"capiArticleId": "lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "wQkS0DLO9vCtp2HnHZ-jW2kDtV8l_ZjDZ7QDk1d3khw",
-			"recipeUID": "30bd13559a79046a893f115e68a3d94eef8e6284",
-			"capiArticleId": "lifeandstyle/2013/nov/15/gluten-free-soya-free-pad-thai",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "ZRzO6SQqfMtwasUxc43vvSGMhucZ97THVZUOBvvE9lw",
-			"recipeUID": "515ea3920892196759a2038260969210564cf71b",
-			"capiArticleId": "lifeandstyle/2016/feb/21/ofm-classic-cookbooks-margaret-costa-four-seasons-cookery-book",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "g9IsMsoPtAJI7oSgTojSr6xLXaI7ij6ENj-D_9DXFMU",
-			"recipeUID": "efbdeb3607a43af818016a121b0462104652322b",
-			"capiArticleId": "lifeandstyle/2016/feb/21/ofm-classic-cookbooks-margaret-costa-four-seasons-cookery-book",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "WOZoflHIr_T1h0Kcy3_bJIZMgJ67EfjkkURjfH_TgBg",
-			"recipeUID": "4c2e4722a9f00130cc37f1f86addc72156bbeae3",
-			"capiArticleId": "lifeandstyle/2016/feb/21/ofm-classic-cookbooks-margaret-costa-four-seasons-cookery-book",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "gZ_G3rU6ONOtUW9kb94klwTNVDRTEwBwzmGV__oc070",
-			"recipeUID": "2939efafd86ff40615bb411e0e9eddc1f1d117e5",
-			"capiArticleId": "lifeandstyle/2016/feb/21/ofm-classic-cookbooks-margaret-costa-four-seasons-cookery-book",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "GPzS6P3aAOoXmACaLXeuVXnNi01eROk206jD44Id0xs",
-			"recipeUID": "017f9b03a0d7705834bf7202feb2b4ba81328781",
-			"capiArticleId": "lifeandstyle/2016/feb/21/ofm-classic-cookbooks-margaret-costa-four-seasons-cookery-book",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "u9ukDyUnoLDTZUUtm9n4OVLktDYiogDIVLaOL7oRHH0",
-			"recipeUID": "38ec407c2201e12ddca2f744938a9f0bdc046e92",
-			"capiArticleId": "lifeandstyle/2016/mar/02/nuno-mendes-late-winter-recipes-steak-sandwich-piri-piri-sprouts-cake",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "T2p-dJlAyi5DY_d3MQz-lnnHJkzf8cpR01dJmggrLtc",
-			"recipeUID": "9f5350378db7830244539a32fab72c518c582a01",
-			"capiArticleId": "lifeandstyle/2016/mar/02/nuno-mendes-late-winter-recipes-steak-sandwich-piri-piri-sprouts-cake",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Bc6D1vPLXGWNqPo0Eoy68g4aORFbzHHr7cHKCtrXzh8",
-			"recipeUID": "98f5d12ede08bc1715f17841dbba58f42c1caa17",
-			"capiArticleId": "lifeandstyle/2016/mar/02/nuno-mendes-late-winter-recipes-steak-sandwich-piri-piri-sprouts-cake",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "0VJleToP3PkcrzFNfHx0rnR9vpa8B6nDD_dcTiZduso",
-			"recipeUID": "293ec70106734927afa18ceb490a7003da0cca9b",
-			"capiArticleId": "lifeandstyle/2011/nov/14/how-to-cook-caramel",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "GLfzdrriGS5o6N-CNkkfsjdwYmnAqqMT4JGFGGMaFFI",
-			"recipeUID": "10ad80a85d0862572652fce88ceb594fa88b8599",
-			"capiArticleId": "lifeandstyle/2011/nov/14/how-to-cook-caramel",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "cuGDQKwUc4r4Ccnf8tV8YtiTLxJw7fSLQzu15rE4Zxk",
-			"recipeUID": "36067b3c684d09ef82739283cc0fdbf38308e9c4",
-			"capiArticleId": "lifeandstyle/2017/jan/20/oyster-beer-batter-fritters-recipe-peter-gordon-taste-of-home",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "p-_3pEluGhuKLuOyoy2rh_PdhdVYWJUZFC7Lx5PgeaI",
-			"recipeUID": "5e671cf7a5f855ea2deef0be3aca3d90a0028e48",
-			"capiArticleId": "lifeandstyle/2011/may/15/recipe-roast-marrowbone-anchovy",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "BliyG0O9d2-ZTeNGxsgrFfK0uCWT9STFoPpOdMjsjgM",
-			"recipeUID": "93acc9bfa90ee4b859695f01b7cf6f992645a99e",
-			"capiArticleId": "lifeandstyle/2016/feb/01/cheap-meals-food-2-pounds-a-head-cook-budget",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "jm4C4ROEieBgW_POApckJWvwvi4Wv6HtcBJAB-MYSgo",
-			"recipeUID": "ad5d0e6d14f22b5e192cdee0a21bdc20e0b1f7c0",
-			"capiArticleId": "lifeandstyle/2012/nov/30/delia-smith-christmas-lunch-cheap",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "OPSORTMz-l2QH6Xb1CH1bPPrVAWEOwUB5YrNk-ODs7Q",
-			"recipeUID": "5788551d4d9ecde93c9220dd737a373fba1d5ea1",
-			"capiArticleId": "lifeandstyle/2012/nov/30/delia-smith-christmas-lunch-cheap",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "VPGUQcHoMyODT3RMFltzY_qRKH__LbA_nBRJYqZTOoI",
-			"recipeUID": "dab30d39d8d6364bac279a0014f12c411df848da",
-			"capiArticleId": "lifeandstyle/2017/dec/01/jeremy-lee-12-puddings-of-christmas-part-1-creme-caramel-chocolate-turnovers",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "-D16C0mmKsBOFKFsI1EsKjxrsMM4_xdu81VCcR75BFs",
-			"recipeUID": "b3be522d8b1dc96ac988426c46cef6280b9b9b7a",
-			"capiArticleId": "lifeandstyle/wordofmouth/2012/aug/30/how-to-cook-perfect-banana-bread",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "EcjhDIDXz0D_XOWpgcLuyQfHkVoUWXRHNkQVZSUS0-0",
-			"recipeUID": "ac7fcc9fabf14fedbd473ccab7988bd3",
-			"capiArticleId": "food/2024/jan/22/vegetable-ragu-pasta-parmesan-cream-recipe-rachel-roddy",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "ut0eeE3O7pEn1P1bA4lTIbpy_4cZtzxvqfaYDeGHYWI",
-			"recipeUID": "a905a5d3-f745-4deb-8f20-08411d2ffacf",
-			"capiArticleId": "lifeandstyle/article/2024/jul/15/squashed-bananas-and-stew",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "sluDrF6t1Lxj3MVDudpl85fe31OT0qICXAses27w1J0",
-			"recipeUID": "1b8522d1a685df350679b8ea0513839f91ab2f4e",
-			"capiArticleId": "global/2016/apr/18/easy-ottolenghi-fish-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "IcNvEU6TWWvPSKBepK3cshif-NrSQfoOP4cFjaScW2A",
-			"recipeUID": "4e0a11e43294e0d1647ab88bc10e106084414184",
-			"capiArticleId": "lifeandstyle/2013/jul/27/how-to-make-a-proper-burger",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "oYrThpvOtZP0zNqZzN-OCBFWyfMYBF-i9IsGGq9Po5U",
-			"recipeUID": "8d4d07ba7795e809789833f1786fae3dfddf4cdd",
-			"capiArticleId": "lifeandstyle/2011/apr/17/lorraine-pascale-easter-cake-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "NTtO7hdEYsjAFxGvuZjiIA0ZOOkdzdcJH2LEaXR9RDE",
-			"recipeUID": "1947148c5d7702e1f3f93d3a16d2657ad3220c2d",
-			"capiArticleId": "lifeandstyle/2011/apr/17/lorraine-pascale-easter-cake-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "AoMSoggOku6Vx3jiAucR1xxYQnOtpebtXYH2nbAZed8",
-			"recipeUID": "cf523b8d61c9d9c671cc65c3a156f346273e0b26",
-			"capiArticleId": "lifeandstyle/2011/apr/17/lorraine-pascale-easter-cake-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "6yCq01OD-JQ70VnfkXE48Pp-akLYe4uwCRT93M3l44Q",
-			"recipeUID": "e16885f090c2f216f2b58ea75cd3e68e9e56830f",
-			"capiArticleId": "lifeandstyle/2011/apr/17/lorraine-pascale-easter-cake-recipes",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Ks8Q1yYO2RpgIBATA656xLNuIEzRlJiEvDjVtRUl2EY",
-			"recipeUID": "b61d2e0310769da76d6c607e10c5589a00eae74a",
-			"capiArticleId": "lifeandstyle/2011/jan/15/pink-grapefuit-star-anise-recipe",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "Q3Vnv-t0oX75TJX3hJpQJ9Nz_l-yVqQ_bENUKVHkN2s",
-			"recipeUID": "8b930c36bfef63ea33fad8f40e83f07205b6f8d2",
-			"capiArticleId": "lifeandstyle/2009/nov/22/in-your-basket-giorgio-locatelli",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "_pCqWzW-24pSZSCzbC0qv9fRj7TWG7oEqaXWW3bNoe4",
-			"recipeUID": "5a8b8c5d6d7c666f9f3e0da95825b0d462ddd17c",
-			"capiArticleId": "lifeandstyle/2017/feb/11/orange-caramel-ice-cream-sundae-chocolate-digestive-sandwich-quick-dessert-recipe-claire-ptak-baking",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "EOOr7xIk7_-TdNqc3uHWjpAf70y2fNlt83k_Gui2RGw",
-			"recipeUID": "1c04cdcf86d0b874e9ee39e916c6c519d8694d3a",
-			"capiArticleId": "travel/2012/mar/01/mumbai-indian-recipes-chicken-kaari-aubergine-stuffed",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "4E5vrVvnxJ871jE-64Iix0Vcrf70aqGSfDtw0BfvNwk",
-			"recipeUID": "31e2328fc817639614b31b55f26736134ba067e4",
-			"capiArticleId": "travel/2012/mar/01/mumbai-indian-recipes-chicken-kaari-aubergine-stuffed",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "6R8wmJzdgm0VCdUY8e4Xqpg9C1BMz9VZWJLI9aW0ta8",
-			"recipeUID": "23b7a22b4927462dbc451918635ed9f1",
-			"capiArticleId": "food/2024/oct/16/rick-toogood-pumpkin-curry-recipes-hake-katsu-lime-pickle-spiced-hispi",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "1z2gJ7Z0o18eqZ-I1-h2ajfQZUzXLAgYGjeupIlS_p0",
-			"recipeUID": "8a251431f5594d689d03d1a3a4bc39ca",
-			"capiArticleId": "food/2024/oct/16/rick-toogood-pumpkin-curry-recipes-hake-katsu-lime-pickle-spiced-hispi",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "L18pPDXci4-h6cAbwP3wrJDeBu6pjDfClcrZZpuzOPA",
-			"recipeUID": "2baf9f7ddd27dd2eea07c468abb8d7b801dc559f",
-			"capiArticleId": "lifeandstyle/2017/nov/24/potato-leek-wild-mushroom-soup-chipotle-oil-recipe-thomasina-miers",
-			"sponsorshipCount": 0
-		},
-		{
-			"checksum": "-Mghi_r1ImwXFsIn2VLwO1U7BRf4wGsKw7ImqqFoQ5Q",
-			"recipeUID": "9ea7395ca58b463585698a6494b4e2e0",
-			"capiArticleId": "food/2018/nov/24/pear-recipes-cheesecake-choc-chip-cookie-ginger-cake-yotam-ottolenghi",
-			"sponsorshipCount": 0
-		}
-	],
-	"lastUpdated": "2024-11-19T09:41:52.050Z"
-}
+[
+	"food/2021/aug/23/thomasina-miers-recipe-summer-tomato-tagliatelle-toasted-walnut-nduja-pesto",
+	"lifeandstyle/wordofmouth/2011/jan/20/how-make-perfect-orange-marmalade",
+	"lifeandstyle/2017/dec/08/christmas-cocktail-recipes-hawksmoor-hot-doddy-shaky-pete-gin-sherry",
+	"lifeandstyle/2017/dec/08/christmas-cocktail-recipes-hawksmoor-hot-doddy-shaky-pete-gin-sherry",
+	"lifeandstyle/2011/jan/16/stir-fried-beef-noodles-recipe-hugh-fearnley-whittingstall",
+	"lifeandstyle/2014/jan/15/jack-monroe-pearl-barley-risotto",
+	"lifeandstyle/allotment/2007/apr/26/siennasseabass",
+	"lifeandstyle/2017/oct/14/lemon-tart-recipe-jeremy-lee-king-of-puddings",
+	"lifeandstyle/2009/dec/05/northeast-winter-warmer-recipes",
+	"lifeandstyle/2009/dec/05/northeast-winter-warmer-recipes",
+	"lifeandstyle/2009/dec/05/northeast-winter-warmer-recipes",
+	"lifeandstyle/2013/nov/22/irish-salmon-supper-christmas-recipe",
+	"lifeandstyle/2015/jul/24/henry-dimbleby-jane-baxter-vegan-italian-recipes-puglia-pasta-chickpeas",
+	"lifeandstyle/2015/jul/24/henry-dimbleby-jane-baxter-vegan-italian-recipes-puglia-pasta-chickpeas",
+	"lifeandstyle/2015/jul/24/henry-dimbleby-jane-baxter-vegan-italian-recipes-puglia-pasta-chickpeas",
+	"lifeandstyle/2017/oct/21/chilli-tofu-recipe-vegan-meera-sodha",
+	"lifeandstyle/2008/oct/18/cooking-treats-for-kids",
+	"lifeandstyle/2008/oct/18/cooking-treats-for-kids",
+	"lifeandstyle/2013/nov/25/why-free-range-milk-is-good-for-you",
+	"lifeandstyle/2015/jul/11/get-ahead-one-batch-creme-patissiere-custard-four-recipes",
+	"lifeandstyle/2015/jul/11/get-ahead-one-batch-creme-patissiere-custard-four-recipes",
+	"lifeandstyle/2015/jul/11/get-ahead-one-batch-creme-patissiere-custard-four-recipes",
+	"theobserver/2008/jul/20/foodanddrink.alcohol",
+	"lifeandstyle/2010/aug/10/50-best-cookbooks-edouard-pomiane",
+	"lifeandstyle/2010/aug/10/50-best-cookbooks-edouard-pomiane",
+	"lifeandstyle/2010/aug/10/50-best-cookbooks-edouard-pomiane",
+	"food/2024/mar/16/how-to-cook-the-perfect-guinness-soda-bread-recipe-felicity-cloake",
+	"lifeandstyle/2011/jan/15/sweetcorn-cakes-recipe",
+	"lifeandstyle/2013/nov/29/angela-hartnett-simple-party-food-recipes",
+	"lifeandstyle/2013/nov/29/angela-hartnett-simple-party-food-recipes",
+	"lifeandstyle/2013/nov/29/angela-hartnett-simple-party-food-recipes",
+	"lifeandstyle/2015/dec/05/preserved-lemon-recipes-batch-cooking-get-ahead-rosie-birkett",
+	"lifeandstyle/2015/dec/05/preserved-lemon-recipes-batch-cooking-get-ahead-rosie-birkett",
+	"lifeandstyle/2015/dec/05/preserved-lemon-recipes-batch-cooking-get-ahead-rosie-birkett",
+	"lifeandstyle/2015/dec/05/preserved-lemon-recipes-batch-cooking-get-ahead-rosie-birkett",
+	"lifeandstyle/2016/jan/30/seville-orange-marmalade-recipe-get-ahead-rob-andrew-breakfast-sald-ste-ice-cream",
+	"lifeandstyle/2016/jan/30/seville-orange-marmalade-recipe-get-ahead-rob-andrew-breakfast-sald-ste-ice-cream",
+	"lifeandstyle/2016/jan/30/seville-orange-marmalade-recipe-get-ahead-rob-andrew-breakfast-sald-ste-ice-cream",
+	"lifeandstyle/2016/jan/30/seville-orange-marmalade-recipe-get-ahead-rob-andrew-breakfast-sald-ste-ice-cream",
+	"lifeandstyle/2016/jan/30/seville-orange-marmalade-recipe-get-ahead-rob-andrew-breakfast-sald-ste-ice-cream",
+	"lifeandstyle/2014/feb/08/make-your-own-bacon-recipe",
+	"lifeandstyle/2017/oct/27/aztec-baked-eggs-quick-recipe-day-of-dead-mexican-thomasina-miers",
+	"lifeandstyle/2012/nov/27/bruno-loubet-chia-chocolate-cake-caramel-recipe",
+	"lifeandstyle/2014/nov/14/welsh-lamb-snowdon-pudding-cheese-onion-pie-recipes-tom-kerridge",
+	"lifeandstyle/2014/nov/14/welsh-lamb-snowdon-pudding-cheese-onion-pie-recipes-tom-kerridge",
+	"lifeandstyle/2014/nov/14/welsh-lamb-snowdon-pudding-cheese-onion-pie-recipes-tom-kerridge",
+	"lifeandstyle/2011/jan/20/baked-apples-recipe-angela-hartnett",
+	"lifeandstyle/wordofmouth/2010/dec/02/how-make-perfect-sausage-rolls",
+	"lifeandstyle/wordofmouth/2010/dec/02/how-make-perfect-sausage-rolls",
+	"lifeandstyle/2012/sep/07/chicory-peaches-black-pudding-recipe",
+	"lifeandstyle/2013/aug/29/gazpacho-shooter-drinks-make-your-own",
+	"lifeandstyle/2014/feb/19/jack-monroe-cauliflower-garlic-fennel-soup-recipe",
+	"lifeandstyle/2010/nov/15/french-onion-soup",
+	"lifeandstyle/2017/nov/25/lentil-recipes-curried-coconut-soup-aubergine-stew-sweet-potato-croquettes-fritters-yotam-ottolenghi",
+	"lifeandstyle/2017/nov/25/lentil-recipes-curried-coconut-soup-aubergine-stew-sweet-potato-croquettes-fritters-yotam-ottolenghi",
+	"lifeandstyle/2017/nov/25/lentil-recipes-curried-coconut-soup-aubergine-stew-sweet-potato-croquettes-fritters-yotam-ottolenghi",
+	"lifeandstyle/2014/feb/12/bush-food-marron",
+	"lifeandstyle/2008/oct/18/baking-cakes-bread-muffins",
+	"lifeandstyle/2008/oct/18/baking-cakes-bread-muffins",
+	"lifeandstyle/2015/nov/06/the-chicken-and-the-egg-french-bourride-recipe",
+	"lifeandstyle/2015/nov/06/the-chicken-and-the-egg-french-bourride-recipe",
+	"lifeandstyle/2015/nov/06/the-chicken-and-the-egg-french-bourride-recipe",
+	"food/2024/sep/23/quick-easy-chicken-lime-coriander-quesadillas-recipe-carrot-beetroot-slaw-rukmini-iyer",
+	"lifeandstyle/2010/aug/11/ofm-50-bold-knife-fork",
+	"lifeandstyle/2013/oct/18/sachertorte-gluten-egg-dairy-free-recipe",
+	"lifeandstyle/2010/dec/12/christmas-recipes-cake-fruit-baking",
+	"lifeandstyle/2010/dec/12/christmas-recipes-cake-fruit-baking",
+	"lifeandstyle/2010/dec/12/christmas-recipes-cake-fruit-baking",
+	"lifeandstyle/2010/dec/12/christmas-recipes-cake-fruit-baking",
+	"food/2024/apr/21/sticky-aubergine-tart-sea-bass-pistachio-pesto-baklava-cheesecake-greekish-recipes-georgina-hayden",
+	"food/2024/apr/21/sticky-aubergine-tart-sea-bass-pistachio-pesto-baklava-cheesecake-greekish-recipes-georgina-hayden",
+	"food/2024/apr/21/sticky-aubergine-tart-sea-bass-pistachio-pesto-baklava-cheesecake-greekish-recipes-georgina-hayden",
+	"food/2024/apr/21/sticky-aubergine-tart-sea-bass-pistachio-pesto-baklava-cheesecake-greekish-recipes-georgina-hayden",
+	"food/2024/apr/21/sticky-aubergine-tart-sea-bass-pistachio-pesto-baklava-cheesecake-greekish-recipes-georgina-hayden",
+	"food/2024/apr/21/sticky-aubergine-tart-sea-bass-pistachio-pesto-baklava-cheesecake-greekish-recipes-georgina-hayden",
+	"lifeandstyle/2014/jan/04/guardian-home-cook-of-the-year-readers-recipe-swap",
+	"lifeandstyle/2014/jan/04/guardian-home-cook-of-the-year-readers-recipe-swap",
+	"lifeandstyle/2014/jan/04/guardian-home-cook-of-the-year-readers-recipe-swap",
+	"lifeandstyle/2014/jan/04/guardian-home-cook-of-the-year-readers-recipe-swap",
+	"lifeandstyle/2014/jan/04/guardian-home-cook-of-the-year-readers-recipe-swap",
+	"lifeandstyle/wordofmouth/2013/may/16/how-bake-perfect-victoria-sponge-cake",
+	"lifeandstyle/wordofmouth/2011/feb/10/how-cook-perfect-chocolate-fondants",
+	"lifeandstyle/wordofmouth/2011/sep/14/how-to-make-cider",
+	"lifeandstyle/2011/jan/23/monica-galetti-venison-recipe",
+	"lifeandstyle/2017/aug/18/moroccan-chicken-tray-bake-easy-recipe-thomasina-miers-apricots-fennel-spice",
+	"lifeandstyle/2010/aug/13/ofm-50-platter-of-figs",
+	"lifeandstyle/2010/aug/13/ofm-50-platter-of-figs",
+	"lifeandstyle/2010/aug/13/ofm-50-platter-of-figs",
+	"lifeandstyle/2010/aug/13/ofm-50-platter-of-figs",
+	"lifeandstyle/2012/dec/02/lamb-apricots-cinnamon-nigel-slater",
+	"lifeandstyle/2015/mar/04/jack-monroe-tom-kha-gai-thai-coconut-soup-recipe",
+	"lifeandstyle/2013/jul/31/summer-recipes-salads-fish-veg",
+	"lifeandstyle/2013/jul/31/summer-recipes-salads-fish-veg",
+	"lifeandstyle/wordofmouth/2011/may/12/cook-perfect-chilli-con-carne",
+	"lifeandstyle/2007/apr/01/foodanddrink.shopping1",
+	"lifeandstyle/2007/apr/01/foodanddrink.shopping1",
+	"lifeandstyle/2010/jul/19/italian-farro-salad-pesto",
+	"lifeandstyle/2010/sep/04/organic-pork-recipes-fearnley-whittingstall",
+	"lifeandstyle/2010/sep/04/organic-pork-recipes-fearnley-whittingstall",
+	"lifeandstyle/2016/jun/02/elderflower-fritter-zabaglione-recipe-claire-ptak-baking-the-seasons",
+	"lifeandstyle/2016/jun/02/elderflower-fritter-zabaglione-recipe-claire-ptak-baking-the-seasons",
+	"lifeandstyle/2015/sep/21/make-a-meal-with-any-number-of-eggs-cook",
+	"lifeandstyle/2014/mar/05/jack-monroe-tanzanian-sprats-recipe",
+	"lifeandstyle/2012/apr/20/spring-greens-recipes-hugh-fearnley-whittingstall",
+	"lifeandstyle/2012/apr/20/spring-greens-recipes-hugh-fearnley-whittingstall",
+	"lifeandstyle/2012/apr/20/spring-greens-recipes-hugh-fearnley-whittingstall",
+	"lifeandstyle/2011/jul/15/summer-chicken-citrus-stew-recipe",
+	"lifeandstyle/2011/may/15/turbot-recipe-pierre-koffmann",
+	"lifeandstyle/2008/oct/18/healthy-fast-food",
+	"lifeandstyle/2008/oct/18/healthy-fast-food",
+	"lifeandstyle/2008/oct/18/healthy-fast-food",
+	"lifeandstyle/2008/oct/18/healthy-fast-food",
+	"lifeandstyle/2008/oct/18/healthy-fast-food",
+	"lifeandstyle/2013/dec/04/jack-monroe-budget-christmas",
+	"lifeandstyle/2013/dec/04/jack-monroe-budget-christmas",
+	"lifeandstyle/2013/dec/04/jack-monroe-budget-christmas",
+	"lifeandstyle/2013/oct/30/nigel-slater-20-recipes-veg",
+	"lifeandstyle/2013/oct/30/nigel-slater-20-recipes-veg",
+	"lifeandstyle/2013/oct/30/nigel-slater-20-recipes-veg",
+	"lifeandstyle/2013/oct/30/nigel-slater-20-recipes-veg",
+	"lifeandstyle/2012/sep/07/trout-watercress-spelt-recipe-whittingstall",
+	"lifeandstyle/2015/oct/16/sri-lankan-breakfast-feast-recipe-egg-hoppers-henry-dimbleby-jane-baxter-feasting",
+	"lifeandstyle/2015/oct/16/sri-lankan-breakfast-feast-recipe-egg-hoppers-henry-dimbleby-jane-baxter-feasting",
+	"lifeandstyle/2015/oct/16/sri-lankan-breakfast-feast-recipe-egg-hoppers-henry-dimbleby-jane-baxter-feasting",
+	"lifeandstyle/2015/aug/15/roasted-pepper-recipes-get-ahead-kitchen-cooperative",
+	"lifeandstyle/2015/aug/15/roasted-pepper-recipes-get-ahead-kitchen-cooperative",
+	"lifeandstyle/2015/aug/15/roasted-pepper-recipes-get-ahead-kitchen-cooperative",
+	"lifeandstyle/2015/aug/15/roasted-pepper-recipes-get-ahead-kitchen-cooperative",
+	"lifeandstyle/2010/jul/19/salad-nicoise-recipe",
+	"lifeandstyle/2016/mar/05/roast-lamb-shoulder-recipes-batch-cooking-ben-tish",
+	"lifeandstyle/2016/mar/05/roast-lamb-shoulder-recipes-batch-cooking-ben-tish",
+	"lifeandstyle/2016/mar/05/roast-lamb-shoulder-recipes-batch-cooking-ben-tish",
+	"lifeandstyle/2016/mar/05/roast-lamb-shoulder-recipes-batch-cooking-ben-tish",
+	"lifeandstyle/2012/nov/30/dan-lepard-edible-christmas-gift-recipes",
+	"lifeandstyle/2012/nov/30/dan-lepard-edible-christmas-gift-recipes",
+	"lifeandstyle/2012/nov/30/dan-lepard-edible-christmas-gift-recipes",
+	"lifeandstyle/2012/nov/30/dan-lepard-edible-christmas-gift-recipes",
+	"lifeandstyle/2017/jun/24/french-chocolate-cake-recipe-jeremy-lee-king-of-puddings",
+	"lifeandstyle/wordofmouth/2016/oct/06/how-to-make-the-perfect-cheese-scones",
+	"lifeandstyle/2014/may/21/jack-monroe-broad-bean-salad-recipe",
+	"lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+	"lifeandstyle/2013/nov/15/gluten-free-soya-free-pad-thai",
+	"lifeandstyle/2016/feb/21/ofm-classic-cookbooks-margaret-costa-four-seasons-cookery-book",
+	"lifeandstyle/2016/feb/21/ofm-classic-cookbooks-margaret-costa-four-seasons-cookery-book",
+	"lifeandstyle/2016/feb/21/ofm-classic-cookbooks-margaret-costa-four-seasons-cookery-book",
+	"lifeandstyle/2016/feb/21/ofm-classic-cookbooks-margaret-costa-four-seasons-cookery-book",
+	"lifeandstyle/2016/feb/21/ofm-classic-cookbooks-margaret-costa-four-seasons-cookery-book",
+	"lifeandstyle/2016/mar/02/nuno-mendes-late-winter-recipes-steak-sandwich-piri-piri-sprouts-cake",
+	"lifeandstyle/2016/mar/02/nuno-mendes-late-winter-recipes-steak-sandwich-piri-piri-sprouts-cake",
+	"lifeandstyle/2016/mar/02/nuno-mendes-late-winter-recipes-steak-sandwich-piri-piri-sprouts-cake",
+	"lifeandstyle/2011/nov/14/how-to-cook-caramel",
+	"lifeandstyle/2011/nov/14/how-to-cook-caramel",
+	"lifeandstyle/2017/jan/20/oyster-beer-batter-fritters-recipe-peter-gordon-taste-of-home",
+	"lifeandstyle/2011/may/15/recipe-roast-marrowbone-anchovy",
+	"lifeandstyle/2016/feb/01/cheap-meals-food-2-pounds-a-head-cook-budget",
+	"lifeandstyle/2012/nov/30/delia-smith-christmas-lunch-cheap",
+	"lifeandstyle/2012/nov/30/delia-smith-christmas-lunch-cheap",
+	"lifeandstyle/2017/dec/01/jeremy-lee-12-puddings-of-christmas-part-1-creme-caramel-chocolate-turnovers",
+	"lifeandstyle/wordofmouth/2012/aug/30/how-to-cook-perfect-banana-bread",
+	"food/2024/jan/22/vegetable-ragu-pasta-parmesan-cream-recipe-rachel-roddy",
+	"lifeandstyle/article/2024/jul/15/squashed-bananas-and-stew",
+	"global/2016/apr/18/easy-ottolenghi-fish-recipes",
+	"lifeandstyle/2013/jul/27/how-to-make-a-proper-burger",
+	"lifeandstyle/2011/apr/17/lorraine-pascale-easter-cake-recipes",
+	"lifeandstyle/2011/apr/17/lorraine-pascale-easter-cake-recipes",
+	"lifeandstyle/2011/apr/17/lorraine-pascale-easter-cake-recipes",
+	"lifeandstyle/2011/apr/17/lorraine-pascale-easter-cake-recipes",
+	"lifeandstyle/2011/jan/15/pink-grapefuit-star-anise-recipe",
+	"lifeandstyle/2009/nov/22/in-your-basket-giorgio-locatelli",
+	"lifeandstyle/2017/feb/11/orange-caramel-ice-cream-sundae-chocolate-digestive-sandwich-quick-dessert-recipe-claire-ptak-baking",
+	"travel/2012/mar/01/mumbai-indian-recipes-chicken-kaari-aubergine-stuffed",
+	"travel/2012/mar/01/mumbai-indian-recipes-chicken-kaari-aubergine-stuffed",
+	"food/2024/oct/16/rick-toogood-pumpkin-curry-recipes-hake-katsu-lime-pickle-spiced-hispi",
+	"food/2024/oct/16/rick-toogood-pumpkin-curry-recipes-hake-katsu-lime-pickle-spiced-hispi",
+	"lifeandstyle/2017/nov/24/potato-leek-wild-mushroom-soup-chipotle-oil-recipe-thomasina-miers",
+	"food/2018/nov/24/pear-recipes-cheesecake-choc-chip-cookie-ginger-cake-yotam-ottolenghi"
+]

--- a/lambda/recipes-reindex/src/writeBatchToReindexQueue/index.test.ts
+++ b/lambda/recipes-reindex/src/writeBatchToReindexQueue/index.test.ts
@@ -1,7 +1,7 @@
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import type { Callback, Context } from 'aws-lambda';
 import { mockClient } from 'aws-sdk-client-mock';
-import * as indexJSON from './fixtures/index.json';
+import indexJSON from './fixtures/index.json';
 import { writeBatchToReindexQueueHandler } from './index';
 
 const RecipeIndexSnapshotBucket = 'example-reindex-bucket';

--- a/lambda/recipes-reindex/src/writeBatchToReindexQueue/index.test.ts
+++ b/lambda/recipes-reindex/src/writeBatchToReindexQueue/index.test.ts
@@ -37,7 +37,7 @@ describe('writeBatchToReindexQueue', () => {
 		);
 
 		expect(output?.nextIndex).toBe(10);
-		expect(output?.lastIndex).toBe(indexJSON.recipes.length - 1);
+		expect(output?.lastIndex).toBe(indexJSON.length - 1);
 	});
 
 	it('should move the index one beyond the last recipe on completion', async () => {
@@ -52,7 +52,7 @@ describe('writeBatchToReindexQueue', () => {
 			mockCallback,
 		);
 
-		expect(output?.nextIndex).toBe(indexJSON.recipes.length);
-		expect(output?.lastIndex).toBe(indexJSON.recipes.length - 1);
+		expect(output?.nextIndex).toBe(indexJSON.length);
+		expect(output?.lastIndex).toBe(indexJSON.length - 1);
 	});
 });

--- a/lambda/recipes-reindex/src/writeBatchToReindexQueue/index.ts
+++ b/lambda/recipes-reindex/src/writeBatchToReindexQueue/index.ts
@@ -59,12 +59,15 @@ export const writeBatchToReindexQueueHandler: Handler<
 		recipeIndexSnapshot.length,
 	);
 
-	const articleIdsToReindex = recipeIndexSnapshot.slice(nextIndex, nextIndex);
+	const articleIdsToReindex = recipeIndexSnapshot.slice(
+		currentIndex,
+		nextIndex,
+	);
 
 	const dryRunMsg = '[DRY RUN]: ';
 	const writeMsg = `${
 		articleIdsToReindex.length
-	} article ids to the reindex queue, from index ${nextIndex} to index ${
+	} article ids to the reindex queue, from index ${currentIndex} to index ${
 		nextIndex - 1
 	} (batch size ${reindexBatchSize})`;
 

--- a/lambda/recipes-reindex/tsconfig.json
+++ b/lambda/recipes-reindex/tsconfig.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"module": "commonjs"
+		"module": "commonjs",
+		"esModuleInterop": true
 	},
 	"files": [],
 	"include": [],


### PR DESCRIPTION
## What does this change?

Write article ids in our snapshot, rather than the recipe index; it's all we need to provide to the reindex queue.

## Why didn't we do this before?

Before this PR, the assumption was that we would reindex on a per-recipe basis.

However, we fetch recipes from our reindex source, CAPI, on a per-article basis.

It's inefficient, for an article that contains many recipes, to fetch that article many times to retrieve each recipe for a reindex. So we now reindex recipes on a per-article basis, to ensure we only fetch each article once for all the recipes it contains.

## How to test

- Observe that the code and test fixture have been refactored to pull data straight from dynamoDB, and write a list of article paths to S3 (rather than the entire `RecipeIndex` structure.
- Deploy to CODE, and exercise the step function. It should run successfully, and log healthy output:

<img width="1312" alt="Screenshot 2024-12-19 at 15 14 13" src="https://github.com/user-attachments/assets/c1f609cf-9a37-494b-80f7-8978b7e39d84" />

