### PR TITLE
Wire in the printable recipes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,52 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  printable-recipes-generator:
+    runs-on: ubuntu-latest
+    permissions:
+          id-token: write
+          contents: read
+          checks: write
+          issues: read
+          pull-requests: write
+    steps:
+          - uses: actions/checkout@v3
+
+          - uses: actions/setup-node@v3
+            with:
+              node-version-file: .nvmrc
+              cache: 'npm'
+
+          - run: npm ci
+
+          - run: npm run nx run printable-recipe-generator:build
+
+          - name: Set up QEMU
+            uses: docker/setup-qemu-action@v3
+          - name: Set up Docker Buildx
+            uses: docker/setup-buildx-action@v3
+          - uses: aws-actions/configure-aws-credentials@v4
+            with:
+              aws-region: eu-west-1
+              role-to-assume: ${{secrets.GU_ECR_ROLE_ARN}}
+          - uses: aws-actions/amazon-ecr-login@v2
+            id: ecr-login
+            with:
+              mask-password: "true"
+            continue-on-error: true
+          - name: Build and push
+            uses: docker/build-push-action@v5
+            env:
+              REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+              IMAGE_TAG: ${{ github.run_number }}
+            with:
+              context: printable-recipe-generator/docker
+              platforms: linux/arm64
+              push: true
+              tags: ${{ env.REGISTRY }}/recipes-backend/printable-recipes:${{ env.IMAGE_TAG }}
+              cache-from: type=gha
+              cache-to: type=gha,mode=max
+              provenance: false
   build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,8 @@ jobs:
           STATIC_BUCKET: test
           CONTENT_URL_BASE: test
       - run: npm run build
-
+        env:
+          IMAGE_TAG: ${{ github.run_number }}
       - uses: guardian/actions-riff-raff@v4
         with:
           projectName: Feast::recipes-backend

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -72,7 +72,7 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
   },
   "Parameters": {
     "ClusterArn": {
-      "Default": "Add the SSM path as the default value e.g. /$stage/$stack/$app/$param",
+      "Default": "/account/services/ecs-cluster",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "DistributionBucketName": {

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1700,7 +1700,7 @@ def sort_filter_rules(json_obj):
         ],
         "Cpu": "1024",
         "EphemeralStorage": {
-          "SizeInGiB": 20,
+          "SizeInGiB": 25,
         },
         "ExecutionRoleArn": {
           "Fn::GetAtt": [

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1613,9 +1613,14 @@ def sort_filter_rules(json_obj):
             "Memory": 2048,
             "MountPoints": [
               {
-                "ContainerPath": "/home/pdfrender",
+                "ContainerPath": "/tmp",
                 "ReadOnly": false,
                 "SourceVolume": "tmp-volume",
+              },
+              {
+                "ContainerPath": "/home/pdfrender",
+                "ReadOnly": false,
+                "SourceVolume": "home-volume",
               },
             ],
             "Name": "main",
@@ -1670,6 +1675,9 @@ def sort_filter_rules(json_obj):
         "Volumes": [
           {
             "Name": "tmp-volume",
+          },
+          {
+            "Name": "home-volume",
           },
         ],
       },

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1523,7 +1523,7 @@ def sort_filter_rules(json_obj):
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": {
-                "Service": "ecs.amazonaws.com",
+                "Service": "events.amazonaws.com ",
               },
             },
           ],

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1688,7 +1688,7 @@ def sort_filter_rules(json_obj):
                   {
                     "Ref": "RepoName",
                   },
-                  ":618",
+                  ":latest",
                 ],
               ],
             },

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1727,7 +1727,7 @@ def sort_filter_rules(json_obj):
           ],
         },
         "Family": "RecipesBackendPrintableRecipesPrintableRecipeGenTDDB494472",
-        "Memory": "2048",
+        "Memory": "8192",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -2031,7 +2031,7 @@ def sort_filter_rules(json_obj):
                 "detail-checksum": "$.detail.checksum",
                 "detail-uid": "$.detail.uid",
               },
