### PR TITLE
[Feast hackday] Update the schema with new optional fields provided by unified api

### DIFF
--- a/schema/instruction.json
+++ b/schema/instruction.json
@@ -30,6 +30,34 @@
         }
       ],
       "description": "Array of image URLs or identifiers for this step"
+    },
+    "ingredientIndexes": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Array of indexes referring to ingredients used in this step"
+    },
+    "formattedIngredients": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Array of formatted ingredient strings for this step (provided by runtime library)"
     }
   },
   "required": [


### PR DESCRIPTION
## What does this change?

Adds new fields to the recipe schema to match up with the index field added in https://github.com/guardian/feast-unified-api/pull/35 and the rendering in https://github.com/guardian/feast-multiplatform-library/pull/142

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

Keeping the records in sync
