### PR TITLE
A new endpoint to fetch specific container

### DIFF
--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -4148,6 +4148,80 @@ def sort_filter_rules(json_obj):
       },
       "Type": "AWS::Lambda::Permission",
     },
+    "RestEndpointsNoneOrTooLessContainersAlarmABCBAEE6": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "externalsnonurgentalarmarnParameter3CDDBCA7",
+          },
+        ],
+        "AlarmDescription": "Raised if the NoneOrTooLessContainers metric is recorded in an hour",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "NoneOrTooLessContainers",
+        "Namespace": "RecipeBackend",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestEndpointsTooManyContainersAlarm424091C2": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "externalsnonurgentalarmarnParameter3CDDBCA7",
+          },
+        ],
+        "AlarmDescription": "Raised if the TooManyContainers metric is recorded in an hour",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "TooManyContainers",
+        "Namespace": "RecipeBackend",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-backend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "feast",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "SnapshotRecipeIndexLambdaA94048E1": {
       "DependsOn": [
         "SnapshotRecipeIndexLambdaServiceRoleDefaultPolicy189EC0D5",

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -277,6 +277,7 @@ export class RecipesBackend extends GuStack {
 			fastlyKey: fastlyKeyParam.valueAsString,
 			contentUrlBase,
 			dataStore: store,
+			externalParameters,
 		});
 
 		new RecipesReindex(this, 'RecipeReindex', {

--- a/cdk/lib/rest-endpoints.ts
+++ b/cdk/lib/rest-endpoints.ts
@@ -1,18 +1,27 @@
 import { GuApiLambda } from '@guardian/cdk';
 import type { GuStack } from '@guardian/cdk/lib/constructs/core';
-import { Duration } from 'aws-cdk-lib';
+import { aws_sns, Duration } from 'aws-cdk-lib';
 import { EndpointType } from 'aws-cdk-lib/aws-apigateway';
+import {
+	Alarm,
+	ComparisonOperator,
+	Metric,
+	TreatMissingData,
+} from 'aws-cdk-lib/aws-cloudwatch';
+import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import type { IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import type { DataStore } from './datastore';
+import type { ExternalParameters } from './external_parameters';
 
 interface RestEndpointsProps {
 	servingBucket: IBucket;
 	fastlyKey: string;
 	contentUrlBase: string;
 	dataStore: DataStore;
+	externalParameters: ExternalParameters;
 }
 
 export class RestEndpoints extends Construct {
@@ -74,5 +83,54 @@ export class RestEndpoints extends Construct {
 				},
 			],
 		});
+
+		const nonUrgentAlarmTopic = aws_sns.Topic.fromTopicArn(
+			this,
+			'nonurgent-alarm',
+			props.externalParameters.nonUrgentAlarmTopicArn.stringValue,
+		);
+
+		const noneOrTooLessContainersMetric = new Metric({
+			namespace: 'RecipeBackend',
+			metricName: 'NoneOrTooLessContainers',
+			statistic: 'Sum',
+			period: Duration.hours(1),
+		});
+		const noneOrTooLessContainersAlarm = new Alarm(
+			this,
+			'NoneOrTooLessContainersAlarm',
+			{
+				metric: noneOrTooLessContainersMetric,
+				threshold: 1,
+				evaluationPeriods: 1,
+				comparisonOperator:
+					ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+				alarmDescription:
+					'Raised if the NoneOrTooLessContainers metric is recorded in an hour',
+				treatMissingData: TreatMissingData.NOT_BREACHING,
+			},
+		);
+
+		noneOrTooLessContainersAlarm.addAlarmAction(
+			new SnsAction(nonUrgentAlarmTopic),
+		);
+
+		const tooManyContainersMetric = new Metric({
+			namespace: 'RecipeBackend',
+			metricName: 'TooManyContainers',
+			statistic: 'Sum',
+			period: Duration.hours(1),
+		});
+		const tooManyContainersAlarm = new Alarm(this, 'TooManyContainersAlarm', {
+			metric: tooManyContainersMetric,
+			threshold: 1,
+			evaluationPeriods: 1,
+			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+			alarmDescription:
+				'Raised if the TooManyContainers metric is recorded in an hour',
+			treatMissingData: TreatMissingData.NOT_BREACHING,
+		});
+
+		tooManyContainersAlarm.addAlarmAction(new SnsAction(nonUrgentAlarmTopic));
 	}
 }

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -192,12 +192,22 @@ router.get('/api/:region/:variant/localisation', (req, resp) => {
 					curatedFront.flatMap((c) => c.items).flatMap(recipeFromContainer),
 				);
 
+				console.log(
+					'INFO on most popular container, curatedRecipesSet ',
+					JSON.stringify(Array.from(curatedRecipesSet)),
+				);
+
 				const maybeLocalisation = findRecentLocalisation(
 					territoryParam,
 					5,
 					new Date(),
 					curatedRecipesSet,
 					10,
+				);
+
+				console.log(
+					'INFO on most popular container, maybeLocalisation ',
+					JSON.stringify(maybeLocalisation),
 				);
 
 				resp

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -200,7 +200,12 @@ router.get('/api/:region/:variant/localisation', (req, resp) => {
 					10,
 				);
 
-				resp.status(200).json(maybeLocalisation);
+				resp
+					.status(200)
+					.set({
+						'Cache-Control': 'no-store, no-cache',
+					})
+					.json(maybeLocalisation);
 			})
 			.catch((err) => {
 				console.error("Error retrieving today's curation:", err);

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -206,6 +206,23 @@ router.post('/api/:region/:variant/container-by-title', (req, resp) => {
 					containersWithTitle.length,
 				);
 
+				//Extra Smart layer to indicate generated containers are very few or too many, before user tells us!
+				if (containersWithTitle.length < 2) {
+					console.warn(
+						'Generated containers are very few:',
+						containersWithTitle.length,
+					);
+					// Need to add alarm here
+				}
+
+				if (containersWithTitle.length > 20) {
+					console.warn(
+						'Generated containers are too many:',
+						containersWithTitle.length,
+					);
+					// Need to add alarm here
+				}
+
 				if (containersWithTitle.length === 0) {
 					console.log('No containers found with the provided title(s):', title);
 					resp.status(404).json({

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -30,6 +30,7 @@ interface RecipeIdParams {
 
 interface ContainerRequestBody {
 	title: string;
+	date: string;
 }
 
 function validateComposerParams(params: RecipeIdParams) {
@@ -176,7 +177,8 @@ router.get('/api/:region/:variant/hybrid-curation.json', (req, resp) => {
 /** A separate endpoint for any of the container to get extracted based on title */
 router.post('/api/:region/:variant/container-by-title', (async (req, resp) => {
 	try {
-		const { title } = req.body as ContainerRequestBody;
+		const { title, date } = req.body as ContainerRequestBody;
+
 		if (!title) {
 			resp.status(400).json({
 				status: 'error',
@@ -197,7 +199,7 @@ router.post('/api/:region/:variant/container-by-title', (async (req, resp) => {
 				3,
 				7,
 				authToken,
-				undefined,
+				date ? new Date(date) : undefined,
 			);
 
 			console.log('Curated front length:', curatedFront.length);

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -26,6 +26,10 @@ interface RecipeIdParams {
 	recipeUID: string;
 }
 
+interface ContainerRequestBody {
+	title: string;
+}
+
 function validateComposerParams(params: RecipeIdParams) {
 	const checker = /^[\w\d]+$/;
 
@@ -170,7 +174,7 @@ router.get('/api/:region/:variant/hybrid-curation.json', (req, resp) => {
 /** A separate endpoint for any of the container to get extracted based on title */
 router.post('/api/:region/:variant/container-by-title', (req, resp) => {
 	try {
-		const { title } = req.body;
+		const { title } = req.body as ContainerRequestBody;
 		if (!title) {
 			resp.status(400).json({
 				status: 'error',

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -199,7 +199,7 @@ router.post('/api/:region/:variant/container-by-title', (async (req, resp) => {
 				3,
 				7,
 				authToken,
-				date ? new Date(date) : undefined,
+				date ? date : undefined,
 			);
 
 			console.log('Curated front length:', curatedFront.length);

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -193,6 +193,21 @@ router.get('/api/:region/:variant/localisation', (req, resp) => {
 				);
 
 				console.log(
+					'INFO on most popular container, curatedFront:',
+					JSON.stringify(curatedFront),
+				);
+				console.log(
+					'INFO on most popular container, Items after first flatMap:',
+					JSON.stringify(curatedFront.flatMap((c) => c.items)),
+				);
+				console.log(
+					'INFO on most popular container, Recipes after second flatMap:',
+					JSON.stringify(
+						curatedFront.flatMap((c) => c.items).flatMap(recipeFromContainer),
+					),
+				);
+
+				console.log(
 					'INFO on most popular container, curatedRecipesSet ',
 					JSON.stringify(Array.from(curatedRecipesSet)),
 				);

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -6,7 +6,12 @@ import type { Request } from 'express';
 import type { RecipeV3 } from '@recipes-api/lib/feast-models';
 import { recipeByUID } from '@recipes-api/lib/recipes-data';
 import { checkTemplate } from './check-template';
-import { generateHybridFront } from './curation';
+import {
+	findRecentLocalisation,
+	generateHybridFront,
+	recipeFromContainer,
+	retrieveTodaysCuration,
+} from './curation';
 import { countryCodeFromCDN } from './geo_cdn';
 import { recursivelyGetIdList } from './helpers';
 
@@ -165,6 +170,54 @@ router.get('/api/:region/:variant/hybrid-curation.json', (req, resp) => {
 				detail: `An error occurred at ${new Date().toISOString()}. See the server logs for details.`,
 			});
 		});
+});
+
+/** A separate endpoint for Most popular in your country*/
+router.get('/api/:region/:variant/localisation', (req, resp) => {
+	try {
+		const territoryParam =
+			(req.query['ter'] as string | undefined) ?? countryCodeFromCDN(req);
+
+		if (!territoryParam) {
+			resp.status(400).json({
+				status: 'error',
+				detail: 'No territory specified and unable to determine from request',
+			});
+			return;
+		}
+
+		retrieveTodaysCuration(req.params.region, req.params.variant)
+			.then((curatedFront) => {
+				const curatedRecipesSet = new Set(
+					curatedFront.flatMap((c) => c.items).flatMap(recipeFromContainer),
+				);
+
+				const maybeLocalisation = findRecentLocalisation(
+					territoryParam,
+					5,
+					new Date(),
+					curatedRecipesSet,
+					10,
+				);
+
+				resp.status(200).json(maybeLocalisation);
+			})
+			.catch((err) => {
+				console.error("Error retrieving today's curation:", err);
+				resp.status(404).json({
+					status: `Error: No localisation available for ${req.params.region} / ${req.params.variant} in ${territoryParam}`,
+					detail:
+						'No Localisation could be found. See server logs for details.',
+				});
+			});
+	} catch (err) {
+		console.error(err);
+		resp.status(500).json({
+			status: 'error',
+			detail:
+				'An error occurred while fetching localisation. See server logs for details.',
+		});
+	}
 });
 
 router.post(

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -173,7 +173,7 @@ router.get('/api/:region/:variant/hybrid-curation.json', (req, resp) => {
 });
 
 /** A separate endpoint for any of the container to get extracted based on title */
-router.post('/api/:region/:variant/container-by-title', (req, resp) => {
+router.post('/api/:region/:variant/container-by-title', async (req, resp) => {
 	try {
 		const { title } = req.body as ContainerRequestBody;
 		if (!title) {
@@ -188,64 +188,60 @@ router.post('/api/:region/:variant/container-by-title', (req, resp) => {
 			(req.query['ter'] as string | undefined) ?? countryCodeFromCDN(req);
 		const authToken = req.headers['authorization'];
 
-		generateHybridFront(
-			req.params.region,
-			req.params.variant,
-			territoryParam,
-			3,
-			7,
-			authToken,
-			undefined,
-		)
-			.then((curatedFront) => {
-				console.log('Curated front length:', curatedFront.length);
-				console.log('Incoming title(s):', title);
-				const containersWithTitle = curatedFront.filter((container) => {
-					if (Array.isArray(title)) {
-						return title.includes(container.title);
-					}
-					return container.title === title;
-				});
-				console.log(
-					'containersWithTitle front length:',
-					containersWithTitle.length,
-				);
+		try {
+			const curatedFront = await generateHybridFront(
+				req.params.region,
+				req.params.variant,
+				territoryParam,
+				3,
+				7,
+				authToken,
+				undefined,
+			);
 
-				//Extra Smart layer to indicate generated containers are very few or too many, before user tells us!
-				if (curatedFront.length < 2) {
-					console.warn(
-						'Generated containers are very few:',
-						curatedFront.length,
-					);
-					await registerMetric('NoneOrTooLessContainers', 1);
+			console.log('Curated front length:', curatedFront.length);
+			console.log('Incoming title(s):', title);
+
+			const containersWithTitle = curatedFront.filter((container) => {
+				if (Array.isArray(title)) {
+					return title.includes(container.title);
 				}
-
-				if (curatedFront.length > 20) {
-					console.warn(
-						'Generated containers are too many:',
-						curatedFront.length,
-					);
-					await registerMetric('TooManyContainers', 1);
-				}
-
-				if (containersWithTitle.length === 0) {
-					console.log('No containers found with the provided title(s):', title);
-					resp.status(404).json({
-						status: 'not_found',
-						detail: 'No containers found. Please try again.',
-					});
-					return;
-				}
-
-				resp.status(200).json(containersWithTitle);
-			})
-			.catch((err) => {
-				console.error('Error generating curation by title', err);
-				resp.status(500).json({
-					status: 'internal_error',
-					detail: `An error occurred while fetching curation by title. See server logs for details.`,
-				});
+				return container.title === title;
 			});
+
+			console.log(
+				'containersWithTitle front length:',
+				containersWithTitle.length,
+			);
+
+			// Extra Smart layer to indicate generated containers are very few or too many, before user tells us!
+			if (curatedFront.length < 2) {
+				console.warn('Generated containers are very few:', curatedFront.length);
+				await registerMetric('NoneOrTooLessContainers', 1);
+			}
+
+			if (curatedFront.length > 20) {
+				console.warn('Generated containers are too many:', curatedFront.length);
+				await registerMetric('TooManyContainers', 1);
+			}
+
+			if (containersWithTitle.length === 0) {
+				console.log('No containers found with the provided title(s):', title);
+				resp.status(404).json({
+					status: 'not_found',
+					detail: 'No containers found. Please try again.',
+				});
+				return;
+			}
+
+			resp.status(200).json(containersWithTitle);
+		} catch (err) {
+			console.error('Error generating curation by title', err);
+			resp.status(500).json({
+				status: 'internal_error',
+				detail: `An error occurred while fetching curation by title. See server logs for details.`,
+			});
+		}
 	} catch (err) {
 		console.error(err);
 		resp.status(500).json({

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -223,10 +223,7 @@ router.get('/api/:region/:variant/container-by-title', (req, resp) => {
 				resp.status(200).json(containersWithTitle);
 			})
 			.catch((err) => {
-				console.error(
-					`Error generating hybrid front for ${req.params.region} / ${req.params.variant}: `,
-					err,
-				);
+				console.error('Error generating curation by title', err);
 				resp.status(500).json({
 					status: 'internal_error',
 					detail: `An error occurred while fetching curation by title. See server logs for details.`,

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -3,6 +3,7 @@ import { formatISO } from 'date-fns';
 import { renderFile as ejs } from 'ejs';
 import express, { Router } from 'express';
 import type { Request } from 'express';
+import { registerMetric } from '@recipes-api/cwmetrics';
 import type { RecipeV3 } from '@recipes-api/lib/feast-models';
 import { recipeByUID } from '@recipes-api/lib/recipes-data';
 import { checkTemplate } from './check-template';
@@ -211,20 +212,20 @@ router.post('/api/:region/:variant/container-by-title', (req, resp) => {
 				);
 
 				//Extra Smart layer to indicate generated containers are very few or too many, before user tells us!
-				if (containersWithTitle.length < 2) {
+				if (curatedFront.length < 2) {
 					console.warn(
 						'Generated containers are very few:',
-						containersWithTitle.length,
+						curatedFront.length,
 					);
-					// Need to add alarm here
+					await registerMetric('NoneOrTooLessContainers', 1);
 				}
 
-				if (containersWithTitle.length > 20) {
+				if (curatedFront.length > 20) {
 					console.warn(
 						'Generated containers are too many:',
-						containersWithTitle.length,
+						curatedFront.length,
 					);
-					// Need to add alarm here
+					await registerMetric('TooManyContainers', 1);
 				}
 
 				if (containersWithTitle.length === 0) {

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -1,7 +1,8 @@
 import bodyParser from 'body-parser';
 import { formatISO } from 'date-fns';
 import { renderFile as ejs } from 'ejs';
-import express, { Router } from 'express';
+import 'express-async-errors'; // This patches Express 4 to handle async
+import express, { type RequestHandler, Router } from 'express';
 import type { Request } from 'express';
 import { registerMetric } from '@recipes-api/cwmetrics';
 import type { RecipeV3 } from '@recipes-api/lib/feast-models';
@@ -173,7 +174,7 @@ router.get('/api/:region/:variant/hybrid-curation.json', (req, resp) => {
 });
 
 /** A separate endpoint for any of the container to get extracted based on title */
-router.post('/api/:region/:variant/container-by-title', async (req, resp) => {
+router.post('/api/:region/container', (async (req, resp) => {
 	try {
 		const { title } = req.body as ContainerRequestBody;
 		if (!title) {
@@ -249,7 +250,7 @@ router.post('/api/:region/:variant/container-by-title', async (req, resp) => {
 			detail: 'An unexpected error occurred. See server logs for details.',
 		});
 	}
-});
+}) as RequestHandler);
 
 router.post(
 	'/api/check-template',

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -6,12 +6,7 @@ import type { Request } from 'express';
 import type { RecipeV3 } from '@recipes-api/lib/feast-models';
 import { recipeByUID } from '@recipes-api/lib/recipes-data';
 import { checkTemplate } from './check-template';
-import {
-	findRecentLocalisation,
-	generateHybridFront,
-	recipeFromContainer,
-	retrieveTodaysCuration,
-} from './curation';
+import { generateHybridFront } from './curation';
 import { countryCodeFromCDN } from './geo_cdn';
 import { recursivelyGetIdList } from './helpers';
 
@@ -215,7 +210,7 @@ router.get('/api/:region/:variant/container-by-title', (req, resp) => {
 					console.log('No containers found with the provided title(s):', title);
 					resp.status(404).json({
 						status: 'not_found',
-						detail: `No container found with title: ${title}`,
+						detail: 'No containers found. Please try again.',
 					});
 					return;
 				}

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -174,7 +174,7 @@ router.get('/api/:region/:variant/hybrid-curation.json', (req, resp) => {
 });
 
 /** A separate endpoint for any of the container to get extracted based on title */
-router.post('/api/:region/container', (async (req, resp) => {
+router.post('/api/:region/:variant/container-by-title', (async (req, resp) => {
 	try {
 		const { title } = req.body as ContainerRequestBody;
 		if (!title) {

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -172,80 +172,71 @@ router.get('/api/:region/:variant/hybrid-curation.json', (req, resp) => {
 		});
 });
 
-/** A separate endpoint for Most popular in your country*/
-router.get('/api/:region/:variant/localisation', (req, resp) => {
+/** A separate endpoint for any of the container to get extracted based on title */
+router.get('/api/:region/:variant/container-by-title', (req, resp) => {
 	try {
-		const territoryParam =
-			(req.query['ter'] as string | undefined) ?? countryCodeFromCDN(req);
-
-		if (!territoryParam) {
+		const { title } = req.query;
+		if (!title) {
 			resp.status(400).json({
 				status: 'error',
-				detail: 'No territory specified and unable to determine from request',
+				detail: 'You must specify a title to query',
 			});
 			return;
 		}
 
-		retrieveTodaysCuration(req.params.region, req.params.variant)
+		const territoryParam =
+			(req.query['ter'] as string | undefined) ?? countryCodeFromCDN(req);
+		const authToken = req.headers['authorization'];
+
+		generateHybridFront(
+			req.params.region,
+			req.params.variant,
+			territoryParam,
+			3,
+			7,
+			authToken,
+			undefined,
+		)
 			.then((curatedFront) => {
-				const curatedRecipesSet = new Set(
-					curatedFront.flatMap((c) => c.items).flatMap(recipeFromContainer),
+				console.log('Curated front length:', curatedFront.length);
+				console.log('Incoming title(s):', title);
+				const containersWithTitle = curatedFront.filter((container) => {
+					if (Array.isArray(title)) {
+						return title.includes(container.title);
+					}
+					return container.title === title;
+				});
+				console.log(
+					'containersWithTitle front length:',
+					containersWithTitle.length,
 				);
 
-				console.log(
-					'INFO on most popular container, curatedFront:',
-					JSON.stringify(curatedFront),
-				);
-				console.log(
-					'INFO on most popular container, Items after first flatMap:',
-					JSON.stringify(curatedFront.flatMap((c) => c.items)),
-				);
-				console.log(
-					'INFO on most popular container, Recipes after second flatMap:',
-					JSON.stringify(
-						curatedFront.flatMap((c) => c.items).flatMap(recipeFromContainer),
-					),
-				);
+				if (containersWithTitle.length === 0) {
+					console.log('No containers found with the provided title(s):', title);
+					resp.status(404).json({
+						status: 'not_found',
+						detail: `No container found with title: ${title}`,
+					});
+					return;
+				}
 
-				console.log(
-					'INFO on most popular container, curatedRecipesSet ',
-					JSON.stringify(Array.from(curatedRecipesSet)),
-				);
-
-				const maybeLocalisation = findRecentLocalisation(
-					territoryParam,
-					5,
-					new Date(),
-					curatedRecipesSet,
-					10,
-				);
-
-				console.log(
-					'INFO on most popular container, maybeLocalisation ',
-					JSON.stringify(maybeLocalisation),
-				);
-
-				resp
-					.status(200)
-					.set({
-						'Cache-Control': 'no-store, no-cache',
-					})
-					.json(maybeLocalisation);
+				resp.status(200).json(containersWithTitle);
 			})
 			.catch((err) => {
-				console.error("Error retrieving today's curation:", err);
-				resp.status(404).json({
-					status: `Error: No localisation available for ${req.params.region} / ${req.params.variant} in ${territoryParam}`,
-					detail:
-						'No Localisation could be found. See server logs for details.',
+				console.error(
+					`Error generating hybrid front for ${req.params.region} / ${req.params.variant}: `,
+					err,
+				);
+				resp.status(500).json({
+					status: 'internal_error',
+					detail: `An error occurred while fetching curation by title. See server logs for details.`,
 				});
 			});
 	} catch (err) {
 		console.error(err);
 		resp.status(500).json({
 			status: 'error',
-			detail:
-				'An error occurred while fetching localisation. See server logs for details.',
+			detail: 'An unexpected error occurred. See server logs for details.',
 		});
 	}
 });

--- a/lambda/rest-endpoints/src/app.ts
+++ b/lambda/rest-endpoints/src/app.ts
@@ -168,13 +168,13 @@ router.get('/api/:region/:variant/hybrid-curation.json', (req, resp) => {
 });
 
 /** A separate endpoint for any of the container to get extracted based on title */
-router.get('/api/:region/:variant/container-by-title', (req, resp) => {
+router.post('/api/:region/:variant/container-by-title', (req, resp) => {
 	try {
-		const { title } = req.query;
+		const { title } = req.body;
 		if (!title) {
 			resp.status(400).json({
 				status: 'error',
-				detail: 'You must specify a title to query',
+				detail: 'You must specify a title in the request body',
 			});
 			return;
 		}

--- a/lambda/rest-endpoints/src/curation.test.ts
+++ b/lambda/rest-endpoints/src/curation.test.ts
@@ -66,7 +66,7 @@ describe('generateHybridFront', () => {
 		s3Mock
 			.onAnyCommand({
 				Bucket: 'test',
-				Key: `northern/all-recipes/curation.json`,
+				Key: `northern/all-recipes/2025-01-02/curation.json`,
 			})
 			.resolves({
 				// @ts-ignore
@@ -88,7 +88,7 @@ describe('generateHybridFront', () => {
 			1,
 			2,
 			undefined,
-			new Date(2025, 0, 2),
+			'2025-01-02',
 		);
 		expect(result[0].title).toEqual('container 1');
 		expect(result[1].title).toEqual('container 2');
@@ -109,7 +109,7 @@ describe('generateHybridFront', () => {
 		s3Mock
 			.onAnyCommand({
 				Bucket: 'test',
-				Key: `northern/all-recipes/curation.json`,
+				Key: `northern/all-recipes/2025-01-02/curation.json`,
 			})
 			.resolves({
 				// @ts-ignore
@@ -131,7 +131,7 @@ describe('generateHybridFront', () => {
 			100,
 			101,
 			undefined,
-			new Date(2025, 0, 2),
+			'2025-01-02',
 		);
 		expect(result[0].title).toEqual('container 1');
 		expect(result[1].title).toEqual('container 2');
@@ -152,7 +152,7 @@ describe('generateHybridFront', () => {
 		s3Mock
 			.onAnyCommand({
 				Bucket: 'test',
-				Key: `northern/meat-free/curation.json`,
+				Key: `northern/meat-free/2025-01-02/curation.json`,
 			})
 			.resolves({
 				// @ts-ignore
@@ -174,7 +174,7 @@ describe('generateHybridFront', () => {
 			2,
 			3,
 			undefined,
-			new Date(2025, 0, 2),
+			'2025-01-02',
 		);
 		expect(result[0].title).toEqual('container 1');
 		expect(result[1].title).toEqual('container 2');
@@ -194,7 +194,7 @@ describe('generateHybridFront', () => {
 		s3Mock
 			.onAnyCommand({
 				Bucket: 'test',
-				Key: `northern/all-recipes/curation.json`,
+				Key: `northern/all-recipes/2025-01-02/curation.json`,
 			})
 			.resolves({
 				// @ts-ignore
@@ -216,7 +216,7 @@ describe('generateHybridFront', () => {
 			1,
 			2,
 			undefined,
-			new Date(2025, 0, 2),
+			'2025-01-02',
 		);
 		expect(result[0].title).toEqual('container 1');
 		expect(result[1].title).toEqual('container 2');
@@ -242,7 +242,7 @@ describe('generateHybridFront', () => {
 		s3Mock
 			.onAnyCommand({
 				Bucket: 'test',
-				Key: `northern/meat-free/curation.json`,
+				Key: `northern/meat-free/2025-01-02/curation.json`,
 			})
 			.resolves({
 				// @ts-ignore
@@ -267,7 +267,7 @@ describe('generateHybridFront', () => {
 			2,
 			3,
 			undefined,
-			new Date(2025, 0, 2),
+			'2025-01-02',
 		);
 		expect(result[0].title).toEqual('container 1');
 		expect(result[1].title).toEqual('container 2');
@@ -284,7 +284,7 @@ describe('generateHybridFront', () => {
 		s3Mock
 			.onAnyCommand({
 				Bucket: 'test',
-				Key: `northern/meat-free/curation.json`,
+				Key: `northern/meat-free/2025-01-02/curation.json`,
 			})
 			.resolves({
 				// @ts-ignore
@@ -303,7 +303,7 @@ describe('generateHybridFront', () => {
 			2,
 			3,
 			undefined,
-			new Date(2025, 0, 2),
+			'2025-01-02',
 		);
 		expect(result[0].title).toEqual('container 1');
 		expect(result[1].title).toEqual('container 2');
@@ -326,7 +326,7 @@ describe('generateHybridFront', () => {
 		s3Mock
 			.onAnyCommand({
 				Bucket: 'test',
-				Key: `northern/all-recipes/curation.json`,
+				Key: `northern/all-recipes/2025-01-02/curation.json`,
 			})
 			.resolves({
 				// @ts-ignore
@@ -401,7 +401,7 @@ describe('generateHybridFront', () => {
 			2,
 			3,
 			undefined,
-			new Date(2025, 0, 5),
+			'2025-01-02',
 		);
 		expect(result[0].title).toEqual('container 1');
 		expect(result[1].title).toEqual('container 2');

--- a/lambda/rest-endpoints/src/curation.ts
+++ b/lambda/rest-endpoints/src/curation.ts
@@ -177,7 +177,7 @@ export async function findRecentLocalisation(
 	return undefined;
 }
 
-function recipeFromContainer(item: ContainerItem): string[] {
+export function recipeFromContainer(item: ContainerItem): string[] {
 	// eslint-disable-next-line no-prototype-builtins -- how else to do this?
 	if (item.hasOwnProperty('recipe')) {
 		const recipeItem = item as Recipe;
@@ -263,15 +263,15 @@ export async function generateHybridFront(
 		return curatedFront;
 	}
 
-	const curatedRecipesSet = new Set(
-		curatedFront.flatMap((c) => c.items).flatMap(recipeFromContainer),
-	);
-
 	if (!territory) {
 		//no territory given so we can't localise
 		console.error("no territory given so we can't localise ");
 		return curatedFront;
 	}
+
+	const curatedRecipesSet = new Set(
+		curatedFront.flatMap((c) => c.items).flatMap(recipeFromContainer),
+	);
 
 	const maybeLocalisation = await findRecentLocalisation(
 		territory,

--- a/lambda/rest-endpoints/src/curation.ts
+++ b/lambda/rest-endpoints/src/curation.ts
@@ -24,26 +24,31 @@ const s3Client = new S3Client({
 	region: AwsRegion ?? 'eu-west-1',
 });
 
-async function rawCurationDataForToday(
+async function rawCurationData(
 	region: string,
 	variant: string,
+	dateString?: string,
 ): Promise<GetObjectOutput> {
 	try {
 		return await s3Client.send(
 			new GetObjectCommand({
 				Bucket: getStaticBucketName(),
-				Key: `${region}/${variant}/curation.json`,
+				Key: dateString
+					? `${region}/${variant}/${dateString}/curation.json`
+					: `${region}/${variant}/curation.json`,
 			}),
 		);
 	} catch (err) {
 		if (err instanceof S3ServiceException) {
 			if (err.name == 'NotFound') {
-				const today = formatDate(new Date(), 'yyyy-MM-dd');
+				const date = dateString
+					? formatDate(new Date(dateString), 'yyyy-MM-dd')
+					: formatDate(new Date(), 'yyyy-MM-dd');
 
 				return await s3Client.send(
 					new GetObjectCommand({
 						Bucket: getStaticBucketName(),
-						Key: `${region}/${variant}/${today}/curation.json`,
+						Key: `${region}/${variant}/${date}/curation.json`,
 					}),
 				);
 			} else {
@@ -57,11 +62,12 @@ async function rawCurationDataForToday(
 	}
 }
 
-export async function retrieveTodaysCuration(
+export async function retrieveCuration(
 	region: string,
 	variant: string,
+	dateString?: string,
 ): Promise<FeastAppContainer[]> {
-	const s3response = await rawCurationDataForToday(region, variant);
+	const s3response = await rawCurationData(region, variant, dateString); //rawCurationDataForToday
 	if (s3response.Body) {
 		const rawData = await consumeReadable(
 			s3response.Body as NodeJsRuntimeStreamingBlobTypes,
@@ -255,9 +261,9 @@ export async function generateHybridFront(
 	personalisedInsertionPoint: number,
 	localisationInsertionPoint: number,
 	authToken?: string,
-	overrideDate?: Date,
+	dateString?: string,
 ): Promise<FeastAppContainer[]> {
-	const curatedFront = await retrieveTodaysCuration(region, variant);
+	const curatedFront = await retrieveCuration(region, variant, dateString); //retrieveTodaysCuration
 	if (variant == 'meat-free') {
 		//we don't currently support localisation for meat-free
 		return curatedFront;
@@ -276,7 +282,7 @@ export async function generateHybridFront(
 	const maybeLocalisation = await findRecentLocalisation(
 		territory,
 		5,
-		overrideDate ?? new Date(),
+		dateString ? new Date(dateString) : new Date(),
 		curatedRecipesSet,
 		10,
 	);

--- a/lib/cwmetrics/src/lib/cloudwatch.ts
+++ b/lib/cwmetrics/src/lib/cloudwatch.ts
@@ -14,7 +14,9 @@ export type KnownMetric =
 	| 'FailedAnnouncements'
 	| 'FailedDynamicContainer'
 	| 'FailedPersonalisedContainer'
-	| 'BackendContainerRequests';
+	| 'BackendContainerRequests'
+	| 'NoneOrTooLessContainers'
+	| 'TooManyContainers';
 
 export async function registerMetric(metricName: KnownMetric, value: number) {
 	const req = new PutMetricDataCommand({

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 				"csv-parse": "^6.1.0",
 				"date-fns": "^2.30.0",
 				"express": "4.22.1",
+				"express-async-errors": "^3.1.1",
 				"express-async-handler": "^1.2.0",
 				"i18n-iso-countries": "^7.14.0",
 				"lodash-es": "4.18.1",
@@ -11394,6 +11395,15 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-async-errors": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+			"integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+			"license": "ISC",
+			"peerDependencies": {
+				"express": "^4.16.2"
 			}
 		},
 		"node_modules/express-async-handler": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"csv-parse": "^6.1.0",
 		"date-fns": "^2.30.0",
 		"express": "4.22.1",
+		"express-async-errors": "^3.1.1",
 		"express-async-handler": "^1.2.0",
 		"i18n-iso-countries": "^7.14.0",
 		"lodash-es": "4.18.1",
@@ -111,6 +112,7 @@
 		"eslint-plugin-prettier": "^5.2.1",
 		"jest": "30.0.5",
 		"jest-environment-node": "^29.4.1",
+		"jest-util": "30.3.0",
 		"nx": "22.5.4",
 		"prettier": "~3.6.2",
 		"quicktype": "^23.2.6",
@@ -118,7 +120,6 @@
 		"ts-jest": "29.4.6",
 		"ts-node": "10.9.1",
 		"tsconfig-paths": "^4.2.0",
-		"typescript": "~5.5.2",
-		"jest-util": "30.3.0"
+		"typescript": "~5.5.2"
 	}
 }


### PR DESCRIPTION

## What does this change?

Independent endpoint for fetching any container by its title.
A requirement for a 10% project for one of client devs to show any container in the widget.
I think with `title` we should be able to do that, cant rely on `id` as it will be changing
At present shows DOD(DishOfTheDay) recipe in the widget


## How to test

Deploy on CODE
Hit  POST request at https://recipes.code.dev-guardianapis.com/api/northern/all-recipes/container-by-title
{
  "title": "Dish of the Day"
}

## How can we measure success?

We should get data back if available 

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
