### PR TITLE
Add guidance notes fields for terminology substitution

### DIFF
--- a/schema/ingredient-item.json
+++ b/schema/ingredient-item.json
@@ -92,14 +92,9 @@
           "endIndex": {
             "type": "integer",
             "description": "The end index of the matched term"
-          },
-          "termType": {
-            "type": "string",
-            "enum": ["ukTerm", "usTerm"],
-            "description": "The type of term (e.g., UK or US)"
           }
         },
-        "required": ["matchedTerm", "startIndex", "endIndex", "termType"]
+        "required": ["matchedTerm", "startIndex", "endIndex"]
       }
     }
 

--- a/schema/ingredient-item.json
+++ b/schema/ingredient-item.json
@@ -57,7 +57,22 @@
     "template": {
       "$ref": "string-template.json",
       "description": "The template representation of the ingredient"
+    },
+    "ukGuidance": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Guidance notes for any UK term to highlight the context"
+    },
+    "usGuidance": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Guidance notes for any US term to highlight the context"
     }
+
   },
   "required": [
     "name"

--- a/schema/ingredient-item.json
+++ b/schema/ingredient-item.json
@@ -71,6 +71,36 @@
         "null"
       ],
       "description": "Guidance notes for any US term to highlight the context"
+    },
+    "highlights": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "description": "Highlights for matched terms in the ingredient, we want to underline them in the App side of UI",
+      "items": {
+        "type": "object",
+        "properties": {
+          "matchedTerm": {
+            "type": "string",
+            "description": "The term that was matched"
+          },
+          "startIndex": {
+            "type": "integer",
+            "description": "The start index of the matched term"
+          },
+          "endIndex": {
+            "type": "integer",
+            "description": "The end index of the matched term"
+          },
+          "termType": {
+            "type": "string",
+            "enum": ["ukTerm", "usTerm"],
+            "description": "The type of term (e.g., UK or US)"
+          }
+        },
+        "required": ["matchedTerm", "startIndex", "endIndex", "termType"]
+      }
     }
 
   },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As we move toward the substitution phase of the US Terminology conversion, we obtain guidance notes for terms that require special attention during conversion to highlight the context. 
We have added 2 new columns in the Spreadsheet(Terminology dictionary) for us and uk terms, they are ukGuidance and usGuidance, they have been supplied successfully in the terminologies.json to get consumed by the KMP library.

We are adding them as optional properties and in the Ingredient section only. 

The ongoing PR in [KMP library](https://github.com/guardian/feast-multiplatform-library/pull/136) is to get the values in those new guidance fields.

Cmdline tool also updated, in the last PR [here](https://github.com/guardian/recipes-backend/pull/221)

## How has this change been tested?

npm run build
Observe generated models
Run tests

## How can we measure success?

Tests should run fine
We should see newly added properties in the generated ingredeint item schema 

## Have we considered potential risks?

No

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