-              "InputTemplate": "{"containerOverrides":[{"name":"main","environment":[{"name":"RECIPE_UID","value":<detail-uid>},{"name":"RECIPE_CSID","value":<detail-checksum>},{"name":"CONTENT","value":<detail-blob>}]}]}",
+              "InputTemplate": "{"containerOverrides":[{"name":"main","environment":[{"name":"RECIPE_UID","value":<detail-uid>},{"name":"RECIPE_CSID","value":<detail-checksum>},{"name":"CONTENT","value":<detail-blob>},{"name":"BUCKET","value":"feast-recipes-static-test"}]}]}",
             },
             "RoleArn": {
               "Fn::GetAtt": [

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -72,7 +72,7 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
   },
   "Parameters": {
     "ClusterArn": {
-      "Default": "/account/services/ecs-cluster",
+      "Default": "/account/services/ecs-cluster-name",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "DistributionBucketName": {

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -2011,9 +2011,10 @@ def sort_filter_rules(json_obj):
             "InputTransformer": {
               "InputPathsMap": {
                 "detail-blob": "$.detail.blob",
+                "detail-checksum": "$.detail.checksum",
                 "detail-uid": "$.detail.uid",
               },
-              "InputTemplate": "{"containerOverrides":[{"name":"main","environment":[{"name":"RECIPE_ID","value":<detail-uid>},{"name":"CONTENT","value":<detail-blob>}]}]}",
+              "InputTemplate": "{"containerOverrides":[{"name":"main","environment":[{"name":"RECIPE_UID","value":<detail-uid>},{"name":"RECIPE_CSID","value":<detail-checksum>},{"name":"CONTENT","value":<detail-blob>}]}]}",
             },
             "RoleArn": {
               "Fn::GetAtt": [

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1529,6 +1529,25 @@ def sort_filter_rules(json_obj):
           ],
           "Version": "2012-10-17",
         },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:PutObject",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "arn:aws:s3:::feast-recipes-static-test/content/",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "s3write",
+          },
+        ],
         "RoleName": "printable-recipe-generator-TEST",
         "Tags": [
           {

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -22,8 +22,13 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuScheduledLambda",
-      "GuScheduledLambda",
       "GuLambdaFunction",
+      "GuParameter",
+      "GuParameter",
+      "GuParameter",
+      "GuParameter",
+      "GuParameter",
+      "GuParameter",
       "GuParameter",
     ],
     "gu:cdk:version": "TEST",
@@ -66,6 +71,10 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
     },
   },
   "Parameters": {
+    "ClusterArn": {
+      "Default": "Add the SSM path as the default value e.g. /$stage/$stack/$app/$param",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
@@ -79,10 +88,30 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       "Default": "/TEST/feast/feast-shared-infra/crier-event-bus",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "RepoName": {
+      "Default": "/TEST/feast/recipes-backend/ecr-repo-printables",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "TelemetryTopic": {
       "Default": "/TEST/feast/recipe-structuriser/telemetryTopic",
       "Description": "ARN of the SNS topic to use for data submissions (shared with structuriser)",
       "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "VpcAZParam": {
+      "Default": "/account/vpc/primary/availability-zones",
+      "Type": "AWS::SSM::Parameter::Value<List<String>>",
+    },
+    "VpcIdParam": {
+      "Default": "/account/vpc/primary/id",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "VpcPrivateParam": {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Type": "AWS::SSM::Parameter::Value<List<String>>",
+    },
+    "VpcPublicParam": {
+      "Default": "/account/vpc/primary/subnets/public",
+      "Type": "AWS::SSM::Parameter::Value<List<String>>",
     },
     "capiKey": {
       "Default": "/TEST/feast/recipes-responder/capi-key",
@@ -1486,117 +1515,7 @@ def sort_filter_rules(json_obj):
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "PublishContributors7FDDEA0E": {
-      "DependsOn": [
-        "PublishContributorsServiceRoleDefaultPolicyEEA7218F",
-        "PublishContributorsServiceRole5EFC8614",
-      ],
-      "Properties": {
-        "Architectures": [
-          "arm64",
-        ],
-        "Code": {
-          "S3Bucket": {
-            "Ref": "DistributionBucketName",
-          },
-          "S3Key": "feast/TEST/recipes-publish-contributor-information/profile-cache-rebuild.zip",
-        },
-        "Environment": {
-          "Variables": {
-            "APP": "recipes-publish-contributor-information",
-            "CAPI_BASE_URL": "content.guardianapis.com",
-            "CAPI_KEY": {
-              "Ref": "capiKey",
-            },
-            "CONTENT_URL_BASE": "recipes.guardianapis.com",
-            "FASTLY_API_KEY": {
-              "Ref": "fastlyKey",
-            },
-            "STACK": "feast",
-            "STAGE": "TEST",
-            "STATIC_BUCKET": {
-              "Ref": "staticstaticServing53194089",
-            },
-          },
-        },
-        "FunctionName": "PublishRecipeContributors-TEST",
-        "Handler": "main.handler",
-        "LoggingConfig": {
-          "LogFormat": "JSON",
-        },
-        "MemorySize": 256,
-        "Role": {
-          "Fn::GetAtt": [
-            "PublishContributorsServiceRole5EFC8614",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs20.x",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "recipes-publish-contributor-information",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/recipes-backend",
-          },
-          {
-            "Key": "Stack",
-            "Value": "feast",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "PublishContributorsPublishContributorscron16089AD5627": {
-      "Properties": {
-        "Description": "Update cache of contributor information for Feast at 16 minutes past every hour",
-        "ScheduleExpression": "cron(16 * * * ? *)",
-        "State": "ENABLED",
-        "Targets": [
-          {
-            "Arn": {
-              "Fn::GetAtt": [
-                "PublishContributors7FDDEA0E",
-                "Arn",
-              ],
-            },
-            "Id": "Target0",
-          },
-        ],
-      },
-      "Type": "AWS::Events::Rule",
-    },
-    "PublishContributorsPublishContributorscron160AllowEventRuleRecipesBackendPublishContributorsE21492564767307C": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "PublishContributors7FDDEA0E",
-            "Arn",
-          ],
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "PublishContributorsPublishContributorscron16089AD5627",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "PublishContributorsServiceRole5EFC8614": {
+    "PrintableRecipesIAMRole8B7C763A": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -1604,31 +1523,14 @@ def sort_filter_rules(json_obj):
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": {
-                "Service": "lambda.amazonaws.com",
+                "Service": "ecs.amazonaws.com",
               },
             },
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
+        "RoleName": "printable-recipe-generator-TEST",
         "Tags": [
-          {
-            "Key": "App",
-            "Value": "recipes-publish-contributor-information",
-          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1649,43 +1551,62 @@ def sort_filter_rules(json_obj):
       },
       "Type": "AWS::IAM::Role",
     },
-    "PublishContributorsServiceRoleDefaultPolicyEEA7218F": {
+    "PrintableRecipesIAMRoleDefaultPolicyEA27E680": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "*",
-              "Effect": "Deny",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Fn::GetAtt": [
-                        "staticstaticServing53194089",
-                        "Arn",
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":ecs:",
+                        {
+                          "Ref": "AWS::Region",
+                        },
+                        ":",
+                        {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":cluster/",
+                        {
+                          "Ref": "ClusterArn",
+                        },
                       ],
-                    },
-                    "/content/*",
-                  ],
-                ],
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PrintableRecipesPrintableRecipeGenTD7D170872",
               },
             },
             {
-              "Action": [
-                "s3:PutObject",
-                "s3:GetObject",
-              ],
+              "Action": "ecs:TagResource",
               "Effect": "Allow",
               "Resource": {
                 "Fn::Join": [
                   "",
                   [
+                    "arn:",
                     {
-                      "Fn::GetAtt": [
-                        "staticstaticServing53194089",
-                        "Arn",
-                      ],
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ecs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":*:task/",
+                    {
+                      "Ref": "ClusterArn",
                     },
                     "/*",
                   ],
@@ -1693,100 +1614,417 @@ def sort_filter_rules(json_obj):
               },
             },
             {
-              "Action": [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                      "/feast/TEST/recipes-publish-contributor-information/profile-cache-rebuild.zip",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "ssm:GetParametersByPath",
+              "Action": "iam:PassRole",
               "Effect": "Allow",
               "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/TEST/feast/recipes-publish-contributor-information",
-                  ],
+                "Fn::GetAtt": [
+                  "PrintableRecipesPrintableRecipeGenTDExecutionRoleD7C4D437",
+                  "Arn",
                 ],
               },
             },
             {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
+              "Action": "iam:PassRole",
               "Effect": "Allow",
               "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/TEST/feast/recipes-publish-contributor-information/*",
-                  ],
+                "Fn::GetAtt": [
+                  "PrintableRecipesPrintableRecipeGenTDTaskRoleA90C8F20",
+                  "Arn",
                 ],
               },
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "PublishContributorsServiceRoleDefaultPolicyEEA7218F",
+        "PolicyName": "PrintableRecipesIAMRoleDefaultPolicyEA27E680",
         "Roles": [
           {
-            "Ref": "PublishContributorsServiceRole5EFC8614",
+            "Ref": "PrintableRecipesIAMRole8B7C763A",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "PrintableRecipesPrintableRecipeGenTD7D170872": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Essential": true,
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ".dkr.ecr.",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  ".",
+                  {
+                    "Ref": "AWS::URLSuffix",
+                  },
+                  "/",
+                  {
+                    "Ref": "RepoName",
+                  },
+                  ":618",
+                ],
+              ],
+            },
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "PrintableRecipesPrintableRecipeGenTDmainLogGroupF0790787",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "printable-recipe-generator-",
+              },
+            },
+            "Memory": 2048,
+            "MountPoints": [
+              {
+                "ContainerPath": "/tmp",
+                "ReadOnly": false,
+                "SourceVolume": "tmp-volume",
+              },
+            ],
+            "Name": "main",
+            "ReadonlyRootFilesystem": true,
+            "WorkingDirectory": "/tmp",
+          },
+        ],
+        "Cpu": "1024",
+        "EphemeralStorage": {
+          "SizeInGiB": 20,
+        },
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "PrintableRecipesPrintableRecipeGenTDExecutionRoleD7C4D437",
+            "Arn",
+          ],
+        },
+        "Family": "RecipesBackendPrintableRecipesPrintableRecipeGenTDDB494472",
+        "Memory": "2048",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "EC2",
+          "FARGATE",
+        ],
+        "RuntimePlatform": {
+          "CpuArchitecture": "X86_64",
+          "OperatingSystemFamily": "LINUX",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "PrintableRecipesPrintableRecipeGenTDTaskRoleA90C8F20",
+            "Arn",
+          ],
+        },
+        "Volumes": [
+          {
+            "Name": "tmp-volume",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "PrintableRecipesPrintableRecipeGenTDExecutionRoleD7C4D437": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "PrintableRecipesPrintableRecipeGenTDExecutionRoleDefaultPolicyD5897DEA": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ecr:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":repository/",
+                    {
+                      "Ref": "RepoName",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "ecr:GetAuthorizationToken",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "PrintableRecipesPrintableRecipeGenTDmainLogGroupF0790787",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PrintableRecipesPrintableRecipeGenTDExecutionRoleDefaultPolicyD5897DEA",
+        "Roles": [
+          {
+            "Ref": "PrintableRecipesPrintableRecipeGenTDExecutionRoleD7C4D437",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PrintableRecipesPrintableRecipeGenTDSecurityGroup2E72B084": {
+      "Properties": {
+        "GroupDescription": "RecipesBackend/PrintableRecipes/PrintableRecipeGenTD/SecurityGroup",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcIdParam",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "PrintableRecipesPrintableRecipeGenTDTaskRoleA90C8F20": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "PrintableRecipesPrintableRecipeGenTDmainLogGroupF0790787": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "PrintableRecipesPublicationConnectCE29A280": {
+      "Properties": {
+        "EventBusName": {
+          "Ref": "EventBus",
+        },
+        "EventPattern": {
+          "detail-type": [
+            "recipe-update",
+          ],
+          "source": [
+            "recipe-responder",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:",
+                  {
+                    "Ref": "AWS::Partition",
+                  },
+                  ":ecs:",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  ":",
+                  {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ":cluster/",
+                  {
+                    "Ref": "ClusterArn",
+                  },
+                ],
+              ],
+            },
+            "EcsParameters": {
+              "LaunchType": "FARGATE",
+              "NetworkConfiguration": {
+                "AwsVpcConfiguration": {
+                  "AssignPublicIp": "DISABLED",
+                  "SecurityGroups": [
+                    {
+                      "Fn::GetAtt": [
+                        "PrintableRecipesPrintableRecipeGenTDSecurityGroup2E72B084",
+                        "GroupId",
+                      ],
+                    },
+                  ],
+                  "Subnets": {
+                    "Ref": "VpcPrivateParam",
+                  },
+                },
+              },
+              "TaskCount": 1,
+              "TaskDefinitionArn": {
+                "Ref": "PrintableRecipesPrintableRecipeGenTD7D170872",
+              },
+            },
+            "Id": "Target0",
+            "InputTransformer": {
+              "InputPathsMap": {
+                "detail-blob": "$.detail.blob",
+                "detail-uid": "$.detail.uid",
+              },
+              "InputTemplate": "{"containerOverrides":[{"name":"main","environment":[{"name":"RECIPE_ID","value":<detail-uid>},{"name":"CONTENT","value":<detail-blob>}]}]}",
+            },
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "PrintableRecipesIAMRole8B7C763A",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
     },
     "PublishTodaysCuration6EFD9033": {
       "DependsOn": [

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1548,7 +1548,6 @@ def sort_filter_rules(json_obj):
             "PolicyName": "s3write",
           },
         ],
-        "RoleName": "printable-recipe-generator-TEST",
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1523,7 +1523,7 @@ def sort_filter_rules(json_obj):
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": {
-                "Service": "events.amazonaws.com",
+                "Service": "ecs-tasks.amazonaws.com",
               },
             },
           ],
@@ -1548,6 +1548,7 @@ def sort_filter_rules(json_obj):
             "PolicyName": "s3write",
           },
         ],
+        "RoleName": "printable-recipe-generator-TEST",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -1569,7 +1570,147 @@ def sort_filter_rules(json_obj):
       },
       "Type": "AWS::IAM::Role",
     },
