### PR TITLE
bump libraries to remove a crit

### DIFF
--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -79,6 +79,8 @@ export class RecipesBackend extends GuStack {
 
 		const telemetryTopic = new GuParameter(this, 'TelemetryTopic', {
 			fromSSM: true,
+			//This will migrate to /CODE/feast/recipe-structuriser/Telemetry/topicArn once
+			// https://github.com/guardian/data-science-recipes/pull/182 is deployed
 			default: `/${this.stage}/feast/recipe-structuriser/telemetryTopic`,
 			description:
 				'ARN of the SNS topic to use for data submissions (shared with structuriser)',

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
 				"@types/uuid": "^10.0.0",
 				"@typescript-eslint/eslint-plugin": "^8.54.0",
 				"@typescript-eslint/parser": "^8.54.0",
-				"aws-cdk": "2.1107.0",
+				"aws-cdk": "2.1115.0",
 				"aws-cdk-lib": "^2.241.0",
 				"aws-sdk-client-mock": "^3.0.0",
 				"constructs": "10.5.1",
@@ -8858,7 +8858,9 @@
 			}
 		},
 		"node_modules/aws-cdk": {
-			"version": "2.1107.0",
+			"version": "2.1115.0",
+			"resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1115.0.tgz",
+			"integrity": "sha512-PpNNflDt1L2TxpMh2h7cPHnFkDVeY1hwIxuGuvswS08mA0syOT4OmZx8hZYdcLru6NceCsn0x/7uTHpb6Hzo5A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,45 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/@aws-cdk/cloud-assembly-schema": {
+			"version": "53.10.0",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.10.0.tgz",
+			"integrity": "sha512-/gJgJQh9SHIIN82GZ4BB0WS3z3HcKFF734yNOkX0stBeyIfaBl2x476dihVCCM1GpVqnueC9DUA3CyZJOOPitg==",
+			"bundleDependencies": [
+				"jsonschema",
+				"semver"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"jsonschema": "~1.4.1",
+				"semver": "^7.7.4"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			}
+		},
+		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+			"version": "1.4.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+			"version": "7.7.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@aws-crypto/crc32": {
 			"version": "5.2.0",
 			"license": "Apache-2.0",
@@ -8853,7 +8892,7 @@
 				"@aws-cdk/asset-awscli-v1": "2.2.263",
 				"@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
 				"@aws-cdk/cloud-assembly-api": "^2.1.1",
-				"@aws-cdk/cloud-assembly-schema": "^52.1.0",
+				"@aws-cdk/cloud-assembly-schema": "^53.0.0",
 				"@balena/dockerignore": "^1.0.2",
 				"case": "1.6.3",
 				"fs-extra": "^11.3.3",
@@ -8912,25 +8951,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-			"version": "52.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-52.2.0.tgz",
-			"integrity": "sha512-ourZjixQ/UfsZc7gdk3vt1eHBODMUjQTYYYCY3ZX8fiXyHtWNDAYZPrXUK96jpCC2fLP+tfHTJrBjZ563pmcEw==",
-			"bundleDependencies": [
-				"jsonschema",
-				"semver"
-			],
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"jsonschema": "~1.4.1",
-				"semver": "^7.7.3"
-			},
-			"engines": {
-				"node": ">= 18.0.0"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,45 +97,6 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
-		"node_modules/@aws-cdk/cloud-assembly-schema": {
-			"version": "53.10.0",
-			"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.10.0.tgz",
-			"integrity": "sha512-/gJgJQh9SHIIN82GZ4BB0WS3z3HcKFF734yNOkX0stBeyIfaBl2x476dihVCCM1GpVqnueC9DUA3CyZJOOPitg==",
-			"bundleDependencies": [
-				"jsonschema",
-				"semver"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"jsonschema": "~1.4.1",
-				"semver": "^7.7.4"
-			},
-			"engines": {
-				"node": ">= 18.0.0"
-			}
-		},
-		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-			"version": "1.4.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-			"version": "7.7.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@aws-crypto/crc32": {
 			"version": "5.2.0",
 			"license": "Apache-2.0",
@@ -8913,7 +8874,50 @@
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-			"version": "2.1.1",
+			"version": "2.2.0",
+			"bundleDependencies": [
+				"jsonschema",
+				"semver"
+			],
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"jsonschema": "~1.4.1",
+				"semver": "^7.7.4"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"peerDependencies": {
+				"@aws-cdk/cloud-assembly-schema": ">=53.0.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
+			"version": "1.4.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+			"version": "7.7.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
+			"version": "52.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-52.2.0.tgz",
+			"integrity": "sha512-ourZjixQ/UfsZc7gdk3vt1eHBODMUjQTYYYCY3ZX8fiXyHtWNDAYZPrXUK96jpCC2fLP+tfHTJrBjZ563pmcEw==",
 			"bundleDependencies": [
 				"jsonschema",
 				"semver"
@@ -8927,30 +8931,6 @@
 			},
 			"engines": {
 				"node": ">= 18.0.0"
-			},
-			"peerDependencies": {
-				"@aws-cdk/cloud-assembly-schema": ">=52.1.0"
-			}
-		},
-		"node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-			"version": "1.4.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-			"version": "7.7.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -9290,7 +9270,7 @@
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/yaml": {
-			"version": "1.10.2",
+			"version": "1.10.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -9656,7 +9636,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11456,9 +11438,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-xml-builder": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.2.tgz",
-			"integrity": "sha512-NJAmiuVaJEjVa7TjLZKlYd7RqmzOC91EtPFXHvlTcqBVo50Qh7XV5IwvXi1c7NRz2Q/majGX9YLcwJtWgHjtkA==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+			"integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
 			"funding": [
 				{
 					"type": "github",
@@ -11471,9 +11453,9 @@
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-			"integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+			"version": "5.5.8",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+			"integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -11482,8 +11464,9 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"fast-xml-builder": "^1.0.0",
-				"strnum": "^2.1.2"
+				"fast-xml-builder": "^1.1.4",
+				"path-expression-matcher": "^1.2.0",
+				"strnum": "^2.2.0"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -11571,7 +11554,9 @@
 			}
 		},
 		"node_modules/filelist/node_modules/brace-expansion": {
-			"version": "2.0.2",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11673,7 +11658,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -12036,7 +12023,9 @@
 			}
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "5.0.3",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12168,7 +12157,9 @@
 			}
 		},
 		"node_modules/handlebars": {
-			"version": "4.7.8",
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14314,7 +14305,9 @@
 			}
 		},
 		"node_modules/jest-environment-node/node_modules/picomatch": {
-			"version": "2.3.1",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -15478,9 +15471,9 @@
 			}
 		},
 		"node_modules/jest-util/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -16078,7 +16071,9 @@
 			}
 		},
 		"node_modules/micromatch/node_modules/picomatch": {
-			"version": "2.3.1",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -16150,9 +16145,9 @@
 			}
 		},
 		"node_modules/minimatch/node_modules/brace-expansion": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16424,9 +16419,9 @@
 			}
 		},
 		"node_modules/nx/node_modules/yaml": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -16757,9 +16752,9 @@
 			}
 		},
 		"node_modules/path-expression-matcher": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-			"integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+			"integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -16813,7 +16808,9 @@
 			"license": "ISC"
 		},
 		"node_modules/path-to-regexp": {
-			"version": "0.1.12",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
 			"license": "MIT"
 		},
 		"node_modules/path-type": {
@@ -17242,7 +17239,9 @@
 			}
 		},
 		"node_modules/quicktype-core/node_modules/yaml": {
-			"version": "2.8.2",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -18334,7 +18333,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.1.2",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+			"integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
 			"funding": [
 				{
 					"type": "github",
@@ -18587,7 +18588,9 @@
 			}
 		},
 		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.3",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -19450,7 +19453,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "1.10.2",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,9 +98,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@aws-cdk/cloud-assembly-schema": {
-			"version": "52.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-52.2.0.tgz",
-			"integrity": "sha512-ourZjixQ/UfsZc7gdk3vt1eHBODMUjQTYYYCY3ZX8fiXyHtWNDAYZPrXUK96jpCC2fLP+tfHTJrBjZ563pmcEw==",
+			"version": "53.10.0",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.10.0.tgz",
+			"integrity": "sha512-/gJgJQh9SHIIN82GZ4BB0WS3z3HcKFF734yNOkX0stBeyIfaBl2x476dihVCCM1GpVqnueC9DUA3CyZJOOPitg==",
 			"bundleDependencies": [
 				"jsonschema",
 				"semver"
@@ -109,7 +109,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"jsonschema": "~1.4.1",
-				"semver": "^7.7.3"
+				"semver": "^7.7.4"
 			},
 			"engines": {
 				"node": ">= 18.0.0"
@@ -125,7 +125,7 @@
 			}
 		},
 		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-			"version": "7.7.3",
+			"version": "7.7.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -1528,9 +1528,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.15",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.15.tgz",
-			"integrity": "sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==",
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
+			"integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.1",
@@ -4260,9 +4260,9 @@
 			}
 		},
 		"node_modules/@guardian/eslint-config-typescript/node_modules/minimatch/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8082,7 +8082,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "5.0.3",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8653,7 +8655,9 @@
 			}
 		},
 		"node_modules/anymatch/node_modules/picomatch": {
-			"version": "2.3.1",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8865,9 +8869,9 @@
 			}
 		},
 		"node_modules/aws-cdk-lib": {
-			"version": "2.242.0",
-			"resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.242.0.tgz",
-			"integrity": "sha512-AmZl4Ep9gWX7wGxmIaLGNqE7DSQFrIg1tpiCQE/INf4vc9MbLvUVYE2qikzk8LUnwe0qF1bG2SaaZZ0u9UMs3w==",
+			"version": "2.245.0",
+			"resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.245.0.tgz",
+			"integrity": "sha512-Yfeb+wKC6s+Ttm/N93C6vY6ksyCh68WaG/j3N6dalJWTW/V4o6hUolHm+v2c2IofJEUS45c5AF/EEj24e9hfMA==",
 			"bundleDependencies": [
 				"@balena/dockerignore",
 				"@aws-cdk/cloud-assembly-api",
@@ -11452,9 +11456,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-xml-builder": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-			"integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.2.tgz",
+			"integrity": "sha512-NJAmiuVaJEjVa7TjLZKlYd7RqmzOC91EtPFXHvlTcqBVo50Qh7XV5IwvXi1c7NRz2Q/majGX9YLcwJtWgHjtkA==",
 			"funding": [
 				{
 					"type": "github",
@@ -11467,9 +11471,9 @@
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.5.8",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-			"integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+			"integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
 			"funding": [
 				{
 					"type": "github",
@@ -11478,9 +11482,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"fast-xml-builder": "^1.1.4",
-				"path-expression-matcher": "^1.2.0",
-				"strnum": "^2.2.0"
+				"fast-xml-builder": "^1.0.0",
+				"strnum": "^2.1.2"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -16754,9 +16757,9 @@
 			}
 		},
 		"node_modules/path-expression-matcher": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-			"integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+			"integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -18331,9 +18334,7 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-			"integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+			"version": "2.1.2",
 			"funding": [
 				{
 					"type": "github",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 		"@types/uuid": "^10.0.0",
 		"@typescript-eslint/eslint-plugin": "^8.54.0",
 		"@typescript-eslint/parser": "^8.54.0",
-		"aws-cdk": "2.1107.0",
+		"aws-cdk": "2.1115.0",
 		"aws-cdk-lib": "^2.241.0",
 		"aws-sdk-client-mock": "^3.0.0",
 		"constructs": "10.5.1",


### PR DESCRIPTION
## What does this change?

Bumps libraries from `npm audit fix`

## How has this change been tested?

- Deploy to CODE
- Publish a recipe to CODE
- Run any airflow job for dynamic containers

## How can we measure success?

Remove bugs

## Have we considered potential risks?

Minor risk of breakage; check that system is running correctly as above