### PR TITLE
Enable US front seperation

### DIFF
--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -3922,6 +3922,26 @@ def sort_filter_rules(json_obj):
               },
             },
             {
+              "Action": "ssm:GetParameter",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/feast/facia-responder/*",
+                  ],
+                ],
+              },
+            },
+            {
               "Action": [
                 "sqs:ReceiveMessage",
                 "sqs:ChangeMessageVisibility",

--- a/cdk/lib/facia-connection.ts
+++ b/cdk/lib/facia-connection.ts
@@ -109,6 +109,13 @@ export class FaciaConnection extends Construct {
 					actions: ['sts:AssumeRole'],
 					resources: [faciaPublishStatusSNSRole.roleArn],
 				}),
+				new PolicyStatement({
+					effect: Effect.ALLOW,
+					actions: ['ssm:GetParameter'],
+					resources: [
+						`arn:aws:ssm:${scope.region}:${scope.account}:parameter/${scope.stage}/${scope.stack}/facia-responder/*`,
+					],
+				}),
 			],
 			memorySize: 256,
 			runtime: Runtime.NODEJS_20_X,

--- a/lambda/facia-responder/src/main.test.ts
+++ b/lambda/facia-responder/src/main.test.ts
@@ -1,3 +1,5 @@
+import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
+import { mockClient } from 'aws-sdk-client-mock';
 import { deployCurationData } from '@recipes-api/lib/recipes-data';
 import { notifyFaciaTool } from './facia-notifications';
 import {
@@ -9,6 +11,8 @@ import {
 	validMessageUsOnly,
 } from './fixtures/sns';
 import { handler } from './main';
+
+const ssmMock = mockClient(SSMClient);
 
 jest.mock('@recipes-api/lib/recipes-data', () => ({
 	deployCurationData: jest.fn(),
@@ -26,10 +30,18 @@ jest.mock('./facia-notifications', () => ({
 const secondOfJan2024 = new Date('2024-01-02');
 const importCurationDataMock = deployCurationData as jest.Mock;
 const notifyFaciaToolMock = notifyFaciaTool as jest.Mock;
+
 describe('main', () => {
 	beforeEach(() => {
+		ssmMock.reset();
+		ssmMock.on(GetParameterCommand).resolves({
+			Parameter: {
+				Value: 'false',
+			},
+		});
 		jest.clearAllMocks();
 	});
+
 	it('should publish the content it was given', async () => {
 		const rec = {
 			Records: [
@@ -144,6 +156,61 @@ describe('main', () => {
 			version: 'v1',
 		});
 	});
+
+	it('should separate not derive US from Northern if requested not to', async () => {
+		console.log(JSON.stringify(validMessageContentWithUsOnly));
+		ssmMock.on(GetParameterCommand).resolves({
+			Parameter: {
+				Value: 'true',
+			},
+		});
+
+		const rec = {
+			Records: [
+				{
+					eventSource: 'sqs',
+					awsRegion: 'xx-north-n',
+					messageId: 'BDB66A64-F095-4F4D-9B6A-135173E262A5',
+					body: JSON.stringify(validMessageUsOnly),
+				},
+			],
+		};
+		// @ts-ignore
+		await handler(rec, null, null);
+		expect(importCurationDataMock.mock.calls.length).toEqual(2);
+		expect(importCurationDataMock.mock.calls[0][0]).toEqual(
+			//these are all the fronts in the fixture data
+			JSON.stringify([
+				validMessageContentWithUsOnly.fronts['all-recipes'][0],
+				validMessageContentWithUsOnly.fronts['all-recipes'][1],
+				validMessageContentWithUsOnly.fronts['all-recipes'][2],
+			]),
+		);
+		expect(importCurationDataMock.mock.calls[0][1]).toEqual(
+			validMessageContentWithUsOnly.edition,
+		);
+		expect(importCurationDataMock.mock.calls[0][2]).toEqual('all-recipes');
+		expect(importCurationDataMock.mock.calls[0][3]).toEqual(secondOfJan2024);
+		expect(importCurationDataMock.mock.calls[1][0]).toEqual(
+			JSON.stringify(validMessageContentWithUsOnly.fronts['meat-free']),
+		);
+		expect(importCurationDataMock.mock.calls[1][1]).toEqual(
+			validMessageContentWithUsOnly.edition,
+		);
+		expect(importCurationDataMock.mock.calls[1][2]).toEqual('meat-free');
+		expect(importCurationDataMock.mock.calls[1][3]).toEqual(secondOfJan2024);
+
+		const notifyFaciaToolMock = notifyFaciaTool as jest.Mock;
+		expect(notifyFaciaToolMock.mock.calls[0][0]).toMatchObject({
+			edition: 'feast-northern-hemisphere',
+			issueDate: '2024-01-02',
+			message:
+				'This issue has been published but its date is in the past so it can only be seen in the Fronts Preview tool',
+			status: 'Published',
+			version: 'v1',
+		});
+	});
+
 	it('should not accept valid envelope json, failing with an error', async () => {
 		const rec = {
 			Records: [

--- a/lambda/facia-responder/src/main.ts
+++ b/lambda/facia-responder/src/main.ts
@@ -1,3 +1,4 @@
+import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
 import type { SNSMessage, SQSHandler, SQSRecord } from 'aws-lambda';
 import format from 'date-fns/format';
 import type { SafeParseReturnType } from 'zod';
@@ -15,6 +16,8 @@ import {
 import { notifyFaciaTool } from './facia-notifications';
 import { generateTargetedRegionFronts } from './targeted-regions';
 import { generatePublicationMessage, getErrorMessage } from './util';
+
+const ssmClient = new SSMClient({ region: process.env.AWS_REGION });
 
 function getMessageBodyAsObject(from: SQSRecord): unknown {
 	const parsedSNSMessage = JSON.parse(from.body) as SNSMessage; // will throw if the content is not valid;
@@ -60,12 +63,42 @@ async function deployCuration(
 	}
 }
 
+async function getOptionalParameterValue(
+	name: string,
+): Promise<string | undefined> {
+	try {
+		const result = await ssmClient.send(
+			new GetParameterCommand({
+				Name: `/${process.env.STAGE}/${process.env.STACK}/facia-responder/${name}`,
+				WithDecryption: false,
+			}),
+		);
+		return result.Parameter?.Value;
+	} catch (error) {
+		if (error instanceof Error && error.name === 'ParameterNotFound') {
+			return undefined;
+		}
+		throw error;
+	}
+}
+
+async function getOptionalBooleanParameter(
+	name: string,
+): Promise<boolean | undefined> {
+	const value = await getOptionalParameterValue(name);
+	return value ? value.toLowerCase() === 'true' : undefined;
+}
+
 export const handler: SQSHandler = async (event) => {
 	const staticBucketName = getStaticBucketName();
 	const fastlyApiKey = getFastlyApiKey();
 	const contentPrefix = getContentPrefix();
 	const faciaPublicationStatusTopicArn = getFaciaPublicationStatusTopicArn();
 	const faciaPublicationStatusRoleArn = getFaciaPublicationStatusRoleArn();
+
+	const disableUSRegionalisation = await getOptionalBooleanParameter(
+		'disable-us-regionalisation',
+	);
 
 	for (const rec of event.Records) {
 		console.log(
@@ -110,9 +143,11 @@ export const handler: SQSHandler = async (event) => {
 			);
 		}
 
-		for (const regionalisedFronts of generateTargetedRegionFronts(
-			maybeFronts.data,
-		)) {
+		const fronts = disableUSRegionalisation
+			? [maybeFronts.data]
+			: generateTargetedRegionFronts(maybeFronts.data);
+
+		for (const regionalisedFronts of fronts) {
 			try {
 				await deployCuration(regionalisedFronts, {
 					staticBucketName,


### PR DESCRIPTION
## What does this change?

- Adds an SSM parameter that disables the derive-us-from-northern logic

This will allow us to publish to the new US regionalised curated front without risk of overwriting when the northern hemisphere front is published

## How has this change been tested?

- Ensure that https://github.com/guardian/facia-tool/pull/1999 is deployed to Facia CODE (use the semaphore to warn the other teams!)
- Ensure that this branch is deployed to recipes-backend CODE
- Set up a Northern hemisphere front for todays date and a US Regional front for todays date. Use different collection names so you can easily differentiate them in JSON.
- Ensure that the SSM parameter store value `/CODE/feast/facia-responder/disable-us-regionalisation` is set to `false` (string value) or is not present
- Publish the US regional front
- Check https://recipes.code.dev-guardianapis.com/us/all-recipes/curation.json
- You should see your US regional front
- Publish the Northern hemisphere front
- Check https://recipes.code.dev-guardianapis.com/us/all-recipes/curation.json (**US url again**)
- It should have been overwritten by the Northern hemisphere front.  This is expected when `disable-us-regionalisation` is not set
- Now set the SSM parameter store value `/CODE/feast/facia-responder/disable-us-regionalisation` to `true` (string value)
- Publish the US regional front again
- Check https://recipes.code.dev-guardianapis.com/us/all-recipes/curation.json
- You should see your US regional front
- Publish the Northern hemisphere front
- Check https://recipes.code.dev-guardianapis.com/us/all-recipes/curation.json again. It should **still** be showing your US regional front, not Northern hemisphere.
- Check https://recipes.code.dev-guardianapis.com/northern/all-recipes/curation.json.  It should be showing your Northern hemisphere front.

**Note** that this also disables the exclusion of "US" targetted containers in Northern hemisphere fronts. Once the US front is live we will be removing the "US only" checkbox in the Fronts UI; this will therefore not be able to be set.  We will look at adding geo-targeting back in as part of Unified API down the line.

## How can we measure success?

Able to switch over to the curated US front when editorial are ready


