### PR TITLE
Output a single recipe announcement, containing both v3 and v2 checksums

### DIFF
--- a/lib/recipes-data/src/lib/eventbus.test.ts
+++ b/lib/recipes-data/src/lib/eventbus.test.ts
@@ -87,28 +87,18 @@ describe('announce_new_recipe', () => {
 		expect(mockEbClient.commandCalls(PutEventsCommand).length).toEqual(1);
 		const putCmd = mockEbClient.commandCalls(PutEventsCommand)[0]
 			.firstArg as PutEventsCommand;
-		expect(putCmd.input.Entries?.length).toEqual(5);
+		expect(putCmd.input.Entries?.length).toEqual(3);
 		const firstEntry = putCmd.input.Entries ? putCmd.input.Entries[0] : {};
 		expect(firstEntry.DetailType).toEqual('recipe-update');
 		expect(firstEntry.Detail).toEqual(
-			`{"blob":"recep-1-content","uid":"recep-1-uid","checksum":"recep-1-cs2"}`,
+			`{"blob":"recep-1-content","uid":"recep-1-uid","checksum":"recep-1-cs3","checksumV2":"recep-1-cs2"}`,
 		);
-		const secondEntry = putCmd.input.Entries ? putCmd.input.Entries[1] : {};
-		expect(secondEntry.DetailType).toEqual('recipe-update');
-		expect(secondEntry.Detail).toEqual(
-			`{"blob":"recep-1-content","uid":"recep-1-uid","checksum":"recep-1-cs3"}`,
-		);
-		const thirdEntry = putCmd.input.Entries ? putCmd.input.Entries[2] : {};
+		const thirdEntry = putCmd.input.Entries ? putCmd.input.Entries[1] : {};
 		expect(thirdEntry.DetailType).toEqual('recipe-update');
 		expect(thirdEntry.Detail).toEqual(
-			`{"blob":"recep-2-content","uid":"recep-2-uid","checksum":"recep-2-cs2-updated"}`,
+			`{"blob":"recep-2-content","uid":"recep-2-uid","checksum":"recep-2-cs3-updated","checksumV2":"recep-2-cs2-updated"}`,
 		);
-		const fourthEntry = putCmd.input.Entries ? putCmd.input.Entries[3] : {};
-		expect(fourthEntry.DetailType).toEqual('recipe-update');
-		expect(fourthEntry.Detail).toEqual(
-			`{"blob":"recep-2-content","uid":"recep-2-uid","checksum":"recep-2-cs3-updated"}`,
-		);
-		const fifthEntry = putCmd.input.Entries ? putCmd.input.Entries[4] : {};
+		const fifthEntry = putCmd.input.Entries ? putCmd.input.Entries[2] : {};
 		expect(fifthEntry.DetailType).toEqual('recipe-delete');
 		expect(fifthEntry.Detail).toEqual(
 			`{"checksum":"recep-3-cs","uid":"recep-3-uid"}`,

--- a/lib/recipes-data/src/lib/eventbus.ts
+++ b/lib/recipes-data/src/lib/eventbus.ts
@@ -27,21 +27,10 @@ export async function announceNewRecipe(
 			Resources: [], //Affected AWS resources
 			DetailType: 'recipe-update', //What happened
 			Detail: JSON.stringify({
-				blob: recep.recipeV2Blob.jsonBlob,
-				uid: recep.recipeUID,
-				checksum: recep.recipeV2Blob.checksum,
-			}),
-			EventBusName: OutgoingEventBus,
-		},
-		{
-			Time: new Date(), //Timestamp
-			Source: 'recipe-responder', //Identity of sender
-			Resources: [], //Affected AWS resources
-			DetailType: 'recipe-update', //What happened
-			Detail: JSON.stringify({
 				blob: recep.recipeV3Blob.jsonBlob,
 				uid: recep.recipeUID,
 				checksum: recep.recipeV3Blob.checksum,
+				checksumV2: recep.recipeV2Blob.checksum,
 			}),
 			EventBusName: OutgoingEventBus,
 		},


### PR DESCRIPTION
## What does this change?

When a new recipe is published, recipe-responder sends a message onto the event bus to inform consumers (like the search ingest function) that a new recipe is ready.

So far, it has been outputting _two_ messages - one for the V3 recipe and one for the V2 recipe.

This changes the output to send only one message, with a single new field `checksumV2` which contains the V2 checksum of the recipe

```json
{
"blob": {recipe-content},
"uid": "recipe permanent id",
"checksum": "v3 checksum",
"checksumV2": "v2 checksum"
}
```

This is to make downstream integration to the unified api easier

## How has this change been tested?

- Deploy to CODE
- Attach a temporary SQS queue onto the event bus to monitor messages
- Publish a recipe article in CODE
- Each recipe element should receive _one_ message not two
- Consult the logs for the search ingest function
- It should have ingested the recipe fine
- Find the recipe in search

## How can we measure success?

Easier to disambiguate downstream events

## Have we considered potential risks?

n/a