### PR TITLE
Setup devcontainers

### DIFF
--- a/.devcontainer/.gitignore
+++ b/.devcontainer/.gitignore
@@ -1,0 +1,2 @@
+# User-specific devcontainer directory with merged personal preferences
+user/

--- a/.devcontainer/devenv.yaml
+++ b/.devcontainer/devenv.yaml
@@ -1,0 +1,40 @@
+# Devenv project configuration
+# Edit this file to configure your project's devcontainer
+# and then run `devenv generate` to create the devcontainer.json files
+
+# REQUIRED: Change this to your project name
+name: "recipes-backend"
+
+# Modules: Built-in functionality
+# - mise: Install and configure mise for dev tools management (https://mise.jdx.dev/)
+# - docker-in-docker: Enable running Docker containers within the devcontainer
+# - scala: Add IDE plugins and jar caching for Scala development
+# - node: Add IDE plugins for Node.js development
+# To disable, comment out or remove items from this list
+modules:
+  - mise
+  - node 
+
+# Optional: Ports to forward
+# forwardPorts:
+#   - 8080  # same port on host and container
+#   - "8000:9000"  # hostPort:containerPort
+
+# Optional: Mount directories from host to container
+# mounts:
+#   - "source=${localEnv:HOME}/.gu/example,target=/home/vscode/.gu/example,readonly,type=bind,consistency=cached"
+
+# Optional: IDE plugins - shared project plugins like language support
+# plugins:
+#   vscode: []
+#   intellij: []
+
+# Optional: Commands to run after container creation
+# Each command has a 'cmd' field and a 'workingDirectory' field
+# e.g.
+postCreateCommand:
+  - cmd: "npm install"
+    workingDirectory: "."
+postStartCommand:
+  - cmd: "echo 'Container started successfully'"
+    workingDirectory: "."

