### PR TITLE
Cmd tool for terminology csv-json-s3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"aws-lambda": "^1.0.7",
 				"axios": "^1.16.1",
 				"body-parser": "^1.20.5",
+				"commander": "^15.0.0",
 				"csv-parse": "^6.1.0",
 				"date-fns": "^2.30.0",
 				"express": "4.22.2",
@@ -9334,6 +9335,12 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"node_modules/aws-lambda/node_modules/commander": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+			"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+			"license": "MIT"
+		},
 		"node_modules/aws-lambda/node_modules/js-yaml": {
 			"version": "3.14.2",
 			"license": "MIT",
@@ -10131,8 +10138,13 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "3.0.2",
-			"license": "MIT"
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+			"integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.12.0"
+			}
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"aws-lambda": "^1.0.7",
 		"axios": "^1.16.1",
 		"body-parser": "^1.20.5",
+		"commander": "^15.0.0",
 		"csv-parse": "^6.1.0",
 		"date-fns": "^2.30.0",
 		"express": "4.22.2",
@@ -111,6 +112,7 @@
 		"eslint-plugin-prettier": "^5.2.1",
 		"jest": "30.0.5",
 		"jest-environment-node": "^29.4.1",
+		"jest-util": "30.3.0",
 		"nx": "22.5.4",
 		"prettier": "~3.6.2",
 		"quicktype": "^23.2.6",
@@ -118,7 +120,6 @@
 		"ts-jest": "29.4.6",
 		"ts-node": "10.9.1",
 		"tsconfig-paths": "^4.2.0",
-		"typescript": "~5.5.2",
-		"jest-util": "30.3.0"
+		"typescript": "~5.5.2"
 	}
 }

