### PR TITLE
Targeted regions

### DIFF
--- a/lambda/facia-responder/src/fixtures/sns.ts
+++ b/lambda/facia-responder/src/fixtures/sns.ts
@@ -39,6 +39,48 @@ export const validMessage = {
 	Message: JSON.stringify(validMessageContent),
 };
 
+export const validMessageContentWithUsOnly = {
+	...validMessageContent,
+	fronts: {
+		...validMessageContent.fronts,
+		'all-recipes': [
+			...validMessageContent.fronts['all-recipes'],
+			{
+				id: '7ab8a974-d491-4cc5-9a1f-ed3dbc8e2903',
+				title: 'Us-only test',
+				body: '',
+				items: [
+					{
+						recipe: {
+							id: '1237d5fa377e4957adda7b7aea12a72e',
+						},
+					},
+				],
+				targetedRegions: ['us'],
+				excludedRegions: [],
+			},
+			{
+				id: '1aa57e7d-96e7-4047-b117-b1a80f2d4eeb',
+				title: 'Only for the rest of the world',
+				body: '',
+				items: [
+					{
+						recipe: {
+							id: 'b96996b1e34d42e6a3796bfc873d7aaa',
+						},
+					},
+				],
+				targetedRegions: [],
+				excludedRegions: ['us'],
+			},
+		],
+	},
+};
+
+export const validMessageUsOnly = {
+	Message: JSON.stringify(validMessageContentWithUsOnly),
+};
+
 export const messageWithBrokenIssueDate = {
 	...validMessage,
 	Message: JSON.stringify({

--- a/lambda/facia-responder/src/main.test.ts
+++ b/lambda/facia-responder/src/main.test.ts
@@ -47,7 +47,7 @@ describe('main', () => {
 		// @ts-ignore
 		await handler(rec, null, null);
 
-		expect(importCurationDataMock.mock.calls.length).toEqual(2);
+		expect(importCurationDataMock.mock.calls.length).toEqual(4);
 		expect(importCurationDataMock.mock.calls[0][0]).toEqual(
 			JSON.stringify(validMessageContent.fronts['all-recipes']),
 		);
@@ -67,6 +67,24 @@ describe('main', () => {
 		);
 		expect(importCurationDataMock.mock.calls[1][2]).toEqual('meat-free');
 		expect(importCurationDataMock.mock.calls[1][3]).toEqual(
+			new Date(2024, 0, 2),
+		);
+
+		expect(importCurationDataMock.mock.calls[2][0]).toEqual(
+			JSON.stringify(validMessageContent.fronts['all-recipes']),
+		);
+		expect(importCurationDataMock.mock.calls[2][1]).toEqual('us');
+		expect(importCurationDataMock.mock.calls[2][2]).toEqual('all-recipes');
+		expect(importCurationDataMock.mock.calls[2][3]).toEqual(
+			new Date(2024, 0, 2),
+		);
+
+		expect(importCurationDataMock.mock.calls[3][0]).toEqual(
+			JSON.stringify(validMessageContent.fronts['meat-free']),
+		);
+		expect(importCurationDataMock.mock.calls[3][1]).toEqual('us');
+		expect(importCurationDataMock.mock.calls[3][2]).toEqual('meat-free');
+		expect(importCurationDataMock.mock.calls[3][3]).toEqual(
 			new Date(2024, 0, 2),
 		);
 

--- a/lambda/facia-responder/src/main.test.ts
+++ b/lambda/facia-responder/src/main.test.ts
@@ -5,6 +5,8 @@ import {
 	messageWithMissingFrontsTitle,
 	validMessage,
 	validMessageContent,
+	validMessageContentWithUsOnly,
+	validMessageUsOnly,
 } from './fixtures/sns';
 import { handler } from './main';
 
@@ -81,6 +83,84 @@ describe('main', () => {
 
 		expect(importCurationDataMock.mock.calls[3][0]).toEqual(
 			JSON.stringify(validMessageContent.fronts['meat-free']),
+		);
+		expect(importCurationDataMock.mock.calls[3][1]).toEqual('us');
+		expect(importCurationDataMock.mock.calls[3][2]).toEqual('meat-free');
+		expect(importCurationDataMock.mock.calls[3][3]).toEqual(
+			new Date(2024, 0, 2),
+		);
+
+		const notifyFaciaToolMock = notifyFaciaTool as jest.Mock;
+		expect(notifyFaciaToolMock.mock.calls[0][0]).toMatchObject({
+			edition: 'feast-northern-hemisphere',
+			issueDate: '2024-01-02',
+			message:
+				'This issue has been published but its date is in the past so it can only be seen in the Fronts Preview tool',
+			status: 'Published',
+			version: 'v1',
+		});
+	});
+
+	it('should separate US only and rest-of-world fronts', async () => {
+		console.log(JSON.stringify(validMessageContentWithUsOnly));
+
+		const rec = {
+			Records: [
+				{
+					eventSource: 'sqs',
+					awsRegion: 'xx-north-n',
+					messageId: 'BDB66A64-F095-4F4D-9B6A-135173E262A5',
+					body: JSON.stringify(validMessageUsOnly),
+				},
+			],
+		};
+
+		// @ts-ignore
+		await handler(rec, null, null);
+
+		expect(importCurationDataMock.mock.calls.length).toEqual(4);
+		expect(importCurationDataMock.mock.calls[0][0]).toEqual(
+			//these are the non-US fronts in the fixture data
+			JSON.stringify([
+				validMessageContentWithUsOnly.fronts['all-recipes'][0],
+				validMessageContentWithUsOnly.fronts['all-recipes'][2],
+			]),
+		);
+		expect(importCurationDataMock.mock.calls[0][1]).toEqual(
+			validMessageContentWithUsOnly.edition,
+		);
+		expect(importCurationDataMock.mock.calls[0][2]).toEqual('all-recipes');
+		expect(importCurationDataMock.mock.calls[0][3]).toEqual(
+			new Date(2024, 0, 2),
+		);
+
+		expect(importCurationDataMock.mock.calls[1][0]).toEqual(
+			JSON.stringify(validMessageContentWithUsOnly.fronts['meat-free']),
+		);
+		expect(importCurationDataMock.mock.calls[1][1]).toEqual(
+			validMessageContentWithUsOnly.edition,
+		);
+		expect(importCurationDataMock.mock.calls[1][2]).toEqual('meat-free');
+		expect(importCurationDataMock.mock.calls[1][3]).toEqual(
+			new Date(2024, 0, 2),
+		);
+
+		expect(importCurationDataMock.mock.calls[2][0]).toEqual(
+			JSON.stringify([
+				//this one has no explicit include or exclude so should go to both
+				validMessageContentWithUsOnly.fronts['all-recipes'][0],
+				//the only one marked as US only
+				validMessageContentWithUsOnly.fronts['all-recipes'][1],
+			]),
+		);
+		expect(importCurationDataMock.mock.calls[2][1]).toEqual('us');
+		expect(importCurationDataMock.mock.calls[2][2]).toEqual('all-recipes');
+		expect(importCurationDataMock.mock.calls[2][3]).toEqual(
+			new Date(2024, 0, 2),
+		);
+
+		expect(importCurationDataMock.mock.calls[3][0]).toEqual(
+			JSON.stringify(validMessageContentWithUsOnly.fronts['meat-free']),
 		);
 		expect(importCurationDataMock.mock.calls[3][1]).toEqual('us');
 		expect(importCurationDataMock.mock.calls[3][2]).toEqual('meat-free');

--- a/lambda/facia-responder/src/targeted-regions.ts
+++ b/lambda/facia-responder/src/targeted-regions.ts
@@ -1,4 +1,34 @@
 import type * as facia from '@recipes-api/lib/facia';
+import type { FeastAppContainer } from '@recipes-api/lib/facia';
+
+/**
+ * Filters the incoming fronts list based on targetedRegions and excludedRegions
+ * @param fronts fronts list to filter
+ * @param filterFor territory we are filtering for
+ * @param filterIn if `true`, filter IN for this territory (i.e., take global, take targeted, remove excluded)
+ * if `false` filter OUT for this territory (i.e., take global, remove targeted, take excluded)
+ */
+function filterFrontsFor(
+	fronts: Record<string, FeastAppContainer[]>,
+	filterFor: string,
+	filterIn: boolean,
+): Record<string, FeastAppContainer[]> {
+	const filtered: Record<string, FeastAppContainer[]> = {};
+
+	const maybeInverted = (v: boolean) => (filterIn ? !v : v);
+
+	for (const k of Object.keys(fronts)) {
+		filtered[k] = fronts[k].filter((f) => {
+			return (
+				maybeInverted((f.excludedRegions ?? []).includes(filterFor)) ||
+				((f.excludedRegions ?? []).length == 0 &&
+					(f.targetedRegions ?? []).length == 0)
+			);
+		});
+	}
+
+	return filtered;
+}
 
 /**
  * This function takes in a full curation deployment from Facia tool and synthesises
@@ -10,13 +40,22 @@ export function generateTargetedRegionFronts(
 ): facia.FeastCuration[] {
 	if (src.path === 'northern' || src.edition === 'feast-northern-hemisphere') {
 		//regionalise the northern front
-		//TODO: bring through the fields to filter. For now, just duplicate
+		const usOnlyFronts = filterFrontsFor(src.fronts, 'us', true);
+
 		const usOnly = {
 			...src,
 			path: 'us',
 			edition: 'feast-us-only',
+			fronts: usOnlyFronts,
 		};
-		return [src, usOnly];
+
+		const otherFronts = filterFrontsFor(src.fronts, 'us', false);
+		const restOfHemisphere = {
+			...src,
+			fronts: otherFronts,
+		};
+
+		return [restOfHemisphere, usOnly];
 	} else {
 		//don't regionalise others
 		return [src];

--- a/lambda/facia-responder/src/targeted-regions.ts
+++ b/lambda/facia-responder/src/targeted-regions.ts
@@ -8,15 +8,13 @@ import type * as facia from '@recipes-api/lib/facia';
 export function generateTargetedRegionFronts(
 	src: facia.FeastCuration,
 ): facia.FeastCuration[] {
-	const region = src.path ?? src.edition;
-
-	if (region === 'northern') {
+	if (src.path === 'northern' || src.edition === 'feast-northern-hemisphere') {
 		//regionalise the northern front
 		//TODO: bring through the fields to filter. For now, just duplicate
 		const usOnly = {
 			...src,
 			path: 'us',
-			edition: 'us',
+			edition: 'feast-us-only',
 		};
 		return [src, usOnly];
 	} else {

--- a/lambda/facia-responder/src/targeted-regions.ts
+++ b/lambda/facia-responder/src/targeted-regions.ts
@@ -1,0 +1,26 @@
+import type * as facia from '@recipes-api/lib/facia';
+
+/**
+ * This function takes in a full curation deployment from Facia tool and synthesises
+ * regionalised versions, if present
+ * @param src
+ */
+export function generateTargetedRegionFronts(
+	src: facia.FeastCuration,
+): facia.FeastCuration[] {
+	const region = src.path ?? src.edition;
+
+	if (region === 'northern') {
+		//regionalise the northern front
+		//TODO: bring through the fields to filter. For now, just duplicate
+		const usOnly = {
+			...src,
+			path: 'us',
+			edition: 'us',
+		};
+		return [src, usOnly];
+	} else {
+		//don't regionalise others
+		return [src];
+	}
+}

--- a/lambda/publish-todays-curation/src/curation.test.ts
+++ b/lambda/publish-todays-curation/src/curation.test.ts
@@ -196,8 +196,8 @@ describe('curation.validateAllCuration', () => {
 
 		const result = await validateAllCuration(Today, false, staticBucketName);
 
-		expect(s3Mock.commandCalls(HeadObjectCommand).length).toEqual(4);
-		for (let i = 0; i < 4; i++) {
+		expect(s3Mock.commandCalls(HeadObjectCommand).length).toEqual(6);
+		for (let i = 0; i < 6; i++) {
 			const req = s3Mock.commandCalls(HeadObjectCommand)[i].firstArg
 				.input as HeadObjectCommandInput;
 			expect(req.Bucket).toEqual(staticBucketName);
@@ -221,6 +221,12 @@ describe('curation.validateAllCuration', () => {
 					expect(req.Key).toEqual(
 						'southern/all-recipes/2024-02-03/curation.json',
 					);
+					break;
+				case 4:
+					expect(req.Key).toEqual('us/meat-free/2024-02-03/curation.json');
+					break;
+				case 5:
+					expect(req.Key).toEqual('us/all-recipes/2024-02-03/curation.json');
 					break;
 			}
 		}

--- a/lambda/publish-todays-curation/src/curation.ts
+++ b/lambda/publish-todays-curation/src/curation.ts
@@ -17,7 +17,7 @@ export interface CurationPath {
 	day: number;
 }
 
-const KnownEditions = ['northern', 'southern'];
+const KnownEditions = ['northern', 'southern', 'us'];
 
 const KnownFronts = ['meat-free', 'all-recipes'];
 

--- a/lib/facia/src/lib/facia-models.ts
+++ b/lib/facia/src/lib/facia-models.ts
@@ -57,8 +57,8 @@ export const FeastAppContainer = z.object({
 	title: z.string(),
 	body: z.string().optional(),
 	items: z.array(z.union([SubCollection, Chef, Recipe])),
-	targetedRegions: z.array(z.string().optional()),
-	excludedRegions: z.array(z.string().optional()),
+	targetedRegions: z.array(z.string()).optional(),
+	excludedRegions: z.array(z.string()).optional(),
 });
 
 export type FeastAppContainer = z.infer<typeof FeastAppContainer>;

--- a/lib/facia/src/lib/facia-models.ts
+++ b/lib/facia/src/lib/facia-models.ts
@@ -57,6 +57,8 @@ export const FeastAppContainer = z.object({
 	title: z.string(),
 	body: z.string().optional(),
 	items: z.array(z.union([SubCollection, Chef, Recipe])),
+	targetedRegions: z.array(z.string().optional()),
+	excludedRegions: z.array(z.string().optional()),
 });
 
 export type FeastAppContainer = z.infer<typeof FeastAppContainer>;


### PR DESCRIPTION
Co-authored with @Divs-B 

## What does this change?

Implements the first version of regional targeting (https://github.com/guardian/facia-tool/pull/1748) in recipes-backend.
This involves:
- adding the `targetedRegions` and `excludedRegions` fields to the internal data model
- explicitly filtering the Northern hemisphere front based on whether the `us` region is included or excluded
- the Northern hemisphere front will _exclude_ collections specifically targeted at US and _include_ everything else
- a new US-only front is created identical to the Northern hemisphere front that _includes_ collections specifically targeted at US and _excludes_ material specifically targeted elsewhere.
- collections that have no explicit targeting instructions are common to all output fronts

### Future work

Exclusions are not yet implemented in the Fronts tool, so cannot be tested end-to-end in this way.  The exclusion logic is tested in CI though.

## How to test

- Ensure that https://github.com/guardian/facia-tool/pull/1748 is deployed to CODE
- Deploy this to CODE
- Create a front and target some collections to US
- Publish it (in CODE of course!)
- Examine the output data, either in S3 in the CAPI account or via https.
  - https://recipes.code.dev-guardianapis.com/northern/all-recipes/yyyy-mm-dd/curation.json should NOT contain any US targeted containers
  - https://recipes.code.dev-guardianapis.com/us/all-recipes/yyyy-mm-dd/curation.json SHOULD contain any US targeted containers
- Sanity check the new test cases

## How can we measure success?

Able to deliver US targeted content

## Have we considered potential risks?

The biggest risk is that a targeted container displays in the wrong region; this is easily fixable and not a major worry.