-    "PrintableRecipesIAMRoleDefaultPolicyEA27E680": {
+    "PrintableRecipesPrintableRecipeGenTD7D170872": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Essential": true,
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ".dkr.ecr.",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  ".",
+                  {
+                    "Ref": "AWS::URLSuffix",
+                  },
+                  "/",
+                  {
+                    "Ref": "RepoName",
+                  },
+                  ":latest",
+                ],
+              ],
+            },
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "PrintableRecipesPrintableRecipeGenTDmainLogGroupF0790787",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "printable-recipe-generator-",
+              },
+            },
+            "Memory": 2048,
+            "MountPoints": [
+              {
+                "ContainerPath": "/home/pdfrender",
+                "ReadOnly": false,
+                "SourceVolume": "tmp-volume",
+              },
+            ],
+            "Name": "main",
+            "ReadonlyRootFilesystem": true,
+            "WorkingDirectory": "/home/pdfrender",
+          },
+        ],
+        "Cpu": "1024",
+        "EphemeralStorage": {
+          "SizeInGiB": 25,
+        },
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "PrintableRecipesPrintableRecipeGenTDExecutionRoleD7C4D437",
+            "Arn",
+          ],
+        },
+        "Family": "RecipesBackendPrintableRecipesPrintableRecipeGenTDDB494472",
+        "Memory": "8192",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "RuntimePlatform": {
+          "CpuArchitecture": "X86_64",
+          "OperatingSystemFamily": "LINUX",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "PrintableRecipesIAMRole8B7C763A",
+            "Arn",
+          ],
+        },
+        "Volumes": [
+          {
+            "Name": "tmp-volume",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "PrintableRecipesPrintableRecipeGenTDEventsRole01897D42": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "PrintableRecipesPrintableRecipeGenTDEventsRoleDefaultPolicyEE510C6A": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -1646,7 +1787,7 @@ def sort_filter_rules(json_obj):
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "PrintableRecipesPrintableRecipeGenTDTaskRoleA90C8F20",
+                  "PrintableRecipesIAMRole8B7C763A",
                   "Arn",
                 ],
               },
