### PR TITLE
App exclusive branding field

### DIFF
--- a/schema/recipe-v3.json
+++ b/schema/recipe-v3.json
@@ -8,6 +8,10 @@
     "id"
   ],
   "properties": {
+    "appExclusiveBranding": {
+      "type": ["boolean", "null"],
+      "description": "If set, render the recipe with app-exclusive branding and styling. If not present, must be treated as false."
+    },
     "isAppReady": {
       "type": "boolean",
       "description": "Whether the recipe is ready for app display"

--- a/schema/recipe-v3.json
+++ b/schema/recipe-v3.json
@@ -9,8 +9,8 @@
   ],
   "properties": {
     "appExclusiveBranding": {
-      "type": ["boolean", "null"],
-      "description": "If set, render the recipe with app-exclusive branding and styling. If not present, must be treated as false."
+      "type": "boolean",
+      "description": "If true, render the recipe with app-exclusive branding and styling. If not present, must be treated as false."
     },
     "isAppReady": {
       "type": "boolean",


### PR DESCRIPTION
## What does this change?

- Adds "appExclusiveBranding" field to the RecipeV3 definition as an optional field. This will be provided by the corresponding Composer PR at https://github.com/guardian/flexible-content/pull/6609.

## How has this change been tested?

- Deploy the above Composer branch to CODE
- Deploy this to CODE
- Open a recipe element in Composer CODE (as per the instructions on the above PR)
- Set the "app exclusive branding" flag, launch the recipe to CODE
- Find the recipe ID via the "View JSON" functionality on the recipe element in Composer
- Resolve the recipe in the recipe backend: https://recipes.code.dev-guardianapis.com/api/content/by-uid/{recipe-id-here}
- You'll see the new field in the output

## How can we measure success?

- Able to unblock app exclusive recipe branding
- Able to update the kotlin runtime library




