### PR TITLE
add "original measuring system" to the recipe element definition

### DIFF
--- a/schema/recipe-v3.json
+++ b/schema/recipe-v3.json
@@ -115,6 +115,10 @@
         "$ref": "ingredients-list.json"
       }
     },
+    "originalMeasuringSystem": {
+      "enum": ["metric", "us", "aus-cup", "imperial"],
+      "description": "The original measuring system used in the recipe. This is a view hint for conversion and should not be taken as a strict source of truth."
+    },
     "celebrationIds": {
       "type": [
         "array",


### PR DESCRIPTION
## What does this change?

Adds the "original measuring system" field from https://github.com/guardian/flexible-content/pull/6633

## How has this change been tested?

- Deploy the Composer PR
- Publish a recipe with "original measuring system" set
- Validate it strictly against the JSON schema

## How can we measure success?

Able to use the field
