### PR TITLE
Add 'magic tag' to back up dynamodb

### DIFF
--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -3297,6 +3297,10 @@ def sort_filter_rules(json_obj):
         "TableName": "recipes-backend-indexstore-TEST",
         "Tags": [
           {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },

--- a/cdk/lib/datastore.ts
+++ b/cdk/lib/datastore.ts
@@ -7,6 +7,7 @@ import {
 	Table,
 	TableEncryption,
 } from 'aws-cdk-lib/aws-dynamodb';
+import { Tags } from 'aws-cdk-lib/core';
 import { Construct } from 'constructs';
 
 export class DataStore extends Construct {
@@ -33,6 +34,8 @@ export class DataStore extends Construct {
 			pointInTimeRecovery: true,
 			encryption: TableEncryption.AWS_MANAGED,
 		});
+
+		Tags.of(table).add('devx-backup-enabled', 'true');
 
 		this.lastUpdatedIndexName = 'idxArticleLastUpdated';
 


### PR DESCRIPTION
## What does this change?

Adds the `devx-backup-enabled` flag to the index table

## How to test

- Deploy to CODE [done Mon 24th Mar]
- Wait overnight
- Next day, it should have been backed up

## How can we measure success?

Backups working

## Have we considered potential risks?

n/a
