### PR TITLE
Hybrid container tweaks

### DIFF
--- a/lambda/dynamic-fronts-fetcher/src/transform.test.ts
+++ b/lambda/dynamic-fronts-fetcher/src/transform.test.ts
@@ -43,18 +43,4 @@ describe('convertBQReport', () => {
 		expect(result.excludedRegions).toEqual(undefined);
 		expect(result.title).toEqual("What's hot near you");
 	});
-
-	it('should respect the sizeLimit parameter', () => {
-		const result = convertBQReport('US', fakeRows, 3);
-		expect(result.body).toBeUndefined();
-		expect(result.targetedRegions).toEqual(['US']);
-		expect(result.excludedRegions).toEqual(undefined);
-		expect(result.title).toEqual("What's hot in the United States of America");
-		expect(result.items.length).toEqual(3);
-		expect((result.items as Recipe[]).map((_) => _.recipe.id)).toEqual([
-			'123345',
-			'dsa',
-			'GFSD',
-		]);
-	});
 });

--- a/lambda/dynamic-fronts-fetcher/src/transform.ts
+++ b/lambda/dynamic-fronts-fetcher/src/transform.ts
@@ -29,15 +29,12 @@ function printableCountryName(isoCode: string): string {
 export function convertBQReport(
 	territory: string,
 	incoming: IncomingDataRow[],
-	sizeLimit = 10,
 ): FeastAppContainer {
-	let items = incoming.map((r) => ({
+	const items = incoming.map((r) => ({
 		recipe: {
 			id: r.recipe_id,
 		},
 	}));
-
-	if (items.length > sizeLimit) items = items.slice(0, sizeLimit);
 
 	const id = uuid();
 

--- a/lambda/rest-endpoints/src/curation.test.ts
+++ b/lambda/rest-endpoints/src/curation.test.ts
@@ -19,15 +19,31 @@ describe('generateHybridFront', () => {
 	});
 
 	const mockMainCurationData: FeastAppContainer[] = [
-		{ title: 'container 1', items: [] },
+		{
+			title: 'container 1',
+			items: [{ recipe: { id: 'recipe-1a' } }, { recipe: { id: 'recipe-1b' } }],
+		},
 		{ title: 'container 2', items: [] },
-		{ title: 'container 3', items: [] },
-		{ title: 'container 4', items: [] },
+		{
+			title: 'container 3',
+			items: [{ recipe: { id: 'recipe-3a' } }, { recipe: { id: 'recipe-3b' } }],
+		},
+		{
+			title: 'container 4',
+			items: [{ recipe: { id: 'recipe-4a' } }, { recipe: { id: 'recipe-4b' } }],
+		},
 	];
 
 	const mockInsertCurationData: FeastAppContainer = {
 		title: 'inserted container',
-		items: [],
+		items: [
+			{ recipe: { id: 'recipe-5' } },
+			{ recipe: { id: 'recipe-6' } },
+			{ recipe: { id: 'recipe-7' } },
+			{ recipe: { id: 'recipe-1b' } },
+			{ recipe: { id: 'recipe-8' } },
+			{ recipe: { id: 'recipe-9' } },
+		],
 	};
 
 	it('should retrieve both the curated front and inserts and combine them', async () => {
@@ -168,6 +184,57 @@ describe('generateHybridFront', () => {
 		expect(result[1].title).toEqual('container 2');
 		expect(result[2].title).toEqual('container 3');
 		expect(result[3].title).toEqual('container 4');
+	});
+
+	it('should not put recipes in the insert that also exist in the curated content', async () => {
+		const mainCurationBody = Readable.from(
+			Buffer.from(JSON.stringify(mockMainCurationData)),
+		);
+		const insertBody = Readable.from(
+			Buffer.from(JSON.stringify(mockInsertCurationData)),
+		);
+
+		s3Mock.callsFake((input: GetObjectCommandInput) => {
+			console.log(JSON.stringify(input));
+		});
+
+		s3Mock
+			.onAnyCommand({
+				Bucket: 'test',
+				Key: `northern/all-recipes/curation.json`,
+			})
+			.resolves({
+				// @ts-ignore
+				Body: mainCurationBody,
+			});
+
+		s3Mock
+			.onAnyCommand({
+				Bucket: 'test',
+				Key: `dynamic/curation/2025-01-02/FR.json`,
+			})
+			.resolves({
+				//@ts-ignore
+				Body: insertBody,
+			});
+
+		const result = await generateHybridFront(
+			'northern',
+			'all-recipes',
+			'fr',
+			2,
+			new Date(2025, 0, 2),
+		);
+		console.log(JSON.stringify(result));
+
+		expect(result[0].title).toEqual('container 1');
+		expect(result[1].title).toEqual('container 2');
+		expect(result[2].title).toEqual('inserted container');
+		expect(result[2].items.length).toEqual(
+			mockInsertCurationData.items.length - 1,
+		);
+		expect(result[3].title).toEqual('container 3');
+		expect(result[4].title).toEqual('container 4');
 	});
 
 	it("should not crash if the insert data can't be loaded", async () => {

--- a/lambda/rest-endpoints/src/curation.ts
+++ b/lambda/rest-endpoints/src/curation.ts
@@ -131,6 +131,7 @@ export async function findRecentLocalisation(
 	cutoffInDays: number,
 	startDate: Date,
 	curatedRecipes?: Set<string>,
+	cutoff?: number,
 ) {
 	for (let i = 0; i < cutoffInDays; i++) {
 		const testDate = subDays(startDate, i);
@@ -154,10 +155,20 @@ export async function findRecentLocalisation(
 							!row.hasOwnProperty('recipe'),
 					),
 				};
-				return deduplicatedLocalisation;
+				return !!cutoff && deduplicatedLocalisation.items.length > cutoff
+					? {
+							...deduplicatedLocalisation,
+							items: deduplicatedLocalisation.items.slice(0, cutoff),
+					  }
+					: deduplicatedLocalisation;
 			} else {
 				//we have not been asked to de-duplicate
-				return maybeLocalisation;
+				return !!cutoff && maybeLocalisation.items.length > cutoff
+					? {
+							...maybeLocalisation,
+							items: maybeLocalisation.items.slice(0, cutoff),
+					  }
+					: maybeLocalisation;
 			}
 		}
 	}
@@ -204,6 +215,7 @@ export async function generateHybridFront(
 		5,
 		overrideDate ?? new Date(),
 		curatedRecipesSet,
+		10,
 	);
 	if (maybeLocalisation) {
 		if (curatedFront.length < localisationInsertionPoint) {

--- a/lambda/rest-endpoints/src/curation.ts
+++ b/lambda/rest-endpoints/src/curation.ts
@@ -6,6 +6,11 @@ import {
 } from '@aws-sdk/client-s3';
 import type { NodeJsRuntimeStreamingBlobTypes } from '@smithy/types/dist-types/streaming-payload/streaming-blob-common-types';
 import { format as formatDate, subDays } from 'date-fns';
+import type {
+	ContainerItem,
+	Recipe,
+	SubCollection,
+} from '@recipes-api/lib/facia';
 import { FeastAppContainer } from '@recipes-api/lib/facia';
 import {
 	AwsRegion,
@@ -125,6 +130,7 @@ export async function findRecentLocalisation(
 	territory: string,
 	cutoffInDays: number,
 	startDate: Date,
+	curatedRecipes?: Set<string>,
 ) {
 	for (let i = 0; i < cutoffInDays; i++) {
 		const testDate = subDays(startDate, i);
@@ -134,10 +140,42 @@ export async function findRecentLocalisation(
 			testDate,
 		);
 		if (maybeLocalisation) {
-			return maybeLocalisation;
+			//if we have been given a set of curated recipes, ensure that they are not in the returned data
+			if (curatedRecipes) {
+				const deduplicatedLocalisation: FeastAppContainer = {
+					...maybeLocalisation,
+					//filter out anything that is a recipe specifier and also exists in curatedRecipes
+					items: maybeLocalisation.items.filter(
+						(row) =>
+							// eslint-disable-next-line no-prototype-builtins -- how else to do this?
+							(row.hasOwnProperty('recipe') &&
+								!curatedRecipes.has((row as Recipe).recipe.id)) ||
+							// eslint-disable-next-line no-prototype-builtins -- how else to do this?
+							!row.hasOwnProperty('recipe'),
+					),
+				};
+				return deduplicatedLocalisation;
+			} else {
+				//we have not been asked to de-duplicate
+				return maybeLocalisation;
+			}
 		}
 	}
 	return undefined;
+}
+
+function recipeFromContainer(item: ContainerItem): string[] {
+	// eslint-disable-next-line no-prototype-builtins -- how else to do this?
+	if (item.hasOwnProperty('recipe')) {
+		const recipeItem = item as Recipe;
+		return [recipeItem.recipe.id];
+		// eslint-disable-next-line no-prototype-builtins -- how else to do this?
+	} else if (item.hasOwnProperty('collection')) {
+		const collectionItem = item as SubCollection;
+		return collectionItem.collection.recipes;
+	} else {
+		return [];
+	}
 }
 
 export async function generateHybridFront(
@@ -153,6 +191,10 @@ export async function generateHybridFront(
 		return curatedFront;
 	}
 
+	const curatedRecipesSet = new Set(
+		curatedFront.flatMap((c) => c.items).flatMap(recipeFromContainer),
+	);
+
 	if (!territory) {
 		//no territory given so we can't localise
 		return curatedFront;
@@ -161,6 +203,7 @@ export async function generateHybridFront(
 		territory,
 		5,
 		overrideDate ?? new Date(),
+		curatedRecipesSet,
 	);
 	if (maybeLocalisation) {
 		if (curatedFront.length < localisationInsertionPoint) {


### PR DESCRIPTION
## What does this change?

Minor pre-release tweaks to hybrid containers:
- ensure that the localised container does not contain any recipes from the curated front
- remove the `sizeLimit` parameter from the hybrid container fetcher lambda and instead put it at render time (so we can over-request then filter at the end). This is currently hard-coded but simple to change

## How to test

Tested in CI tests

## How can we measure success?

More interesting data!

## Have we considered potential risks?
n/a
