### PR TITLE
Add metric and alarm for failed dynamic container

### DIFF
--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -485,6 +485,43 @@ def sort_filter_rules(json_obj):
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
+    "DynamicFrontsFailedDynamicContainerAlarmEAC7CEFB": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "externalsnonurgentalarmarnParameter3CDDBCA7",
+          },
+        ],
+        "AlarmDescription": "Raised if any failed dynamic container metric is recorded in a hour",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "FailedDynamicContainer",
+        "Namespace": "RecipeBackend",
+        "Period": 3600,
+        "Statistic": "Average",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "ignore",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "DynamicFrontsFetcher3EADD89B": {
       "DependsOn": [
         "DynamicFrontsFetcherRoleDefaultPolicyC29B02CC",

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -605,6 +605,19 @@ def sort_filter_rules(json_obj):
             },
             "PolicyName": "S3Put",
           },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "cloudwatch:PutMetricData",
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "MetricPut",
+          },
         ],
         "RoleName": "dynamic-fronts-fetcher-TEST",
         "Tags": [

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -518,7 +518,7 @@ def sort_filter_rules(json_obj):
           },
         ],
         "Threshold": 1,
-        "TreatMissingData": "ignore",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/cdk/lib/dynamic-fronts.ts
+++ b/cdk/lib/dynamic-fronts.ts
@@ -44,6 +44,15 @@ export class DynamicFronts extends Construct {
 						}),
 					],
 				}),
+				MetricPut: new PolicyDocument({
+					statements: [
+						new PolicyStatement({
+							effect: Effect.ALLOW,
+							resources: ['*'],
+							actions: ['cloudwatch:PutMetricData'],
+						}),
+					],
+				}),
 			},
 		});
 

--- a/cdk/lib/dynamic-fronts.ts
+++ b/cdk/lib/dynamic-fronts.ts
@@ -130,7 +130,7 @@ export class DynamicFronts extends Construct {
 					ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 				alarmDescription:
 					'Raised if any failed dynamic container metric is recorded in a hour',
-				treatMissingData: TreatMissingData.IGNORE,
+				treatMissingData: TreatMissingData.NOT_BREACHING,
 			},
 		);
 

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -383,6 +383,7 @@ export class RecipesBackend extends GuStack {
 
 		new DynamicFronts(this, 'DynamicFronts', {
 			destBucket: serving.staticBucket,
+			externalParameters,
 		});
 
 		new PrintableRecipeGenerator(this, 'PrintableRecipes', { eventBus });

--- a/lambda/dynamic-fronts-fetcher/src/main.ts
+++ b/lambda/dynamic-fronts-fetcher/src/main.ts
@@ -62,7 +62,7 @@ export const handler = async (eventRaw: unknown) => {
 				event,
 			)}.`,
 		);
-		await registerMetric('FailedDynamicFronts', 0);
+		await registerMetric('FailedDynamicFronts', 1);
 		throw new Error('Invalid invoke data');
 	}
 };

--- a/lambda/dynamic-fronts-fetcher/src/main.ts
+++ b/lambda/dynamic-fronts-fetcher/src/main.ts
@@ -1,5 +1,6 @@
 import * as process from 'node:process';
 import type { Storage } from '@google-cloud/storage';
+import { registerMetric } from '@recipes-api/cwmetrics';
 import { loadConfig } from './config';
 import { getStorageClient } from './gcloud';
 import type { IncomingDataRow } from './models';
@@ -54,12 +55,14 @@ export const handler = async (eventRaw: unknown) => {
 			container,
 		);
 		console.log(`Completed`);
+		await registerMetric('SuccessfulDynamicFronts', 1);
 	} else {
 		console.error(
 			`Invalid invoke data, missing either country key or GCS path. Got ${JSON.stringify(
 				event,
 			)}.`,
 		);
+		await registerMetric('FailedDynamicFronts', 0);
 		throw new Error('Invalid invoke data');
 	}
 };

--- a/lambda/dynamic-fronts-fetcher/src/main.ts
+++ b/lambda/dynamic-fronts-fetcher/src/main.ts
@@ -55,14 +55,13 @@ export const handler = async (eventRaw: unknown) => {
 			container,
 		);
 		console.log(`Completed`);
-		await registerMetric('SuccessfulDynamicFronts', 1);
 	} else {
 		console.error(
 			`Invalid invoke data, missing either country key or GCS path. Got ${JSON.stringify(
 				event,
 			)}.`,
 		);
-		await registerMetric('FailedDynamicFronts', 1);
+		await registerMetric('FailedDynamicContainer', 1);
 		throw new Error('Invalid invoke data');
 	}
 };

--- a/lib/cwmetrics/src/lib/cloudwatch.ts
+++ b/lib/cwmetrics/src/lib/cloudwatch.ts
@@ -10,8 +10,7 @@ export type KnownMetric =
 	| 'SuccessfulRecipes'
 	| 'UpdatesTotalOfArticle'
 	| 'FailedAnnouncements'
-	| 'FailedDynamicFronts'
-	| 'SuccessfulDynamicFronts';
+	| 'FailedDynamicContainer';
 
 export async function registerMetric(metricName: KnownMetric, value: number) {
 	const req = new PutMetricDataCommand({

--- a/lib/cwmetrics/src/lib/cloudwatch.ts
+++ b/lib/cwmetrics/src/lib/cloudwatch.ts
@@ -9,7 +9,9 @@ export type KnownMetric =
 	| 'FailedRecipes'
 	| 'SuccessfulRecipes'
 	| 'UpdatesTotalOfArticle'
-	| 'FailedAnnouncements';
+	| 'FailedAnnouncements'
+	| 'FailedDynamicFronts'
+	| 'SuccessfulDynamicFronts';
 
 export async function registerMetric(metricName: KnownMetric, value: number) {
 	const req = new PutMetricDataCommand({


### PR DESCRIPTION
## What does this change?

Recently, we came across the problem where dynamic fronts were not generated since 8th July; I observed on 24th July. 
We didn't have any logs to check on that because it was already over 2 weeks. 
It clearly shows we missed seeing this problem well before.

I raised the concern to Data Tech team, [details in here](https://chat.google.com/room/AAAAAeMn93M/axobtjmPH_8/axobtjmPH_8?cls=10), lambda was not triggered after 8th from Airflow's end and we saw failure Invocation in BQ DAG's too.

Keeping alerts on both ends, one at Airflow's end which can show if the lambda not get triggered and another one at recipe-backend's end where if there is failure then we can have some notification, will help us in dealing with these situations.

James from DT team kindly offered help in checking the divertion of alerts notification to our Feast Dev chat channel.
And This PR change will keep some metric for our end too.

## How to test

- Deploy on CODE
- Observe the metric for `FailedDynamicContainer` after lambda gets triggerd usually by midnight. The metric should be present if there is any failure recorded so we might need to wait if we need to see it.

## How can we measure success?

- Metric should be available and email should be recieved for failed container.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
