### PR TITLE
terminology cmdline - add block and guidance column informations

### DIFF
--- a/tools/update-terminologies/csv-json-s3.ts
+++ b/tools/update-terminologies/csv-json-s3.ts
@@ -2,7 +2,7 @@
 /**
  * terminologies tool — convert a UK/US terminologies CSV to JSON and manage it in S3.
  *
- * CSV input has 3 columns: id, ukTerm, usTerm, block, ukGuidance, usGuidance
+ * CSV input has 6 columns: id, ukTerm, usTerm, block, ukGuidance, usGuidance
  *
  * Produces JSON of the shape:
  *   {

--- a/tools/update-terminologies/csv-json-s3.ts
+++ b/tools/update-terminologies/csv-json-s3.ts
@@ -2,7 +2,7 @@
 /**
  * terminologies tool — convert a UK/US terminologies CSV to JSON and manage it in S3.
  *
- * CSV input has 3 columns: id, ukTerm, usTerm
+ * CSV input has 3 columns: id, ukTerm, usTerm, block
  *
  * Produces JSON of the shape:
  *   {
@@ -44,7 +44,7 @@ const LIVE_PREFIX = 'terminologies/latest/'; // subfolder for the live file
 const LIVE_KEY = 'terminologies/latest/terminologies.json';
 
 // The JSON key array, exactly as the consuming library expects.
-const KEYS = ['id', 'ukTerm', 'usTerm'] as const;
+const KEYS = ['id', 'ukTerm', 'usTerm', 'block'] as const;
 
 function archiveKey(stamp: string): string {
 	return `${ARCHIVE_PREFIX}${stamp}/terminologies.json`;
@@ -74,7 +74,12 @@ async function update(stage: string, file: string): Promise<void> {
 	const doc = {
 		prepared_at: preparedAt,
 		key: [...KEYS],
-		values: records.map((r) => [toId(r.id), r.ukTerm, r.usTerm]),
+		values: records.map((r) => [
+			toId(r.id),
+			r.ukTerm,
+			r.usTerm,
+			r.block ? r.block.split(',').map((b) => b.trim()) : [],
+		]),
 	};
 
 	const body = JSON.stringify(doc, null, 2);

--- a/tools/update-terminologies/csv-json-s3.ts
+++ b/tools/update-terminologies/csv-json-s3.ts
@@ -2,7 +2,7 @@
 /**
  * terminologies tool — convert a UK/US terminologies CSV to JSON and manage it in S3.
  *
- * CSV input has 3 columns: id, ukTerm, usTerm, block
+ * CSV input has 3 columns: id, ukTerm, usTerm, block, ukGuidance, usGuidance
  *
  * Produces JSON of the shape:
  *   {
@@ -44,7 +44,14 @@ const LIVE_PREFIX = 'terminologies/latest/'; // subfolder for the live file
 const LIVE_KEY = 'terminologies/latest/terminologies.json';
 
 // The JSON key array, exactly as the consuming library expects.
-const KEYS = ['id', 'ukTerm', 'usTerm', 'block'] as const;
+const KEYS = [
+	'id',
+	'ukTerm',
+	'usTerm',
+	'block',
+	'ukGuidance',
+	'usGuidance',
+] as const;
 
 function archiveKey(stamp: string): string {
 	return `${ARCHIVE_PREFIX}${stamp}/terminologies.json`;
@@ -79,6 +86,8 @@ async function update(stage: string, file: string): Promise<void> {
 			r.ukTerm,
 			r.usTerm,
 			r.block ? r.block.split(',').map((b) => b.trim()) : [],
+			r.ukGuidance ?? '',
+			r.usGuidance ?? '',
 		]),
 	};
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Tools need to know 3 new columns from the spreadsheet (downloaded as CSV) to put it in JSON file and then upload to S3

- `block` 
block column is group of key words to cover the edge cases on the terminology like `sponge` should not be converted to `cake` if it is with `sponge cake` otherwise convert. 
- ` ukGuidance`
ukGuidance column is free text coloum to supply notes related to uk-term, to cover special subsitition cases
- `usGuidance`
 usGudiance is similar one but for us terms


## How has this change been tested?

npm install
Put feast key
export AWS_PROFILE=feast

Then run these commands from inside the update-terminologies folder
To see list of files:
npx tsx csv-json-s3.ts list --stage CODE

To update the file on S3 bucket:
npx tsx csv-json-s3.ts update --stage CODE --file (file.name)

To rollback:
npx tsx csv-json-s3.ts rollback --stage CODE --datetime

And hit at:
https://recipes.code.dev-guardianapis.com/terminologies/latest/terminologies.json

## How can we measure success?

S3 bucket should have updated terminologies.json file in latest folder and dated folder with added coloumns in them.
Endpoint should give you extensive updated list of terminologies with all data includes 
     "id",
    "ukTerm",
    "usTerm",
    "block",
    "ukGuidance",
    "usGuidance"
    
Note: If you do not see the updated file, please wait for an hour to clear your cache. Alternatively, you can purge the URL to clear the cache immediately.

## Have we considered potential risks?

No
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Let me know if you need it
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

None
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
