### PR TITLE
update policies to allow write from GCS to transfer bucket

### DIFF
--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -896,6 +896,26 @@ def sort_filter_rules(json_obj):
             },
             "PolicyName": "invokeFetcher",
           },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:PutObject",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    "arn:aws:s3:::feast-unifiedapi-datatransfer-test",
+                    "arn:aws:s3:::feast-unifiedapi-datatransfer-test/*",
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "unifiedApiData",
+          },
         ],
         "Tags": [
           {

--- a/cdk/lib/dynamic-fronts.ts
+++ b/cdk/lib/dynamic-fronts.ts
@@ -102,6 +102,19 @@ export class DynamicFronts extends Construct {
 						}),
 					],
 				}),
+				unifiedApiData: new PolicyDocument({
+					statements: [
+						// Extra bucket for unified API data transfer
+						new PolicyStatement({
+							effect: Effect.ALLOW,
+							resources: [
+								`arn:aws:s3:::feast-unifiedapi-datatransfer-${scope.stage.toLowerCase()}`,
+								`arn:aws:s3:::feast-unifiedapi-datatransfer-${scope.stage.toLowerCase()}/*`,
+							],
+							actions: ['s3:GetObject', 's3:ListBucket', 's3:PutObject'],
+						}),
+					],
+				}),
 			},
 			assumedBy: new AccountPrincipal(dataTechAcctParam.valueAsString),
 		});


### PR DESCRIPTION
## What does this change?

Small (possibly temporary) integration for https://github.com/guardian/feast-unified-api/pull/16 to allow existing GCS crosscloud role access to the new transfer buckets

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

Able to transfer larger bulk data from GCS

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
