### PR TITLE
Remove Highlight data schema from Ingredient schema

### DIFF
--- a/schema/ingredient-item.json
+++ b/schema/ingredient-item.json
@@ -71,33 +71,7 @@
         "null"
       ],
       "description": "Guidance notes for any US term to highlight the context"
-    },
-    "highlights": {
-      "type": [
-        "array",
-        "null"
-      ],
-      "description": "Highlights for matched terms in the ingredient, we want to underline them in the App side of UI",
-      "items": {
-        "type": "object",
-        "properties": {
-          "matchedTerm": {
-            "type": "string",
-            "description": "The term that was matched"
-          },
-          "startIndex": {
-            "type": "integer",
-            "description": "The start index of the matched term"
-          },
-          "endIndex": {
-            "type": "integer",
-            "description": "The end index of the matched term"
-          }
-        },
-        "required": ["matchedTerm", "startIndex", "endIndex"]
-      }
     }
-
   },
   "required": [
     "name"


### PR DESCRIPTION


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We don't need `Highlight` data scheme anymore as we are providing `<u>` tag on the us-terms from KMP library
The PR for KMP is here: https://github.com/guardian/feast-multiplatform-library/pull/136

As this was optional so removing it wont break the app

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

npm run build
npm run test
Deploy on CODE
Check Feast app

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

The tests should run fine
The recipes should publish as normal
Feast app should work as normal

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
none

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
