### PR TITLE
Change the wording for the localised fronts container

### DIFF
--- a/lambda/dynamic-fronts-fetcher/src/transform.test.ts
+++ b/lambda/dynamic-fronts-fetcher/src/transform.test.ts
@@ -19,7 +19,7 @@ describe('convertBQReport', () => {
 		expect(result.body).toBeUndefined();
 		expect(result.targetedRegions).toEqual(['GB']);
 		expect(result.excludedRegions).toEqual(undefined);
-		expect(result.title).toEqual("What's hot in the United Kingdom");
+		expect(result.title).toEqual('Most popular in the United Kingdom');
 		expect((result.items as Recipe[]).map((_) => _.recipe.id)).toEqual(
 			fakeRows.map((_) => _.recipe_id),
 		);
@@ -30,7 +30,7 @@ describe('convertBQReport', () => {
 		expect(result.body).toBeUndefined();
 		expect(result.targetedRegions).toEqual(['FR']);
 		expect(result.excludedRegions).toEqual(undefined);
-		expect(result.title).toEqual("What's hot in France");
+		expect(result.title).toEqual('Most popular in France');
 		expect((result.items as Recipe[]).map((_) => _.recipe.id)).toEqual(
 			fakeRows.map((_) => _.recipe_id),
 		);
@@ -41,6 +41,6 @@ describe('convertBQReport', () => {
 		expect(result.body).toBeUndefined();
 		expect(result.targetedRegions).toEqual(['AXF']);
 		expect(result.excludedRegions).toEqual(undefined);
-		expect(result.title).toEqual("What's hot near you");
+		expect(result.title).toEqual('Most popular near you');
 	});
 });

--- a/lambda/dynamic-fronts-fetcher/src/transform.ts
+++ b/lambda/dynamic-fronts-fetcher/src/transform.ts
@@ -41,7 +41,7 @@ export function convertBQReport(
 	return {
 		id,
 		targetedRegions: [territory],
-		title: `What's hot ${printableCountryName(territory)}`,
+		title: `Most popular ${printableCountryName(territory)}`,
 		items,
 	};
 }

--- a/lambda/rest-endpoints/src/curation.test.ts
+++ b/lambda/rest-endpoints/src/curation.test.ts
@@ -225,14 +225,18 @@ describe('generateHybridFront', () => {
 			2,
 			new Date(2025, 0, 2),
 		);
-		console.log(JSON.stringify(result));
 
 		expect(result[0].title).toEqual('container 1');
 		expect(result[1].title).toEqual('container 2');
 		expect(result[2].title).toEqual('inserted container');
-		expect(result[2].items.length).toEqual(
-			mockInsertCurationData.items.length - 1,
-		);
+		expect(result[2].items).toEqual([
+			//i.e., it should not contain the duplicated `recipe-1b`
+			{ recipe: { id: 'recipe-5' } },
+			{ recipe: { id: 'recipe-6' } },
+			{ recipe: { id: 'recipe-7' } },
+			{ recipe: { id: 'recipe-8' } },
+			{ recipe: { id: 'recipe-9' } },
+		]);
 		expect(result[3].title).toEqual('container 3');
 		expect(result[4].title).toEqual('container 4');
 	});


### PR DESCRIPTION
## What does this change?

Following successful beta, the UX consensus is that the container should be named `Most Popular in...` for the time being

Also minor test improvements that did not make it into the last PR!

## How to test

- Deploy to CODE
- Force a run of the extraction job in Airflow to trigger the lambda
- Test by going to https://recipes.code.dev-guardianapis.com/api/northern/all-recipes/hybrid-curation.json?ter=fr - you should see `Most popular in France` at about number 3
- Test by going to https://recipes.code.dev-guardianapis.com/api/northern/all-recipes/hybrid-curation.json?ter=nl - you should see `Most popular in the Netherlands` at about number 3