@@ -1654,119 +1795,14 @@ def sort_filter_rules(json_obj):
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "PrintableRecipesIAMRoleDefaultPolicyEA27E680",
+        "PolicyName": "PrintableRecipesPrintableRecipeGenTDEventsRoleDefaultPolicyEE510C6A",
         "Roles": [
           {
-            "Ref": "PrintableRecipesIAMRole8B7C763A",
+            "Ref": "PrintableRecipesPrintableRecipeGenTDEventsRole01897D42",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "PrintableRecipesPrintableRecipeGenTD7D170872": {
-      "Properties": {
-        "ContainerDefinitions": [
-          {
-            "Essential": true,
-            "Image": {
-              "Fn::Join": [
-                "",
-                [
-                  {
-                    "Ref": "AWS::AccountId",
-                  },
-                  ".dkr.ecr.",
-                  {
-                    "Ref": "AWS::Region",
-                  },
-                  ".",
-                  {
-                    "Ref": "AWS::URLSuffix",
-                  },
-                  "/",
-                  {
-                    "Ref": "RepoName",
-                  },
-                  ":latest",
-                ],
-              ],
-            },
-            "LogConfiguration": {
-              "LogDriver": "awslogs",
-              "Options": {
-                "awslogs-group": {
-                  "Ref": "PrintableRecipesPrintableRecipeGenTDmainLogGroupF0790787",
-                },
-                "awslogs-region": {
-                  "Ref": "AWS::Region",
-                },
-                "awslogs-stream-prefix": "printable-recipe-generator-",
-              },
-            },
-            "Memory": 2048,
-            "MountPoints": [
-              {
-                "ContainerPath": "/tmp",
-                "ReadOnly": false,
-                "SourceVolume": "tmp-volume",
-              },
-            ],
-            "Name": "main",
-            "ReadonlyRootFilesystem": true,
-            "WorkingDirectory": "/tmp",
-          },
-        ],
-        "Cpu": "1024",
-        "EphemeralStorage": {
-          "SizeInGiB": 25,
-        },
-        "ExecutionRoleArn": {
-          "Fn::GetAtt": [
-            "PrintableRecipesPrintableRecipeGenTDExecutionRoleD7C4D437",
-            "Arn",
-          ],
-        },
-        "Family": "RecipesBackendPrintableRecipesPrintableRecipeGenTDDB494472",
-        "Memory": "8192",
-        "NetworkMode": "awsvpc",
-        "RequiresCompatibilities": [
-          "FARGATE",
-        ],
-        "RuntimePlatform": {
-          "CpuArchitecture": "X86_64",
-          "OperatingSystemFamily": "LINUX",
-        },
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/recipes-backend",
-          },
-          {
-            "Key": "Stack",
-            "Value": "feast",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "TaskRoleArn": {
-          "Fn::GetAtt": [
-            "PrintableRecipesPrintableRecipeGenTDTaskRoleA90C8F20",
-            "Arn",
-          ],
-        },
-        "Volumes": [
-          {
-            "Name": "tmp-volume",
-          },
-        ],
-      },
-      "Type": "AWS::ECS::TaskDefinition",
     },
     "PrintableRecipesPrintableRecipeGenTDExecutionRoleD7C4D437": {
       "Properties": {
@@ -1902,41 +1938,6 @@ def sort_filter_rules(json_obj):
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "PrintableRecipesPrintableRecipeGenTDTaskRoleA90C8F20": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "ecs-tasks.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/recipes-backend",
-          },
-          {
-            "Key": "Stack",
-            "Value": "feast",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
     "PrintableRecipesPrintableRecipeGenTDmainLogGroupF0790787": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -2035,7 +2036,7 @@ def sort_filter_rules(json_obj):
             },
             "RoleArn": {
               "Fn::GetAtt": [
-                "PrintableRecipesIAMRole8B7C763A",
+                "PrintableRecipesPrintableRecipeGenTDEventsRole01897D42",
                 "Arn",
               ],
             },

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -22,6 +22,7 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuScheduledLambda",
+      "GuScheduledLambda",
       "GuLambdaFunction",
       "GuParameter",
       "GuParameter",
@@ -2048,6 +2049,308 @@ def sort_filter_rules(json_obj):
         ],
       },
       "Type": "AWS::Events::Rule",
+    },
+    "PublishContributors7FDDEA0E": {
+      "DependsOn": [
+        "PublishContributorsServiceRoleDefaultPolicyEEA7218F",
+        "PublishContributorsServiceRole5EFC8614",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "feast/TEST/recipes-publish-contributor-information/profile-cache-rebuild.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "recipes-publish-contributor-information",
+            "CAPI_BASE_URL": "content.guardianapis.com",
+            "CAPI_KEY": {
+              "Ref": "capiKey",
+            },
+            "CONTENT_URL_BASE": "recipes.guardianapis.com",
+            "FASTLY_API_KEY": {
+              "Ref": "fastlyKey",
+            },
+            "STACK": "feast",
+            "STAGE": "TEST",
+            "STATIC_BUCKET": {
+              "Ref": "staticstaticServing53194089",
+            },
+          },
+        },
+        "FunctionName": "PublishRecipeContributors-TEST",
+        "Handler": "main.handler",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 256,
+        "Role": {
+          "Fn::GetAtt": [
+            "PublishContributorsServiceRole5EFC8614",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "recipes-publish-contributor-information",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "PublishContributorsPublishContributorscron16089AD5627": {
+      "Properties": {
+        "Description": "Update cache of contributor information for Feast at 16 minutes past every hour",
+        "ScheduleExpression": "cron(16 * * * ? *)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "PublishContributors7FDDEA0E",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "PublishContributorsPublishContributorscron160AllowEventRuleRecipesBackendPublishContributorsE21492564767307C": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "PublishContributors7FDDEA0E",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "PublishContributorsPublishContributorscron16089AD5627",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "PublishContributorsServiceRole5EFC8614": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "recipes-publish-contributor-information",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "PublishContributorsServiceRoleDefaultPolicyEEA7218F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "*",
+              "Effect": "Deny",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "staticstaticServing53194089",
+                        "Arn",
+                      ],
+                    },
+                    "/content/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "staticstaticServing53194089",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/feast/TEST/recipes-publish-contributor-information/profile-cache-rebuild.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/feast/recipes-publish-contributor-information",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/feast/recipes-publish-contributor-information/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PublishContributorsServiceRoleDefaultPolicyEEA7218F",
+        "Roles": [
+          {
+            "Ref": "PublishContributorsServiceRole5EFC8614",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "PublishTodaysCuration6EFD9033": {
       "DependsOn": [

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1523,7 +1523,7 @@ def sort_filter_rules(json_obj):
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": {
-                "Service": "events.amazonaws.com ",
+                "Service": "events.amazonaws.com",
               },
             },
           ],

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1534,11 +1534,7 @@ def sort_filter_rules(json_obj):
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": [
-                    "s3:GetObject",
-                    "s3:ListBucket",
-                    "s3:PutObject",
-                  ],
+                  "Action": "s3:PutObject",
                   "Effect": "Allow",
                   "Resource": "arn:aws:s3:::feast-recipes-static-test/content/*",
                 },
@@ -1639,7 +1635,7 @@ def sort_filter_rules(json_obj):
           ],
         },
         "Family": "RecipesBackendPrintableRecipesPrintableRecipeGenTDDB494472",
-        "Memory": "8192",
+        "Memory": "2048",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1540,7 +1540,7 @@ def sort_filter_rules(json_obj):
                     "s3:PutObject",
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:s3:::feast-recipes-static-test/content/",
+                  "Resource": "arn:aws:s3:::feast-recipes-static-test/content/*",
                 },
               ],
               "Version": "2012-10-17",

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -1712,7 +1712,6 @@ def sort_filter_rules(json_obj):
         "Memory": "2048",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
