### PR TITLE
Fix No PDF found due to unnormalized Unicode character and too large size in recipe JSON

### DIFF
--- a/printable-recipe-generator/src/main.ts
+++ b/printable-recipe-generator/src/main.ts
@@ -46,8 +46,9 @@ export async function downloadRecipeContent(
 	console.log(`Obtaining recipe data from ${path}`);
 	const response = await fetch(path); //This should follow the redirect by default
 	const content = await response.text();
+	const normalisedContent = content.normalize('NFC'); //to avoid special character/unicode issue in recipe data, where EFC fails to read and hence no PDF
 	if (response.status == 200) {
-		return JSON.parse(content) as RecipeData;
+		return JSON.parse(normalisedContent) as RecipeData;
 	} else {
 		console.error(
 			`Unable to retrieve recipe data: server responded ${response.status} ${content}`,


### PR DESCRIPTION
## What does this change?
We have encountered a recipe where PDF is not generated. 
This has two recipes in it both are failing due to the underlying issues - 

1. `"errorMessage": "Environment variable value must be normalized according to Unicode Normalization Form C”,`
Working on:
Normalise the recipe before stringify due to the facts:
- Unicode Normalization Form C (NFC) ensures that characters like é (e with acute) are stored as a single composed character, not as e + ´ (base + accent).

- AWS requires all environment variable values to be NFC normalized.

2. `"errorMessage": "Container Overrides length must be at most 8192”,`

This means the total size of all container overrides (usually environment variables or command overrides) cannot exceed 8KB.
Work in progress on this ..

## How to test

Thanks to @simonbyford  for providing me CODE composer link for that recipe to help in testing. 
The link is as follows:
https://composer.code.dev-gutools.co.uk/content/680f50868f08e65b05d20b16

deploy this branch on CODE and publish above recipe and watch logs.

## How can we measure success?
- Should resolve the Unicode error an If this fixes then we should see PDF as well.

- Work in progress for sizing error ..
