### PR TITLE
Fix for inability to preview fronts in iOS app

### DIFF
--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -107,6 +107,11 @@ router.get('/api/content/by-uid', (req, resp) => {
 		});
 });
 
+router.get('/api/:region/:variant/:date/hybrid-curation.json', (req, resp) => {
+	const newUrl = `/${req.params.region}/${req.params.variant}/${req.params.date}/curation.json`;
+	resp.status(301).setHeader('Location', newUrl).send(newUrl);
+});
+
 router.get('/api/:region/:variant/hybrid-curation.json', (req, resp) => {
 	const territoryParam =
 		(req.query['ter'] as string | undefined) ?? countryCodeFromCDN(req);

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -109,7 +109,7 @@ router.get('/api/content/by-uid', (req, resp) => {
 
 router.get('/api/:region/:variant/:date/hybrid-curation.json', (req, resp) => {
 	const newUrl = `/${req.params.region}/${req.params.variant}/${req.params.date}/curation.json`;
-	resp.status(301).setHeader('Location', newUrl).send(newUrl);
+	resp.redirect(301, newUrl);
 });
 
 router.get('/api/:region/:variant/hybrid-curation.json', (req, resp) => {


### PR DESCRIPTION
## What does this change?

When previewing the fronts in iOS, they request the curation.json from the dated folders.  However, when we switched to hybrid fronts they started using a hybridised URL /api/{region}/{variant}/{date}/hybrid-curation.json across the board.  This is unfortunate as it results in a 404 from the server.

This PR responds to that URL with a redirect to the static front as published

## How to test

- Tested in CI
- Deploy to CODE
- Publish a front for a future date in CODE
- Check that it can be accessed both through /{region}/{variant}/{date}/curation.json and  /{region}/{variant}/{date}/hybrid-curation.json

## How can we measure success?

Editorial can preview fronts in-app again

## Have we considered potential risks?

n/a
