### PR TITLE
slightly loosen image url regex so valid images don't get rejected

### DIFF
--- a/lib/recipes-data/src/lib/utils.test.ts
+++ b/lib/recipes-data/src/lib/utils.test.ts
@@ -131,6 +131,14 @@ describe('extractCropIdFromGuimUrl', () => {
 			4259,
 			'png',
 		],
+		[
+			//This specific URL form was causing problems since the last number was too long, so we've added a test case to ensure it doesn't regress
+			'https://media.guim.co.uk/6a4de89b071368602094005335a3266910a36f0a/675_755_9267_11585/1600.jpg',
+			'6a4de89b071368602094005335a3266910a36f0a',
+			'675_755_9267_11585',
+			9267,
+			'jpg',
+		],
 	] as const;
 	cropDataToAssert.forEach(([url, mediaId, cropId, width, extension]) => {
 		it(`should find a crop id for ${url}`, () => {

--- a/lib/recipes-data/src/lib/utils.ts
+++ b/lib/recipes-data/src/lib/utils.ts
@@ -49,7 +49,7 @@ export const extractCropDataFromGuimUrl = (
 	| undefined => {
 	// Some capturing groups here are not needed – they're added to make the regex a bit more comprehensible.
 	const match = url.match(
-		/https:\/\/.*\/(?<mediaId>.*?)\/(?<cropId>\d{1,4}_\d{1,4}_(?<width>\d{1,4})_\d{1,4})\/(?<fileName>.*?)\.(?<extension>.*?)(?<queryParams>\?.*)?$/,
+		/https:\/\/.*\/(?<mediaId>.*?)\/(?<cropId>\d{1,6}_\d{1,6}_(?<width>\d{1,4})_\d{1,6})\/(?<fileName>.*?)\.(?<extension>.*?)(?<queryParams>\?.*)?$/,
 	);
 
 	if (!match?.groups) {

--- a/lib/recipes-data/src/lib/utils.ts
+++ b/lib/recipes-data/src/lib/utils.ts
@@ -49,7 +49,7 @@ export const extractCropDataFromGuimUrl = (
 	| undefined => {
 	// Some capturing groups here are not needed – they're added to make the regex a bit more comprehensible.
 	const match = url.match(
-		/https:\/\/.*\/(?<mediaId>.*?)\/(?<cropId>\d{1,6}_\d{1,6}_(?<width>\d{1,4})_\d{1,6})\/(?<fileName>.*?)\.(?<extension>.*?)(?<queryParams>\?.*)?$/,
+		/https:\/\/.*\/(?<mediaId>.*?)\/(?<cropId>\d{1,6}_\d{1,6}_(?<width>\d{1,6})_\d{1,6})\/(?<fileName>.*?)\.(?<extension>.*?)(?<queryParams>\?.*)?$/,
 	);
 
 	if (!match?.groups) {


### PR DESCRIPTION
## What does this change?

Fixes an issue reported where one image was not getting the proper Fastly scaling URL when published.

The issue turned out to be that the URL used to validate and extract the data from the Grid URL was overly strict, only matching between 1 and 4 digits in the encoded data part.  The affected image had 5 digits in the last (unused) part.

The PR updates the regex to allow up to 6 digits in the unknown parts and adds a test for the specific problematic URL to avoid a regression.

## How has this change been tested?

- Deployed to CODE
- Relaunched https://composer.code.dev-gutools.co.uk/content/6a2fdf5f8f084fe6123b53f4
- Check that the image URL in the resulting recipe on [recipes.guardianapis.com](https://recipes.code.dev-guardianapis.com/api/content/by-uid/01ddc030f3c94c11ad0a7df8d3055a14) is of the form `https://i.guim.co.uk/img/media/....` not of the form `https://media.guim.co.uk/....` - once the CDN caching clears!

## How can we measure success?

All images displaying properly in the app

## Have we considered potential risks?

n/a