--- a/tools/update-terminologies/csv-json-s3.ts
+++ b/tools/update-terminologies/csv-json-s3.ts
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+/**
+ * terminologies tool — convert a UK/US terminologies CSV to JSON and manage it in S3.
+ *
+ * CSV input has 3 columns: id, ukTerm, usTerm
+ *
+ * Produces JSON of the shape:
+ *   {
+ *     "prepared_at": "2026-06-02T10:30:00Z",
+ *     "key": ["id", "ukTerm", "usTerm"],
+ *     "values": [[1, "sugar", "sugar"], ...]
+ *   }
+ *
+ * S3 layout (per stage bucket):
+ *   terminologies/terminologies-<timestamp>.json   <- dated archives (what `list` shows)
+ *   terminologies/latest/terminologies.json        <- live file the library reads
+ *
+ * Commands:
+ *   update   --stage CODE --file ./terms.csv
+ *            -> writes a new dated archive AND overwrites the live file
+ *   list     --stage CODE
+ *            -> lists the dated archives in the terminologies folder
+ *   rollback --stage CODE --datetime 2026-06-02T10-30-00
+ *            -> copies the matching archive back over the live file
+ */
+
+import { readFileSync } from 'node:fs';
+import { parse } from 'csv-parse/sync';
+import { Command } from 'commander';
+import {
+	S3Client,
+	PutObjectCommand,
+	ListObjectsV2Command,
+	CopyObjectCommand,
+} from '@aws-sdk/client-s3';
+
+// ---------------------------------------------------------------------------
+// Config — map each stage to its bucket. Edit to your real bucket names.
+// ---------------------------------------------------------------------------
+type Stage = 'CODE' | 'PROD';
+
+const BUCKETS: Record<Stage, string> = {
+	CODE: 'feast-recipes-static-code',
+	PROD: 'feast-recipes-static-prod',
+};
+
+const REGION = process.env.AWS_REGION ?? 'eu-west-1';
+const s3 = new S3Client({ region: REGION });
+
+// Fixed S3 paths.
+const ARCHIVE_PREFIX = 'terminologies/'; // dated copies live here
+const LIVE_PREFIX = 'terminologies/latest/'; // subfolder for the live file
+const LIVE_KEY = 'terminologies/latest/terminologies.json';
+
+// The JSON key array, exactly as the consuming library expects.
+const KEYS = ['id', 'ukTerm', 'usTerm'] as const;
+
+function resolveStage(value: string): Stage {
+	const s = value.toUpperCase();
+	if (s !== 'CODE' && s !== 'PROD') {
+		throw new Error(`Invalid stage "${value}". Use CODE or PROD.`);
+	}
+	return s as Stage;
+}
+
+function archiveKey(stamp: string): string {
+	return `${ARCHIVE_PREFIX}${stamp}/terminologies.json`;
+}
+
+// id should be a number; fall back to the raw string if it isn't numeric.
+function toId(raw: string): number | string {
+	const n = Number(raw);
+	return Number.isNaN(n) ? raw : n;
+}
+
+// ---------------------------------------------------------------------------
+// update: CSV -> JSON, write a dated archive + overwrite the live file
+// ---------------------------------------------------------------------------
+async function update(stage: Stage, file: string): Promise<void> {
+	const bucket = BUCKETS[stage];
+
+	const records: Array<Record<string, string>> = parse(readFileSync(file), {
+		columns: (header: string[]) => header.map((h) => h.trim()),
+		skip_empty_lines: true,
+		trim: true,
+	});
+
+	const now = new Date();
+	const preparedAt = now.toISOString(); // 2026-04-22T15:02:13.338Z
+	const stamp = preparedAt; //.replace(/:/g, '-').replace('Z', ''); // 2026-06-02T10-30-00
+
+	const doc = {
+		prepared_at: preparedAt,
+		key: [...KEYS],
+		values: records.map((r) => [toId(r.id), r.ukTerm, r.usTerm]),
+	};
+
+	const body = JSON.stringify(doc, null, 2);
+
+	// 1) dated archive (history / rollback source)
+	const archive = archiveKey(stamp);
+	await s3.send(
+		new PutObjectCommand({
+			Bucket: bucket,
+			Key: archive,
+			Body: body,
+			ContentType: 'application/json',
+		}),
+	);
+
+	// 2) live file the library reads
+	await s3.send(
+		new PutObjectCommand({
+			Bucket: bucket,
+			Key: LIVE_KEY,
+			Body: body,
+			ContentType: 'application/json',
+		}),
+	);
+
+	console.log(`✓ ${doc.values.length} terms prepared at ${preparedAt}`);
+	console.log(`  archive : s3://${bucket}/${archive}`);
+	console.log(`  live    : s3://${bucket}/${LIVE_KEY}`);
+}
+
+// ---------------------------------------------------------------------------
+// Shared helper: fetch the dated archives (excludes the live/ subfolder)
+// ---------------------------------------------------------------------------
+interface Archive {
+	key: string;
+	stamp: string;
+	lastModified?: Date;
+}
+
+async function listArchives(bucket: string): Promise<Archive[]> {
+	const out: Archive[] = [];
+	let token: string | undefined;
+
+	do {
+		const res = await s3.send(
+			new ListObjectsV2Command({
+				Bucket: bucket,
+				Prefix: ARCHIVE_PREFIX,
+				ContinuationToken: token,
+			}),
+		);
+		for (const obj of res.Contents ?? []) {
+			const key = obj.Key;
+			if (!key || !key.endsWith('.json')) continue;
+			if (key.startsWith(LIVE_PREFIX)) continue; // skip the live file
+			const m = key.match(/terminologies-(.+)\.json$/);
+			out.push({ key, stamp: m ? m[1] : key, lastModified: obj.LastModified });
+		}
+		token = res.IsTruncated ? res.NextContinuationToken : undefined;
+	} while (token);
+
+	// Newest first.
+	out.sort(
+		(a, b) =>
+			(b.lastModified?.getTime() ?? 0) - (a.lastModified?.getTime() ?? 0),
+	);
+	return out;
+}
+
+// ---------------------------------------------------------------------------
+// list: show the dated archives in the terminologies folder
+// ---------------------------------------------------------------------------
+async function list(stage: Stage): Promise<void> {
+	const bucket = BUCKETS[stage];
+	const archives = await listArchives(bucket);
+
+	if (archives.length === 0) {
+		console.log(
+			`(no terminologies archives in s3://${bucket}/${ARCHIVE_PREFIX})`,
+		);
+		return;
+	}
+
+	console.log(`terminologies archives in s3://${bucket}/${ARCHIVE_PREFIX}:`);
+	for (const a of archives) {
+		console.log(`  ${a.stamp}   (${a.lastModified?.toISOString() ?? '?'})`);
+	}
+	console.log(
+		`\nRoll back with:  rollback --stage ${stage} --datetime <stamp>`,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// rollback: copy a chosen dated archive back over the live file
+// ---------------------------------------------------------------------------
+async function rollback(stage: Stage, datetime: string): Promise<void> {
+	const bucket = BUCKETS[stage];
+	const archives = await listArchives(bucket);
+
+	// Match archives whose stamp contains the supplied date/time string,
+	// so the user can pass a full stamp or a unique prefix like "2026-06-02".
+	const matches = archives.filter(
+		(a) => a.stamp.includes(datetime) || a.key.includes(datetime),
+	);
+
+	if (matches.length === 0) {
+		console.error(`No archive matches "${datetime}". Available:`);
+		archives.forEach((a) => console.error(`  ${a.stamp}`));
+		process.exit(1);
+	}
+	if (matches.length > 1) {
+		console.error(
+			`"${datetime}" matches multiple archives — be more specific:`,
+		);
+		matches.forEach((a) => console.error(`  ${a.stamp}`));
+		process.exit(1);
+	}
+
+	const target = matches[0];
+	await s3.send(
+		new CopyObjectCommand({
+			Bucket: bucket,
+			Key: LIVE_KEY,
+			CopySource: `${bucket}/${target.key}`,
+			MetadataDirective: 'COPY',
+		}),
+	);
+
+	console.log(`✓ Rolled back live file to archive ${target.stamp}`);
+	console.log(`  ${target.key}  ->  ${LIVE_KEY}`);
+}
+
+// ---------------------------------------------------------------------------
+// CLI wiring
+// ---------------------------------------------------------------------------
+const program = new Command();
+program
+	.name('terminologies')
+	.description('UK/US terminologies CSV -> JSON -> S3 tool');
+
+program
+	.command('update')
+	.requiredOption('--stage <stage>', 'CODE or PROD')
+	.requiredOption('--file <path>', 'path to the terminologies CSV file')
+	.action(async (opts) => {
+		await update(resolveStage(opts.stage), opts.file);
+	});
+
+program
+	.command('list')
+	.requiredOption('--stage <stage>', 'CODE or PROD')
+	.action(async (opts) => {
+		await list(resolveStage(opts.stage));
+	});
+
+program
+	.command('rollback')
+	.requiredOption('--stage <stage>', 'CODE or PROD')
+	.requiredOption(
+		'--datetime <stamp>',
+		'archive date/time to restore (see `list`)',
+	)
+	.action(async (opts) => {
+		await rollback(resolveStage(opts.stage), opts.datetime);
+	});
+
+program.parseAsync().catch((err) => {
+	console.error('Error:', err.message);
+	process.exit(1);
+});

--- a/tools/update-terminologies/csv-json-s3.ts
+++ b/tools/update-terminologies/csv-json-s3.ts
@@ -34,10 +34,6 @@ import {
 	CopyObjectCommand,
 } from '@aws-sdk/client-s3';
 
-const stage = process.env['STAGE'] ?? 'CODE';
-
-const bucket = process.env['BUCKET'] ?? 'feast-recipes-static-code';
-
 const region = process.env['REGION'] ?? 'eu-west-1';
 
 const s3 = new S3Client({ region: region });
@@ -64,6 +60,7 @@ function toId(raw: string): number | string {
 // update: CSV -> JSON, write a dated archive + overwrite the live file
 // ---------------------------------------------------------------------------
 async function update(stage: string, file: string): Promise<void> {
+	const bucket = `feast-recipes-static-${stage.toLowerCase()}`;
 	const records: Array<Record<string, string>> = parse(readFileSync(file), {
 		columns: (header: string[]) => header.map((h) => h.trim()),
 		skip_empty_lines: true,
@@ -117,7 +114,8 @@ interface Archive {
 	lastModified?: Date;
 }
 
-async function listArchives(bucket: string): Promise<Archive[]> {
+async function listArchives(stage: string): Promise<Archive[]> {
+	const bucket = `feast-recipes-static-${stage.toLowerCase()}`;
 	const out: Archive[] = [];
 	let token: string | undefined;
 
@@ -151,7 +149,8 @@ async function listArchives(bucket: string): Promise<Archive[]> {
 // list: show the dated archives in the terminologies folder
 // ---------------------------------------------------------------------------
 async function list(stage: string): Promise<void> {
-	const archives = await listArchives(bucket);
+	const bucket = `feast-recipes-static-${stage.toLowerCase()}`;
+	const archives = await listArchives(stage);
 
 	if (archives.length === 0) {
 		console.log(
@@ -173,7 +172,8 @@ async function list(stage: string): Promise<void> {
 // rollback: copy a chosen dated archive back over the live file
 // ---------------------------------------------------------------------------
 async function rollback(stage: string, datetime: string): Promise<void> {
-	const archives = await listArchives(bucket);
+	const bucket = `feast-recipes-static-${stage.toLowerCase()}`;
+	const archives = await listArchives(stage);
 
 	// Match archives whose stamp contains the supplied date/time string,
 	// so the user can pass a full stamp or a unique prefix like "2026-06-02".
@@ -221,14 +221,14 @@ program
 	.requiredOption('--stage <stage>', 'CODE or PROD')
 	.requiredOption('--file <path>', 'path to the terminologies CSV file')
 	.action(async (opts) => {
-		await update(stage, opts.file);
+		await update(opts.stage, opts.file);
 	});
 
 program
 	.command('list')
 	.requiredOption('--stage <stage>', 'CODE or PROD')
 	.action(async (opts) => {
-		await list(stage);
+		await list(opts.stage);
 	});
 
 program
@@ -239,7 +239,7 @@ program
 		'archive date/time to restore (see `list`)',
 	)
 	.action(async (opts) => {
-		await rollback(stage, opts.datetime);
+		await rollback(opts.stage, opts.datetime);
 	});
 
 program.parseAsync().catch((err) => {

--- a/tools/update-terminologies/csv-json-s3.ts
+++ b/tools/update-terminologies/csv-json-s3.ts
@@ -34,18 +34,13 @@ import {
 	CopyObjectCommand,
 } from '@aws-sdk/client-s3';
 
-// ---------------------------------------------------------------------------
-// Config — map each stage to its bucket. Edit to your real bucket names.
-// ---------------------------------------------------------------------------
-type Stage = 'CODE' | 'PROD';
+const stage = process.env['STAGE'] ?? 'CODE';
 
-const BUCKETS: Record<Stage, string> = {
-	CODE: 'feast-recipes-static-code',
-	PROD: 'feast-recipes-static-prod',
-};
+const bucket = process.env['BUCKET'] ?? 'feast-recipes-static-code';
 
-const REGION = process.env.AWS_REGION ?? 'eu-west-1';
-const s3 = new S3Client({ region: REGION });
+const region = process.env['REGION'] ?? 'eu-west-1';
+
+const s3 = new S3Client({ region: region });
 
 // Fixed S3 paths.
 const ARCHIVE_PREFIX = 'terminologies/'; // dated copies live here
@@ -54,14 +49,6 @@ const LIVE_KEY = 'terminologies/latest/terminologies.json';
 
 // The JSON key array, exactly as the consuming library expects.
 const KEYS = ['id', 'ukTerm', 'usTerm'] as const;
-
-function resolveStage(value: string): Stage {
-	const s = value.toUpperCase();
-	if (s !== 'CODE' && s !== 'PROD') {
-		throw new Error(`Invalid stage "${value}". Use CODE or PROD.`);
-	}
-	return s as Stage;
-}
 
 function archiveKey(stamp: string): string {
 	return `${ARCHIVE_PREFIX}${stamp}/terminologies.json`;
@@ -76,9 +63,7 @@ function toId(raw: string): number | string {
 // ---------------------------------------------------------------------------
 // update: CSV -> JSON, write a dated archive + overwrite the live file
 // ---------------------------------------------------------------------------
-async function update(stage: Stage, file: string): Promise<void> {
-	const bucket = BUCKETS[stage];
-
+async function update(stage: string, file: string): Promise<void> {
 	const records: Array<Record<string, string>> = parse(readFileSync(file), {
 		columns: (header: string[]) => header.map((h) => h.trim()),
 		skip_empty_lines: true,
@@ -165,8 +150,7 @@ async function listArchives(bucket: string): Promise<Archive[]> {
 // ---------------------------------------------------------------------------
 // list: show the dated archives in the terminologies folder
 // ---------------------------------------------------------------------------
-async function list(stage: Stage): Promise<void> {
-	const bucket = BUCKETS[stage];
+async function list(stage: string): Promise<void> {
 	const archives = await listArchives(bucket);
 
 	if (archives.length === 0) {
@@ -188,8 +172,7 @@ async function list(stage: Stage): Promise<void> {
 // ---------------------------------------------------------------------------
 // rollback: copy a chosen dated archive back over the live file
 // ---------------------------------------------------------------------------
-async function rollback(stage: Stage, datetime: string): Promise<void> {
-	const bucket = BUCKETS[stage];
+async function rollback(stage: string, datetime: string): Promise<void> {
 	const archives = await listArchives(bucket);
 
 	// Match archives whose stamp contains the supplied date/time string,
@@ -238,14 +221,14 @@ program
 	.requiredOption('--stage <stage>', 'CODE or PROD')
 	.requiredOption('--file <path>', 'path to the terminologies CSV file')
 	.action(async (opts) => {
-		await update(resolveStage(opts.stage), opts.file);
+		await update(stage, opts.file);
 	});
 
 program
 	.command('list')
 	.requiredOption('--stage <stage>', 'CODE or PROD')
 	.action(async (opts) => {
-		await list(resolveStage(opts.stage));
+		await list(stage);
 	});
 
 program
@@ -256,7 +239,7 @@ program
 		'archive date/time to restore (see `list`)',
 	)
 	.action(async (opts) => {
-		await rollback(resolveStage(opts.stage), opts.datetime);
+		await rollback(stage, opts.datetime);
 	});
 
 program.parseAsync().catch((err) => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This is command line tool to use a Typescript based script that reads CSV file, converts it into JSON and put it in S3 bucket.

In the initial phase of terminology development, we will utilise a CSV file for one-to-one mapping across the entire recipe for US-based users. This approach will provide a straightforward and efficient method for this task. Should the requirement for this task increase, we may consider implementing a web tool that will allow editorial team members to perform this task independently.

CSV file at present is in the format of id, ukTerm, usTerm

## How has this change been tested?

npm install
Put feast key
export AWS_PROFILE=feast

Then run these commands from inside the update-terminologies folder
To see list of files -->>
npx tsx csv-json-s3.ts list --stage CODE

To update the file on S3 bucket -->> 
npx tsx csv-json-s3.ts update --stage CODE --file ‘<file>’

To rollback -->>
npx tsx csv-json-s3.ts rollback --stage CODE --datetime <date>

## How can we measure success?

These commnds should work as expected.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