--- a/.devcontainer/shared/devcontainer.json
+++ b/.devcontainer/shared/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name" : "recipes-backend",
+  "customizations" : {
+    "vscode" : {
+      "extensions" : [
+        "hverlin.mise-vscode"
+      ]
+    },
+    "jetbrains" : {
+      "plugins" : [
+        "com.github.l34130.mise",
+        "NodeJS"
+      ]
+    }
+  },
+  "forwardPorts" : [
+  ],
+  "image" : "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "remoteUser" : "vscode",
+  "postCreateCommand" : "((printf \"\\033[1;34m[setup] Starting misePostCreateCommand.sh\\033[0m\\n\" && (cd . && printf '%s' \"IyEvdXNyL2Jpbi9lbnYgYmFzaAojIFNldHMgdXAgbWlzZSBpbnNpZGUgdGhlIGRldmNvbnRhaW5lciBhZnRlciBjcmVhdGlvbi4KIwojIEFsc28gbG9ncyB1c2VmdWwgaW5mbyAoaW5jbHVkaW5nIHRoZSBvdXRwdXQgZnJvbSBgbWlzZSBkb2N0b3JgKSB0byB0aGUgdGVybWluYWwgdG8gaGVscCB3aXRoIGRlYnVnZ2luZy4KCmVycm9yKCkgeyBwcmludGYgIlwwMzNbMTszMW1bLi4uXSAlc1wwMzNbMG1cbiIgIiQqIjsgfSAgIyByZWQKb2soKSAgICB7IHByaW50ZiAiXDAzM1sxOzMybVsuLi5dICVzXDAzM1swbVxuIiAiJCoiOyB9ICAjIGdyZWVuCndhcm4oKSAgeyBwcmludGYgIlwwMzNbMTszM21bLi4uXSAlc1wwMzNbMG1cbiIgIiQqIjsgfSAgIyBnb2xkCmxvZygpICAgeyBwcmludGYgIlwwMzNbMTszNm1bLi4uXSAlc1wwMzNbMG1cbiIgIiQqIjsgfSAgIyBjeWFuCgppZiB3aGljaCBtaXNlICYmIG1pc2UgLS12ZXJzaW9uOyB0aGVuCiAgbG9nICJtaXNlIGlzIGFscmVhZHkgcHJlc2VudCBhdCAkKHdoaWNoIG1pc2UpLiIKZWxzZQogIGxvZyAiSW5zdGFsbGluZyBtaXNlLi4uIgogIGN1cmwgLWZzU0wgaHR0cHM6Ly9taXNlLnJ1bi9iYXNoIHwgc2gKZmkKCmxvZyAiQ2hlY2tpbmcgbWlzZSBpcyB3b3JraW5nIGNvcnJlY3RseSBhbmQgb24gdGhlIHBhdGguIgptaXNlIC0tdmVyc2lvbgoKbG9nICJVcGRhdGluZyBtaXNlIGlmIG5lZWRlZC4iCm1pc2Ugc2VsZi11cGRhdGUgLS15ZXMgfHwgd2FybiAiU2tpcHBpbmcgbWlzZSBzZWxmLXVwZGF0ZSAtIHlvdSBtYXkgYmUgb2ZmbGluZS4iCgpsb2cgIlRydXN0aW5nIG1pc2UgY29uZmlnIChzZWU6IGh0dHBzOi8vbWlzZS5qZHguZGV2L2NsaS90cnVzdC5odG1sKS4iCm1pc2UgdHJ1c3QgLS15ZXMgfHwgdHJ1ZQoKbG9nICJJbnN0YWxsaW5nIG1pc2UgdG9vbGluZy4iCm1pc2UgaW5zdGFsbCB8fCB3YXJuICJtaXNlIGluc3RhbGwgZmFpbGVkLiBZb3UgbWF5IG5lZWQgdG8gcnVuIG1pc2UgaW5zdGFsbCBtYW51YWxseSBpbnNpZGUgdGhlIGNvbnRhaW5lci4iCgpsb2cgIkVuc3VyZSB0aGF0IG1pc2UgYWN0aXZhdGUgLS1zaGltcyBiYXNoIGlzIGluIGJhc2hyYy4iCnNlZCAtaSAncy9taXNlIGFjdGl2YXRlIGJhc2gvbWlzZSBhY3RpdmF0ZSAtLXNoaW1zIGJhc2gvJyB+Ly5iYXNocmMKZ3JlcCAnbWlzZSBhY3RpdmF0ZSAtLXNoaW1zIGJhc2gnIH4vLmJhc2hyYyB8fCBlY2hvICdldmFsICIkKG1pc2UgYWN0aXZhdGUgLS1zaGltcyBiYXNoKSIgI0FkZGVkIGJ5IGRldmVudicgfCB0ZWUgLWEgfi8uYmFzaHJjCgpsb2cgIkNoZWNrIHRoZXJlIGlzIGV4YWN0bHkgb25lIGFjdGl2YXRlIGNvbW1hbmQgaW4gYmFzaHJjLiIKdGVzdCAiJChncmVwIC1jICdtaXNlIGFjdGl2YXRlJyB+Ly5iYXNocmMpIiAtZXEgMSB8fCBlY2hvICdEaWQgbm90IGZpbmQgZXhhY3RseSBvbmUgYWN0aXZhdGUgY29tbWFuZCcKCmxvZyAiUnVuIHRoZSBhY3RpdmF0ZSBjb21tYW5kIGZyb20gYmFzaHJjLiIKZXZhbCAiJChncmVwICdtaXNlIGFjdGl2YXRlJyB+Ly5iYXNocmMpIgoKbG9nICJMaXN0IGluc3RhbGxlZCB0b29scy4iCm1pc2UgbGlzdAoKbG9nICJGaW5hbCBjaGVja3MuIgptaXNlIGRvY3Rvcgo=\" | base64 -d | bash -euo pipefail && printf \"\\033[1;32m[setup] Finished misePostCreateCommand.sh\\033[0m\\n\") || printf \"\\033[1;31m[setup] Errored! misePostCreateCommand.sh\\033[0m\\n\") && (printf \"\\033[1;34m[setup] Starting unknown\\033[0m\\n\" && (cd . && npm install && printf \"\\033[1;32m[setup] Finished unknown\\033[0m\\n\") || printf \"\\033[1;31m[setup] Errored! unknown\\033[0m\\n\")) 2>&1 | sudo tee /var/log/post-create.log",
+  "postStartCommand" : "((printf \"\\033[1;34m[setup] Starting unknown\\033[0m\\n\" && (cd . && echo 'Container started successfully' && printf \"\\033[1;32m[setup] Finished unknown\\033[0m\\n\") || printf \"\\033[1;31m[setup] Errored! unknown\\033[0m\\n\")) 2>&1 | sudo tee /var/log/post-start.log"
+}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 nodejs 22.17.1
 aqua:aws/aws-cli latest
+golang 1.24.13

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+nodejs 22.17.1
+aqua:aws/aws-cli latest

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Debug update-density with Nx",
+			"runtimeExecutable": "npx",
+			"runtimeArgs": ["nx", "serve", "update-density"],
+			"env": {
+				"NODE_OPTIONS": "--inspect=9229"
+			},
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen",
+			"skipFiles": ["<node_internals>/**"],
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceFolder}/lambda/update-density/dist/**/*.(m|c|)js",
+				"!**/node_modules/**"
+			]
+		}
+	]
+}


### PR DESCRIPTION
## What does this change?

Add setup for devx dev containers

## How has this change been tested?

- Check out the branch
- Open in VSCode using 'Open in folder' as normal
- Use Command-Shift-P to open the Command Palette
- Select `Dev containers: Reopen In Container`
- Point to .devcontainer/shared/devcontainer.json
- Let it build and open the container
- Once it's re-opened, open a terminal window
- Run `uname -r` - it'll claim to be Linux!
- Use `npm install`, `npm test`, etc. as per normal
- If the shell complains about not being able to find `npm`, use `mise install` and/or `eval $(mise activate --shims)`

## How can we measure success?

Road-testing a more secure development process
