### PR TITLE
Update telemetry topic arn to fix deployemnt error in RiffRaff

### DIFF
--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -120,7 +120,7 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "TelemetryTopic": {
-      "Default": "/TEST/feast/recipe-structuriser/telemetryTopic",
+      "Default": "/TEST/feast/recipe-structuriser/Telemetry/topicArn",
       "Description": "ARN of the SNS topic to use for data submissions (shared with structuriser)",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -79,9 +79,7 @@ export class RecipesBackend extends GuStack {
 
 		const telemetryTopic = new GuParameter(this, 'TelemetryTopic', {
 			fromSSM: true,
-			//This will migrate to /CODE/feast/recipe-structuriser/Telemetry/topicArn once
-			// https://github.com/guardian/data-science-recipes/pull/182 is deployed
-			default: `/${this.stage}/feast/recipe-structuriser/telemetryTopic`,
+			default: `/${this.stage}/feast/recipe-structuriser/Telemetry/topicArn`,
 			description:
 				'ARN of the SNS topic to use for data submissions (shared with structuriser)',
 		});


### PR DESCRIPTION
## What does this change?
The ARN value needed to update due to deployement error

<img width="1299" height="781" alt="image" src="https://github.com/user-attachments/assets/b89d722e-ca51-494c-ab22-94e10bba6000" />

-------
I have followed what was suggested in the comment: 
_Comment: This will migrate to /CODE/feast/recipe-structuriser/Telemetry/topicArn once https://github.com/guardian/data-science-recipes/pull/182 is deployed_


## How has this change been tested?

Deploy on CODE and Check status of deployment

## How can we measure success?

No error should get raised

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