-          "EC2",
           "FARGATE",
         ],
         "RuntimePlatform": {

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -118,7 +118,7 @@ export class PrintableRecipeGenerator extends Construct {
 			repoNameParam.valueAsString,
 		);
 
-		const imageTag = '618'; //FIXME - hardcoded!
+		const imageTag = process.env['IMAGE_TAG'] ?? 'latest';
 
 		const container = taskDefinition.addContainer('main', {
 			image: ContainerImage.fromEcrRepository(ecrRepo, imageTag),

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -158,6 +158,10 @@ export class PrintableRecipeGenerator extends Construct {
 							name: 'CONTENT',
 							value: EventField.fromPath('$.detail.blob'),
 						},
+						{
+							name: 'BUCKET',
+							value: `feast-recipes-static-${scope.stage.toLowerCase()}`,
+						},
 					],
 				},
 			],

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -15,7 +15,13 @@ import {
 import type { IEventBus } from 'aws-cdk-lib/aws-events';
 import { EventField, Rule } from 'aws-cdk-lib/aws-events';
 import { EcsTask } from 'aws-cdk-lib/aws-events-targets';
-import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import {
+	Effect,
+	PolicyDocument,
+	PolicyStatement,
+	Role,
+	ServicePrincipal,
+} from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 
 interface TestConstructProps {
@@ -75,11 +81,23 @@ export class PrintableRecipeGenerator extends Construct {
 			roleName: `printable-recipe-generator-${scope.stage}`,
 			assumedBy:
 				ServicePrincipal.fromStaticServicePrincipleName('ecs.amazonaws.com'), //CHECK
-			// inlinePolicies: {
-			// 	s3write: new PolicyDocument({
-			// 		statements: [],
-			// 	}),
-			// },
+			inlinePolicies: {
+				s3write: new PolicyDocument({
+					statements: [
+						new PolicyStatement({
+							effect: Effect.ALLOW,
+							actions: [
+								's3:GetObject',
+								's3:ListBucket',
+								's3:PutObject',
+							] /*Check for listBucket?*/,
+							resources: [
+								`arn:aws:s3:::feast-recipes-static-${scope.stage.toLowerCase()}/content/`,
+							],
+						}),
+					],
+				}),
+			},
 		});
 
 		const taskDefinition = new TaskDefinition(this, 'PrintableRecipeGenTD', {

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -85,7 +85,7 @@ export class PrintableRecipeGenerator extends Construct {
 		const taskDefinition = new TaskDefinition(this, 'PrintableRecipeGenTD', {
 			compatibility: Compatibility.FARGATE,
 			cpu: '1024', //1 vcpu
-			ephemeralStorageGiB: 20, //minimum 20Gb ephemeral storage
+			ephemeralStorageGiB: 25, //minimum 21Gb ephemeral storage
 			memoryMiB: '2048', //2 Gb RAM, minimum value for 1vcpu
 			runtimePlatform: {
 				cpuArchitecture: CpuArchitecture.X86_64, //Chrome headless does not appear to have an ARM64 package at present :-/

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -110,7 +110,7 @@ export class PrintableRecipeGenerator extends Construct {
 				cpuArchitecture: CpuArchitecture.X86_64, //Chrome headless does not appear to have an ARM64 package at present :-/
 				operatingSystemFamily: OperatingSystemFamily.LINUX,
 			},
-			volumes: [{ name: 'tmp-volume' }],
+			volumes: [{ name: 'tmp-volume' }, { name: 'home-volume' }],
 			taskRole: role,
 		});
 
@@ -134,6 +134,12 @@ export class PrintableRecipeGenerator extends Construct {
 
 		container.addMountPoints({
 			sourceVolume: 'tmp-volume',
+			containerPath: '/tmp',
+			readOnly: false,
+		});
+
+		container.addMountPoints({
+			sourceVolume: 'home-volume',
 			containerPath: '/home/pdfrender',
 			readOnly: false,
 		});

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -170,7 +170,7 @@ export class PrintableRecipeGenerator extends Construct {
 		});
 
 		new Rule(this, 'PublicationConnect', {
-			enabled: true,
+			enabled: scope.stage !== 'PROD', //only enabled in the CODE environment until design work fully implemented, but available for testing in PROD
 			eventBus,
 			targets: [ruleTarget],
 			eventPattern: {

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -87,11 +87,7 @@ export class PrintableRecipeGenerator extends Construct {
 					statements: [
 						new PolicyStatement({
 							effect: Effect.ALLOW,
-							actions: [
-								's3:GetObject',
-								's3:ListBucket',
-								's3:PutObject',
-							] /*Check for listBucket?*/,
+							actions: ['s3:PutObject'],
 							resources: [
 								`arn:aws:s3:::feast-recipes-static-${scope.stage.toLowerCase()}/content/*`,
 							],
@@ -105,7 +101,7 @@ export class PrintableRecipeGenerator extends Construct {
 			compatibility: Compatibility.FARGATE,
 			cpu: '1024', //1 vcpu
 			ephemeralStorageGiB: 25, //minimum 21Gb ephemeral storage
-			memoryMiB: '8192', //8 Gb RAM, max value for 1vcpu
+			memoryMiB: '2048', //2 Gb RAM, minimum value for 1vcpu
 			runtimePlatform: {
 				cpuArchitecture: CpuArchitecture.X86_64, //Chrome headless does not appear to have an ARM64 package at present :-/
 				operatingSystemFamily: OperatingSystemFamily.LINUX,

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -127,8 +127,12 @@ export class PrintableRecipeGenerator extends Construct {
 					containerName: 'main',
 					environment: [
 						{
-							name: 'RECIPE_ID',
+							name: 'RECIPE_UID',
 							value: EventField.fromPath('$.detail.uid'),
+						},
+						{
+							name: 'RECIPE_CSID',
+							value: EventField.fromPath('$.detail.checksum'),
 						},
 						{
 							name: 'CONTENT',

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -79,8 +79,9 @@ export class PrintableRecipeGenerator extends Construct {
 
 		const role = new Role(this, 'IAMRole', {
 			roleName: `printable-recipe-generator-${scope.stage}`,
-			assumedBy:
-				ServicePrincipal.fromStaticServicePrincipleName('ecs.amazonaws.com'), //CHECK
+			assumedBy: ServicePrincipal.fromStaticServicePrincipleName(
+				'events.amazonaws.com ',
+			),
 			inlinePolicies: {
 				s3write: new PolicyDocument({
 					statements: [

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -1,0 +1,152 @@
+import type { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuParameter } from '@guardian/cdk/lib/constructs/core';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import { Repository } from 'aws-cdk-lib/aws-ecr';
+import {
+	Cluster,
+	Compatibility,
+	ContainerImage,
+	CpuArchitecture,
+	LaunchType,
+	LogDriver,
+	OperatingSystemFamily,
+	TaskDefinition,
+} from 'aws-cdk-lib/aws-ecs';
+import type { IEventBus } from 'aws-cdk-lib/aws-events';
+import { EventField, Rule } from 'aws-cdk-lib/aws-events';
+import { EcsTask } from 'aws-cdk-lib/aws-events-targets';
+import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+
+interface TestConstructProps {
+	eventBus: IEventBus;
+}
+
+export class PrintableRecipeGenerator extends Construct {
+	constructor(scope: GuStack, id: string, { eventBus }: TestConstructProps) {
+		super(scope, id);
+
+		const vpcid = new GuParameter(scope, 'VpcIdParam', {
+			fromSSM: true,
+			default: `/account/vpc/primary/id`,
+		});
+
+		const publicSubnetIds = new GuParameter(scope, 'VpcPublicParam', {
+			fromSSM: true,
+			default: '/account/vpc/primary/subnets/public',
+			type: 'List<String>',
+		});
+
+		const privateSubnetIds = new GuParameter(scope, 'VpcPrivateParam', {
+			fromSSM: true,
+			default: '/account/vpc/primary/subnets/private',
+			type: 'List<String>',
+		});
+
+		const availabilityZones = new GuParameter(scope, 'VpcAZParam', {
+			fromSSM: true,
+			default: '/account/vpc/primary/availability-zones',
+			type: 'List<String>',
+		});
+
+		const vpc = Vpc.fromVpcAttributes(this, 'VPC', {
+			vpcId: vpcid.valueAsString,
+			publicSubnetIds: publicSubnetIds.valueAsList,
+			privateSubnetIds: privateSubnetIds.valueAsList,
+			availabilityZones: availabilityZones.valueAsList,
+		});
+
+		const clusterArnParam = new GuParameter(scope, 'ClusterArn', {
+			fromSSM: true,
+		});
+
+		const repoNameParam = new GuParameter(scope, 'RepoName', {
+			fromSSM: true,
+			default: `/${scope.stage}/feast/recipes-backend/ecr-repo-printables`,
+		});
+
+		const cluster = Cluster.fromClusterAttributes(this, 'ECSCluster', {
+			clusterName: clusterArnParam.valueAsString,
+			vpc,
+		});
+
+		const role = new Role(this, 'IAMRole', {
+			roleName: `printable-recipe-generator-${scope.stage}`,
+			assumedBy:
+				ServicePrincipal.fromStaticServicePrincipleName('ecs.amazonaws.com'), //CHECK
+			// inlinePolicies: {
+			// 	s3write: new PolicyDocument({
+			// 		statements: [],
+			// 	}),
+			// },
+		});
+
+		const taskDefinition = new TaskDefinition(this, 'PrintableRecipeGenTD', {
+			compatibility: Compatibility.EC2_AND_FARGATE,
+			cpu: '1024', //1 vcpu
+			ephemeralStorageGiB: 20, //minimum 20Gb ephemeral storage
+			memoryMiB: '2048', //2 Gb RAM, minimum value for 1vcpu
+			runtimePlatform: {
+				cpuArchitecture: CpuArchitecture.X86_64, //Chrome headless does not appear to have an ARM64 package at present :-/
+				operatingSystemFamily: OperatingSystemFamily.LINUX,
+			},
+			volumes: [{ name: 'tmp-volume' }],
+		});
+
+		const ecrRepo = Repository.fromRepositoryName(
+			this,
+			'ECRRepo',
+			repoNameParam.valueAsString,
+		);
+
+		const imageTag = '618'; //FIXME - hardcoded!
+
+		const container = taskDefinition.addContainer('main', {
+			image: ContainerImage.fromEcrRepository(ecrRepo, imageTag),
+			memoryLimitMiB: 2048,
+			readonlyRootFilesystem: true,
+			logging: LogDriver.awsLogs({
+				streamPrefix: 'printable-recipe-generator-',
+			}),
+			workingDirectory: '/tmp',
+		});
+
+		container.addMountPoints({
+			sourceVolume: 'tmp-volume',
+			containerPath: '/tmp',
+			readOnly: false,
+		});
+
+		const ruleTarget = new EcsTask({
+			taskDefinition,
+			cluster,
+			role,
+			launchType: LaunchType.FARGATE,
+			containerOverrides: [
+				{
+					containerName: 'main',
+					environment: [
+						{
+							name: 'RECIPE_ID',
+							value: EventField.fromPath('$.detail.uid'),
+						},
+						{
+							name: 'CONTENT',
+							value: EventField.fromPath('$.detail.blob'),
+						},
+					],
+				},
+			],
+		});
+
+		new Rule(this, 'PublicationConnect', {
+			enabled: true,
+			eventBus,
+			targets: [ruleTarget],
+			eventPattern: {
+				source: ['recipe-responder'],
+				detailType: ['recipe-update'],
+			},
+		});
+	}
+}

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -93,7 +93,7 @@ export class PrintableRecipeGenerator extends Construct {
 								's3:PutObject',
 							] /*Check for listBucket?*/,
 							resources: [
-								`arn:aws:s3:::feast-recipes-static-${scope.stage.toLowerCase()}/content/`,
+								`arn:aws:s3:::feast-recipes-static-${scope.stage.toLowerCase()}/content/*`,
 							],
 						}),
 					],

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -105,7 +105,7 @@ export class PrintableRecipeGenerator extends Construct {
 			compatibility: Compatibility.FARGATE,
 			cpu: '1024', //1 vcpu
 			ephemeralStorageGiB: 25, //minimum 21Gb ephemeral storage
-			memoryMiB: '2048', //2 Gb RAM, minimum value for 1vcpu
+			memoryMiB: '8192', //8 Gb RAM, max value for 1vcpu
 			runtimePlatform: {
 				cpuArchitecture: CpuArchitecture.X86_64, //Chrome headless does not appear to have an ARM64 package at present :-/
 				operatingSystemFamily: OperatingSystemFamily.LINUX,

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -58,6 +58,7 @@ export class PrintableRecipeGenerator extends Construct {
 
 		const clusterArnParam = new GuParameter(scope, 'ClusterArn', {
 			fromSSM: true,
+			default: '/account/services/ecs-cluster',
 		});
 
 		const repoNameParam = new GuParameter(scope, 'RepoName', {

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -78,7 +78,7 @@ export class PrintableRecipeGenerator extends Construct {
 		});
 
 		const role = new Role(this, 'IAMRole', {
-			roleName: `printable-recipe-generator-${scope.stage}`,
+			// roleName: `printable-recipe-generator-${scope.stage}`,
 			assumedBy: ServicePrincipal.fromStaticServicePrincipleName(
 				'events.amazonaws.com ',
 			),

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -58,7 +58,7 @@ export class PrintableRecipeGenerator extends Construct {
 
 		const clusterArnParam = new GuParameter(scope, 'ClusterArn', {
 			fromSSM: true,
-			default: '/account/services/ecs-cluster',
+			default: '/account/services/ecs-cluster-name',
 		});
 
 		const repoNameParam = new GuParameter(scope, 'RepoName', {

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -83,7 +83,7 @@ export class PrintableRecipeGenerator extends Construct {
 		});
 
 		const taskDefinition = new TaskDefinition(this, 'PrintableRecipeGenTD', {
-			compatibility: Compatibility.EC2_AND_FARGATE,
+			compatibility: Compatibility.FARGATE,
 			cpu: '1024', //1 vcpu
 			ephemeralStorageGiB: 20, //minimum 20Gb ephemeral storage
 			memoryMiB: '2048', //2 Gb RAM, minimum value for 1vcpu

--- a/cdk/lib/printable-recipe-generator.ts
+++ b/cdk/lib/printable-recipe-generator.ts
@@ -80,7 +80,7 @@ export class PrintableRecipeGenerator extends Construct {
 		const role = new Role(this, 'IAMRole', {
 			// roleName: `printable-recipe-generator-${scope.stage}`,
 			assumedBy: ServicePrincipal.fromStaticServicePrincipleName(
-				'events.amazonaws.com ',
+				'events.amazonaws.com',
 			),
 			inlinePolicies: {
 				s3write: new PolicyDocument({

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -19,6 +19,7 @@ import { DataStore } from './datastore';
 import { DynamicFronts } from './dynamic-fronts';
 import { ExternalParameters } from './external_parameters';
 import { FaciaConnection } from './facia-connection';
+import { PrintableRecipeGenerator } from './printable-recipe-generator';
 import { RecipesReindex } from './recipes-reindex';
 import { RestEndpoints } from './rest-endpoints';
 import { StaticServing } from './static-serving';
@@ -383,5 +384,7 @@ export class RecipesBackend extends GuStack {
 		new DynamicFronts(this, 'DynamicFronts', {
 			destBucket: serving.staticBucket,
 		});
+
+		new PrintableRecipeGenerator(this, 'PrintableRecipes', { eventBus });
 	}
 }

--- a/printable-recipe-generator/docker/Dockerfile
+++ b/printable-recipe-generator/docker/Dockerfile
@@ -1,6 +1,9 @@
 FROM --platform=linux/amd64 node:22-slim
 
 RUN adduser pdfrender
+RUN mkdir -p /tmp && chmod 777 /tmp
+#RUN ln -s /tmp /home/pdfrender/.local && ln -s /tmp /home/pdfrender/.config
+VOLUME /tmp
 VOLUME /home/pdfrender
 RUN apt-get update && apt-get -y install wget gnupg awscli
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -

--- a/printable-recipe-generator/docker/Dockerfile
+++ b/printable-recipe-generator/docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM --platform=linux/amd64 node:22-slim
 
 RUN adduser pdfrender
+RUN mkdir -p /tmp && chmod 777 /tmp
+VOLUME /tmp
 RUN apt-get update && apt-get -y install wget gnupg
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN sh -c 'echo "deb https://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'

--- a/printable-recipe-generator/docker/Dockerfile
+++ b/printable-recipe-generator/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=linux/amd64 node:22-slim
 
 RUN adduser pdfrender
 RUN mkdir -p /tmp && chmod 777 /tmp
-RUN ln -s /tmp /home/pdfrender/.local
+RUN ln -s /tmp /home/pdfrender/.local && ln -s /tmp /home/pdfrender/.config
 VOLUME /tmp
 RUN apt-get update && apt-get -y install wget gnupg awscli
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -

--- a/printable-recipe-generator/docker/Dockerfile
+++ b/printable-recipe-generator/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM --platform=linux/amd64 node:22-slim
 
 RUN adduser pdfrender
 RUN mkdir -p /tmp && chmod 777 /tmp
+RUN ln -s /tmp /home/pdfrender/.local
 VOLUME /tmp
 RUN apt-get update && apt-get -y install wget gnupg awscli
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -

--- a/printable-recipe-generator/docker/Dockerfile
+++ b/printable-recipe-generator/docker/Dockerfile
@@ -1,9 +1,7 @@
 FROM --platform=linux/amd64 node:22-slim
 
 RUN adduser pdfrender
-RUN mkdir -p /tmp && chmod 777 /tmp
-RUN ln -s /tmp /home/pdfrender/.local && ln -s /tmp /home/pdfrender/.config
-VOLUME /tmp
+VOLUME /home/pdfrender
 RUN apt-get update && apt-get -y install wget gnupg awscli
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN sh -c 'echo "deb https://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'

--- a/printable-recipe-generator/docker/Dockerfile
+++ b/printable-recipe-generator/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 node:22-slim
 RUN adduser pdfrender
 RUN mkdir -p /tmp && chmod 777 /tmp
 VOLUME /tmp
-RUN apt-get update && apt-get -y install wget gnupg
+RUN apt-get update && apt-get -y install wget gnupg awscli
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN sh -c 'echo "deb https://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 RUN apt-get update && apt-get -y install google-chrome-stable

--- a/printable-recipe-generator/docker/Dockerfile
+++ b/printable-recipe-generator/docker/Dockerfile
@@ -2,7 +2,6 @@ FROM --platform=linux/amd64 node:22-slim
 
 RUN adduser pdfrender
 RUN mkdir -p /tmp && chmod 777 /tmp
-#RUN ln -s /tmp /home/pdfrender/.local && ln -s /tmp /home/pdfrender/.config
 VOLUME /tmp
 VOLUME /home/pdfrender
 RUN apt-get update && apt-get -y install wget gnupg awscli

--- a/printable-recipe-generator/docker/docker-entrypoint.sh
+++ b/printable-recipe-generator/docker/docker-entrypoint.sh
@@ -1,3 +1,21 @@
 #!/usr/bin/env bash
 
-node /printable-recipe-generator/main.js "$1"
+#node /printable-recipe-generator/main.js "$1"
+
+#log the recipe UUID and checksum ID
+echo "RECIPE UUID is $RECIPE_UID"
+echo "CHECKSUM ID is $RECIPE_CSID"
+echo "CONTENT is $CONTENT"
+
+#Put json content into file
+echo "Write content into a file.."
+RECIPE_CONTENT_PATH="/tmp/recipe.json"
+echo "$CONTENT" > "$RECIPE_CONTENT_PATH"
+echo "Recipe json is saved in the path $RECIPE_CONTENT_PATH"
+
+#Run the renderer on that file
+echo "Render the json to html.."
+RECIPE_HTML_OUTPUT="/tmp/recipe.html"
+node /printable-recipe-generator/main.js "$RECIPE_CONTENT_PATH" "$RECIPE_HTML_OUTPUT"
+echo "Recipe html is rendered at $RECIPE_HTML_OUTPUT"
+

--- a/printable-recipe-generator/docker/docker-entrypoint.sh
+++ b/printable-recipe-generator/docker/docker-entrypoint.sh
@@ -7,13 +7,6 @@ echo "RECIPE UUID is $RECIPE_UID"
 echo "CHECKSUM ID is $RECIPE_CSID"
 echo "CONTENT is $CONTENT"
 
-id
-ls -lhd /tmp
-ls -lh /tmp
-mount
-ulimit -a
-
-ls -alh /home/pdfrender
 
 #Put json content into file
 echo "Write content into a file.."
@@ -30,7 +23,7 @@ echo "Recipe html is rendered at $RECIPE_HTML_OUTPUT"
 #Convert htmlfile to PDF file
 echo "Take html and convert it to PDF using headless chrome"
 RECIPE_PDF_OUTPUT='./recipe.pdf'
-google-chrome-stable --headless --disable-gpu --no-sandbox --disable-plugins --enable-logging --v=1 --print-to-pdf="$RECIPE_PDF_OUTPUT" "$RECIPE_HTML_OUTPUT"
+google-chrome-stable --headless --disable-gpu --no-sandbox --no-pdf-header-footer --print-to-pdf="$RECIPE_PDF_OUTPUT" "$RECIPE_HTML_OUTPUT"
 echo "Recipe PDF is generated at $RECIPE_PDF_OUTPUT"
 
 #Copy PDF file to S3

--- a/printable-recipe-generator/docker/docker-entrypoint.sh
+++ b/printable-recipe-generator/docker/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 
 #node /printable-recipe-generator/main.js "$1"
 

--- a/printable-recipe-generator/docker/docker-entrypoint.sh
+++ b/printable-recipe-generator/docker/docker-entrypoint.sh
@@ -13,6 +13,8 @@ ls -lh /tmp
 mount
 ulimit -a
 
+ls -alh /home/pdfrender
+
 #Put json content into file
 echo "Write content into a file.."
 RECIPE_CONTENT_PATH="/tmp/recipe.json"

--- a/printable-recipe-generator/docker/docker-entrypoint.sh
+++ b/printable-recipe-generator/docker/docker-entrypoint.sh
@@ -17,19 +17,19 @@ ls -alh /home/pdfrender
 
 #Put json content into file
 echo "Write content into a file.."
-RECIPE_CONTENT_PATH="/tmp/recipe.json"
+RECIPE_CONTENT_PATH="./recipe.json"
 echo "$CONTENT" > "$RECIPE_CONTENT_PATH"
 echo "Recipe json is saved in the path $RECIPE_CONTENT_PATH"
 
 #Run the renderer on that file
 echo "Render the json to html.."
-RECIPE_HTML_OUTPUT="/tmp/recipe.html"
+RECIPE_HTML_OUTPUT="./recipe.html"
 node /printable-recipe-generator/main.js "$RECIPE_CONTENT_PATH" "$RECIPE_HTML_OUTPUT"
 echo "Recipe html is rendered at $RECIPE_HTML_OUTPUT"
 
 #Convert htmlfile to PDF file
 echo "Take html and convert it to PDF using headless chrome"
-RECIPE_PDF_OUTPUT='/tmp/recipe.pdf'
+RECIPE_PDF_OUTPUT='./recipe.pdf'
 google-chrome-stable --headless --disable-gpu --no-sandbox --disable-plugins --enable-logging --v=1 --print-to-pdf="$RECIPE_PDF_OUTPUT" "$RECIPE_HTML_OUTPUT"
 echo "Recipe PDF is generated at $RECIPE_PDF_OUTPUT"
 

--- a/printable-recipe-generator/docker/docker-entrypoint.sh
+++ b/printable-recipe-generator/docker/docker-entrypoint.sh
@@ -7,6 +7,11 @@ echo "RECIPE UUID is $RECIPE_UID"
 echo "CHECKSUM ID is $RECIPE_CSID"
 echo "CONTENT is $CONTENT"
 
+id
+ls -lhd /tmp
+ls -lh /tmp
+mount
+
 #Put json content into file
 echo "Write content into a file.."
 RECIPE_CONTENT_PATH="/tmp/recipe.json"

--- a/printable-recipe-generator/docker/docker-entrypoint.sh
+++ b/printable-recipe-generator/docker/docker-entrypoint.sh
@@ -24,3 +24,15 @@ RECIPE_HTML_OUTPUT="/tmp/recipe.html"
 node /printable-recipe-generator/main.js "$RECIPE_CONTENT_PATH" "$RECIPE_HTML_OUTPUT"
 echo "Recipe html is rendered at $RECIPE_HTML_OUTPUT"
 
+#Convert htmlfile to PDF file
+echo "Take html and convert it to PDF using headless chrome"
+RECIPE_PDF_OUTPUT='/tmp/recipe.pdf'
+google-chrome-stable --headless --disable-gpu --print-to-pdf="$RECIPE_PDF_OUTPUT" "$RECIPE_HTML_OUTPUT"
+echo "Recipe PDF is generated at $RECIPE_PDF_OUTPUT"
+
+#Copy PDF file to S3
+echo "Copy recipe.pdf file to S3 now"
+RECIPE_PDF_S3_OUTPUT="s3://${BUCKET}/content/${RECIPE_CSID}.pdf"
+aws s3 cp "$RECIPE_PDF_OUTPUT" "$RECIPE_PDF_S3_OUTPUT"
+echo "Recipe PDF is uploaded to S3 bucket at $RECIPE_PDF_S3_OUTPUT"
+

--- a/printable-recipe-generator/docker/docker-entrypoint.sh
+++ b/printable-recipe-generator/docker/docker-entrypoint.sh
@@ -28,7 +28,7 @@ echo "Recipe html is rendered at $RECIPE_HTML_OUTPUT"
 #Convert htmlfile to PDF file
 echo "Take html and convert it to PDF using headless chrome"
 RECIPE_PDF_OUTPUT='/tmp/recipe.pdf'
-google-chrome-stable --headless --disable-gpu --no-sandbox --disable-plugins, --enable-logging and --v=1 --print-to-pdf="$RECIPE_PDF_OUTPUT" "$RECIPE_HTML_OUTPUT"
+google-chrome-stable --headless --disable-gpu --no-sandbox --disable-plugins --enable-logging --v=1 --print-to-pdf="$RECIPE_PDF_OUTPUT" "$RECIPE_HTML_OUTPUT"
 echo "Recipe PDF is generated at $RECIPE_PDF_OUTPUT"
 
 #Copy PDF file to S3

--- a/printable-recipe-generator/docker/docker-entrypoint.sh
+++ b/printable-recipe-generator/docker/docker-entrypoint.sh
@@ -11,6 +11,7 @@ id
 ls -lhd /tmp
 ls -lh /tmp
 mount
+ulimit -a
 
 #Put json content into file
 echo "Write content into a file.."
@@ -27,7 +28,7 @@ echo "Recipe html is rendered at $RECIPE_HTML_OUTPUT"
 #Convert htmlfile to PDF file
 echo "Take html and convert it to PDF using headless chrome"
 RECIPE_PDF_OUTPUT='/tmp/recipe.pdf'
-google-chrome-stable --headless --disable-gpu --print-to-pdf="$RECIPE_PDF_OUTPUT" "$RECIPE_HTML_OUTPUT"
+google-chrome-stable --headless --disable-gpu --no-sandbox --disable-plugins, --enable-logging and --v=1 --print-to-pdf="$RECIPE_PDF_OUTPUT" "$RECIPE_HTML_OUTPUT"
 echo "Recipe PDF is generated at $RECIPE_PDF_OUTPUT"
 
 #Copy PDF file to S3

--- a/printable-recipe-generator/docker/docker-entrypoint.sh
+++ b/printable-recipe-generator/docker/docker-entrypoint.sh
@@ -29,6 +29,6 @@ echo "Recipe PDF is generated at $RECIPE_PDF_OUTPUT"
 #Copy PDF file to S3
 echo "Copy recipe.pdf file to S3 now"
 RECIPE_PDF_S3_OUTPUT="s3://${BUCKET}/content/${RECIPE_CSID}.pdf"
-aws s3 cp "$RECIPE_PDF_OUTPUT" "$RECIPE_PDF_S3_OUTPUT"
+aws s3 cp "$RECIPE_PDF_OUTPUT" "$RECIPE_PDF_S3_OUTPUT" --cache-control "max-age=7200, stale-while-revalidate=300, stale-if-error=14400"
 echo "Recipe PDF is uploaded to S3 bucket at $RECIPE_PDF_S3_OUTPUT"
 

--- a/printable-recipe-generator/src/main.ts
+++ b/printable-recipe-generator/src/main.ts
@@ -25,7 +25,8 @@ function renderJsonToHtml(recipeDataPath: string) {
 	}
 
 	//Output
-	const outputPath = path.join(__dirname, 'output', 'recipe.html');
+	const outputPath =
+		process.argv[3] ?? path.join(__dirname, 'output', 'recipe.html');
 	fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 	fs.writeFileSync(outputPath, renderHtml);
 


### PR DESCRIPTION
## What does this change?

Deploys infrastructure to run the printable-recipes-generator container in ECS and to trigger it in response to EventBridge.
Given that we have prepared the prototype of html renderer in PR #105 we are ready to use it on docker container to process the number of recipes for their pdf's generation.

How process entails:
- Recipe curated to S3
- EventBridge will trigger the ECS Task with recipe data.  
- It will provide env variable details such as the recipe JSON, recipe ID, S3 bucket, etc to the Task.
- ECS Fargate will pulls the Docker image we have created and runs it in a secure VPC in the container without managing 
   EC2 instances. Inside this container:
    *  reads recipe json,
    *  save into a file,
    *  recipe.ejs will render it to HTML
    *  Node script renders the recipe to HTML → PDF
        * And the pdf is uploaded to S3




<img width="889" alt="image" src="https://github.com/user-attachments/assets/1aa6bda0-bcf0-430d-82b8-9626d6753934" />


## How to test

- Deploy the branch to CODE
- Publish or Update any recipe in CODE Composer
- Check the logs in Feast account: In log-group name, starting with "feast-CODE-recipes-backend-PrintableRecipes" 
- Check S3 bucket: FEAST -> S3 -> feast-recipes-static-code -> content
- And at the end, check by hitting at endpoint: https://recipes.code.dev-guardianapis.com/content/`YOUR-RECIPE-checksum-ID`.pdf

## How can we measure success?

- Logs should clearly describe all the steps performed while reading json to generating pdf
- S3 should show recipe-<UIID>.pdf
- Hitting at endpoint should open the pdf

