### PR TITLE
Fix telemetry write

### DIFF
--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -3810,6 +3810,13 @@ def sort_filter_rules(json_obj):
               },
             },
             {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "TelemetryTopic",
+              },
+            },
+            {
               "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -189,6 +189,11 @@ export class RecipesBackend extends GuStack {
 					actions: ['events:PutEvents'],
 					resources: [eventBus.eventBusArn],
 				}),
+				new PolicyStatement({
+					effect: Effect.ALLOW,
+					actions: ['sns:Publish'],
+					resources: [telemetryTopic.valueAsString],
+				}),
 			],
 			runtime: Runtime.NODEJS_20_X,
 			app,


### PR DESCRIPTION
> [!WARNING]
> Please don't deploy this to CODE at the moment, there is some important infra on a branch from #94 that should not be overwritten

## What does this change?

Fixes `AuthorizationErrorException` during telemetry write

## How to test

- Deploy to CODE
- Publish a recipe from Composer
- Monitor the logs for recipe-responder.  You should _not_ see an `AuthorizationErrorException` (or any other errors for that matter)

## How can we measure success?

- No more `AuthorizationErrorException`
- Complete telemetry data (currently missing publication times)

## Have we considered potential risks?

n/a
